### PR TITLE
fix(dsl): ambiguous alternatives

### DIFF
--- a/packages/language-server/src/like-c4.langium
+++ b/packages/language-server/src/like-c4.langium
@@ -144,6 +144,10 @@ ImplicitRelation:
 fragment RelationFragment:
   ('->' | '-[' kind=[RelationshipKind] ']->' | kind=[RelationshipKind:DotId] )
   target=ElementRef
+  (
+    title=String  // title
+    technology=String? // technology is possible only if threre is title
+  )?
   title=String?
   technology=String?
   tags=Tags?


### PR DESCRIPTION
[log] [lsp] Ambiguous Alternatives Detected: <0, 1> in <OPTION1> inside <RelationFragment​> Rule, <String, }, }> may appears as a prefix path in all these alternatives. See: https://chevrotain.io/docs/guide/resolving_grammar_errors.html#AMBIGUOUS_ALTERNATIVES For Further details.
[log] [lsp] Ambiguous Alternatives Detected: <0, 1> in <OPTION1> inside <RelationFragment​> Rule, <String, IdTerminal, ->> may appears as a prefix path in all these alternatives. See: https://chevrotain.io/docs/guide/resolving_grammar_errors.html#AMBIGUOUS_ALTERNATIVES For Further details.