### PR TITLE
Implemented support for custom colors (#916)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -75,5 +75,6 @@
     "webcola",
     "xyflow",
     "zoomable"
-  ]
+  ],
+  "editor.tabSize": 2
 }

--- a/apps/docs/src/content/docs/dsl/specification.mdx
+++ b/apps/docs/src/content/docs/dsl/specification.mdx
@@ -64,6 +64,23 @@ specification {
 }
 ```
 
+### Color
+
+Custom colors could be defined to extend built in themes. Being defined in specification they could be used later along with the theme colors.
+
+```likec4
+specification {
+  color custom-color #808
+  color another-color #440
+
+  element person {
+    style {
+      color custom-color
+    }
+  }
+}
+``` 
+
 {/*
 
 #### Color

--- a/apps/docs/src/content/docs/dsl/styling.mdx
+++ b/apps/docs/src/content/docs/dsl/styling.mdx
@@ -118,6 +118,8 @@ If not set, the default color is `primary`.
 
 <LikeC4ThemeView viewId="index"/>
 
+It's also possible to use custom colors defined in [specification](/dsl/specification/#color).
+
 
 #### Opacity
 

--- a/examples/cloud-system/_spec.c4
+++ b/examples/cloud-system/_spec.c4
@@ -1,4 +1,5 @@
 specification {
+  color custom #f0882e
 
   element actor {
     notation "Person"

--- a/examples/cloud-system/_spec.c4
+++ b/examples/cloud-system/_spec.c4
@@ -1,6 +1,4 @@
 specification {
-  color custom #f0882e
-
   element actor {
     notation "Person"
     style {

--- a/examples/cloud-system/_spec.c4
+++ b/examples/cloud-system/_spec.c4
@@ -1,4 +1,6 @@
 specification {
+  color custom #6BD731
+
   element actor {
     notation "Person"
     style {

--- a/examples/cloud-system/model.c4
+++ b/examples/cloud-system/model.c4
@@ -42,6 +42,9 @@ model {
       '
 
       -> customer 'helps with questions' {
+        style {
+          color custom
+        }
         metadata {
           rps '1000'
         }

--- a/examples/cloud-system/model.c4
+++ b/examples/cloud-system/model.c4
@@ -40,11 +40,7 @@ model {
         A emploere from the support team
         Has limited access to the system
       '
-
       -> customer 'helps with questions' {
-        style {
-          color custom
-        }
         metadata {
           rps '1000'
         }

--- a/examples/cloud-system/views.c4
+++ b/examples/cloud-system/views.c4
@@ -27,4 +27,14 @@ views {
     }
   }
 
+  view view-with-custom-colors {
+    include *,
+    cloud -> * with {
+      color custom
+    }
+
+    style cloud {
+      color custom
+    }
+  }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -63,6 +63,10 @@
     "access": "public"
   },
   "dependencies": {
+    "@mantine/colors-generator": "^7.12.2",
+    "chroma-js": "^3.0.0",
+    "remeda": "^2.11.0",
+    "ts-custom-error": "^3.3.1",
     "type-fest": "^4.21.0"
   },
   "devDependencies": {

--- a/packages/core/src/colors/index.ts
+++ b/packages/core/src/colors/index.ts
@@ -1,11 +1,7 @@
-import type {
-  HexColorLiteral,
-  LikeC4Theme,
-  ThemeColorValues,
-} from '../types/theme'
+import { generateColors } from '@mantine/colors-generator'
+import type { HexColorLiteral, LikeC4Theme, ThemeColorValues } from '../types/theme'
 import { ElementColors } from './element'
 import { RelationshipColors } from './relationships'
-import { generate } from '@ant-design/colors'
 
 export const defaultTheme = {
   elements: ElementColors,
@@ -15,19 +11,26 @@ export const defaultTheme = {
 } satisfies LikeC4Theme
 
 export function computeColorValues(color: HexColorLiteral): ThemeColorValues {
-  const colors = generate(color)
+  if (color.match(/^#([0-9a-f]{3}){1,2}$/i)) {
+    const colors = generateColors(color)
 
-  return {
-    elements: {
-      fill: color,
-      stroke: colors[6] as HexColorLiteral,
-      hiContrast: colors[1] as HexColorLiteral,
-      loContrast: colors[2] as HexColorLiteral
-    },
-    relationships: {
-      lineColor: color,
-      labelColor: colors[4] as HexColorLiteral,
-      labelBgColor: colors[9] as HexColorLiteral
+    return {
+      elements: {
+        fill: colors[6] as HexColorLiteral,
+        stroke: colors[7] as HexColorLiteral,
+        hiContrast: colors[0] as HexColorLiteral,
+        loContrast: colors[1] as HexColorLiteral
+      },
+      relationships: {
+        lineColor: colors[4] as HexColorLiteral,
+        labelColor: colors[3] as HexColorLiteral,
+        labelBgColor: colors[9] as HexColorLiteral
+      }
+    }
+  } else {
+    return {
+      elements: defaultTheme.elements['primary'],
+      relationships: defaultTheme.relationships['primary']
     }
   }
 }

--- a/packages/core/src/colors/index.ts
+++ b/packages/core/src/colors/index.ts
@@ -1,6 +1,11 @@
-import type { LikeC4Theme } from '../types/theme'
+import type {
+  HexColorLiteral,
+  LikeC4Theme,
+  ThemeColorValues,
+} from '../types/theme'
 import { ElementColors } from './element'
 import { RelationshipColors } from './relationships'
+import { generate } from '@ant-design/colors'
 
 export const defaultTheme = {
   elements: ElementColors,
@@ -8,5 +13,23 @@ export const defaultTheme = {
   font: 'Arial',
   shadow: '#0a0a0a'
 } satisfies LikeC4Theme
+
+export function computeColorValues(color: HexColorLiteral): ThemeColorValues {
+  const colors = generate(color)
+
+  return {
+    elements: {
+      fill: color,
+      stroke: colors[6] as HexColorLiteral,
+      hiContrast: colors[1] as HexColorLiteral,
+      loContrast: colors[2] as HexColorLiteral
+    },
+    relationships: {
+      lineColor: color,
+      labelColor: colors[4] as HexColorLiteral,
+      labelBgColor: colors[9] as HexColorLiteral
+    }
+  }
+}
 
 export { ElementColors, RelationshipColors }

--- a/packages/core/src/types/_common.ts
+++ b/packages/core/src/types/_common.ts
@@ -4,7 +4,7 @@ export type NonEmptyArray<T> = [T, ...T[]]
 
 export type IconUrl = Tagged<string, 'IconUrl'>
 
-export type CustomColor = Opaque<string, 'CustomColor'>
+export type CustomColor = string
 
 export type Point = readonly [x: number, y: number]
 

--- a/packages/core/src/types/_common.ts
+++ b/packages/core/src/types/_common.ts
@@ -4,6 +4,8 @@ export type NonEmptyArray<T> = [T, ...T[]]
 
 export type IconUrl = Tagged<string, 'IconUrl'>
 
+export type CustomColor = Opaque<string, 'CustomColor'>
+
 export type Point = readonly [x: number, y: number]
 
 export interface XYPoint {

--- a/packages/core/src/types/element.ts
+++ b/packages/core/src/types/element.ts
@@ -56,7 +56,7 @@ export interface Element {
   readonly links: NonEmptyArray<Link> | null
   readonly icon?: IconUrl
   readonly shape?: ElementShape
-  readonly color?: ThemeColor
+  readonly color?: Color
   readonly style?: ElementStyle
   readonly notation?: string
   readonly metadata?: { [key: string]: string }

--- a/packages/core/src/types/expression.ts
+++ b/packages/core/src/types/expression.ts
@@ -2,7 +2,7 @@ import type { IconUrl } from './_common'
 import type { BorderStyle, ElementKind, ElementShape, Fqn, Tag } from './element'
 import type { WhereOperator } from './operators'
 import type { RelationshipArrowType, RelationshipLineType } from './relation'
-import type { ThemeColor } from './theme'
+import type { Color } from './theme'
 import type { ViewID } from './view'
 
 interface BaseExpr {
@@ -46,7 +46,7 @@ export interface CustomElementExpr extends Omit<BaseExpr, 'custom'> {
     technology?: string
     notation?: string
     shape?: ElementShape
-    color?: ThemeColor
+    color?: Color
     icon?: IconUrl
     border?: BorderStyle
     opacity?: number
@@ -161,7 +161,7 @@ export interface CustomRelationExpr extends Omit<BaseExpr, 'customRelation'> {
     description?: string
     technology?: string
     notation?: string
-    color?: ThemeColor
+    color?: Color
     line?: RelationshipLineType
     head?: RelationshipArrowType
     tail?: RelationshipArrowType

--- a/packages/core/src/types/relation.ts
+++ b/packages/core/src/types/relation.ts
@@ -1,7 +1,7 @@
 import type { Tagged } from 'type-fest'
 import type { NonEmptyArray } from './_common'
 import type { Fqn, Link, Tag } from './element'
-import type { ThemeColor } from './theme'
+import type { Color, ThemeColor } from './theme'
 
 export type RelationID = Tagged<string, 'RelationID'>
 export type RelationshipKind = Tagged<string, 'RelationshipKind'>
@@ -35,7 +35,7 @@ export interface Relation {
   readonly technology?: string
   readonly tags?: NonEmptyArray<Tag>
   readonly kind?: RelationshipKind
-  readonly color?: ThemeColor
+  readonly color?: Color
   readonly line?: RelationshipLineType
   readonly head?: RelationshipArrowType
   readonly tail?: RelationshipArrowType

--- a/packages/core/src/types/theme.ts
+++ b/packages/core/src/types/theme.ts
@@ -1,3 +1,5 @@
+import type { CustomColor } from "./_common"
+
 const ThemeColors = [
   'amber',
   'blue',
@@ -16,14 +18,10 @@ export type HexColorLiteral = `#${string}`
 
 export type ColorLiteral = HexColorLiteral
 
-export type Color = ThemeColor | ColorLiteral
+export type Color = ThemeColor | CustomColor
 
 export function isThemeColor(color: Color): color is ThemeColor {
   return color in ThemeColors
-}
-
-export function isColorLiteral(color: Color): color is ColorLiteral {
-  return !(color in ThemeColors)
 }
 
 export interface ElementThemeColorValues {

--- a/packages/core/src/types/theme.ts
+++ b/packages/core/src/types/theme.ts
@@ -1,19 +1,30 @@
-export type ThemeColor =
-  | 'amber'
-  | 'blue'
-  | 'gray'
-  | 'slate'
-  | 'green'
-  | 'indigo'
-  | 'muted'
-  | 'primary'
-  | 'red'
-  | 'secondary'
-  | 'sky'
+const ThemeColors = [
+  'amber',
+  'blue',
+  'gray',
+  'slate',
+  'green',
+  'indigo',
+  'muted',
+  'primary',
+  'red',
+  'secondary',
+  'sky'] as const
+export type ThemeColor = typeof ThemeColors[number]
 
 export type HexColorLiteral = `#${string}`
 
 export type ColorLiteral = HexColorLiteral
+
+export type Color = ThemeColor | ColorLiteral
+
+export function isThemeColor(color: Color): color is ThemeColor {
+  return color in ThemeColors
+}
+
+export function isColorLiteral(color: Color): color is ColorLiteral {
+  return !(color in ThemeColors)
+}
 
 export interface ElementThemeColorValues {
   fill: ColorLiteral
@@ -32,6 +43,11 @@ export interface RelationshipThemeColorValues {
   lineColor: ColorLiteral
   labelBgColor: ColorLiteral
   labelColor: ColorLiteral
+}
+
+export interface ThemeColorValues {
+  elements: ElementThemeColorValues
+  relationships: RelationshipThemeColorValues
 }
 
 export type RelationshipThemeColors = {

--- a/packages/core/src/types/theme.ts
+++ b/packages/core/src/types/theme.ts
@@ -1,4 +1,4 @@
-import type { CustomColor } from "./_common"
+import type { CustomColor } from './_common'
 
 const ThemeColors = [
   'amber',
@@ -11,7 +11,8 @@ const ThemeColors = [
   'primary',
   'red',
   'secondary',
-  'sky'] as const
+  'sky'
+] as const
 export type ThemeColor = typeof ThemeColors[number]
 
 export type HexColorLiteral = `#${string}`

--- a/packages/core/src/types/view-notation.ts
+++ b/packages/core/src/types/view-notation.ts
@@ -1,9 +1,9 @@
 import type { ElementKind, ElementShape } from './element'
-import type { ThemeColor } from './theme'
+import type { Color } from './theme'
 
 export type ElementNotation = {
   kinds: ElementKind[]
   shape: ElementShape
-  color: ThemeColor
+  color: Color
   title: string
 }

--- a/packages/core/src/types/view.ts
+++ b/packages/core/src/types/view.ts
@@ -4,7 +4,7 @@ import type { IconUrl, NonEmptyArray, Point, XYPoint } from './_common'
 import type { ElementKind, ElementShape, ElementStyle, Fqn, Link, Tag } from './element'
 import type { ElementExpression, ElementPredicateExpression, Expression } from './expression'
 import type { RelationID, RelationshipArrowType, RelationshipKind, RelationshipLineType } from './relation'
-import type { ThemeColor } from './theme'
+import type { Color, HexColorLiteral, ThemeColor, ThemeColorValues } from './theme'
 import type { ElementNotation } from './view-notation'
 
 // Full-qualified-name
@@ -30,7 +30,7 @@ export interface ViewRuleStyle {
   targets: ElementExpression[]
   notation?: string
   style: ElementStyle & {
-    color?: ThemeColor
+    color?: Color
     shape?: ElementShape
     icon?: IconUrl
   }
@@ -76,6 +76,8 @@ export interface BasicView<ViewType extends 'element' | 'dynamic'> {
    * If the view is changed manually this field contains the layout data.
    */
   readonly manualLayout?: ViewManualLayout | undefined
+
+  readonly customColorDefinitions: CustomColorDefinitions
 }
 
 export interface BasicElementView extends BasicView<'element'> {
@@ -98,7 +100,7 @@ export interface DynamicViewStep {
   readonly description?: string
   readonly technology?: string
   readonly notation?: string
-  readonly color?: ThemeColor
+  readonly color?: Color
   readonly line?: RelationshipLineType
   readonly head?: RelationshipArrowType
   readonly tail?: RelationshipArrowType
@@ -121,6 +123,8 @@ export interface DynamicView extends BasicView<'dynamic'> {
 
   readonly rules: DynamicViewRule[]
 }
+
+export type CustomColorDefinitions = { [key: string]: ThemeColorValues }
 
 export type LikeC4View = ElementView | DynamicView
 
@@ -175,7 +179,7 @@ export interface ComputedNode {
   /**
    * @deprecated Use `style` instead
    */
-  color: ThemeColor
+  color: Color
   /**
    * @deprecated Use `style` instead
    */
@@ -201,7 +205,7 @@ export interface ComputedEdge {
   technology?: string
   relations: RelationID[]
   kind?: RelationshipKind
-  color?: ThemeColor
+  color?: Color
   line?: RelationshipLineType
   head?: RelationshipArrowType
   tail?: RelationshipArrowType

--- a/packages/core/src/types/view.ts
+++ b/packages/core/src/types/view.ts
@@ -4,7 +4,7 @@ import type { IconUrl, NonEmptyArray, Point, XYPoint } from './_common'
 import type { ElementKind, ElementShape, ElementStyle, Fqn, Link, Tag } from './element'
 import type { ElementExpression, ElementPredicateExpression, Expression } from './expression'
 import type { RelationID, RelationshipArrowType, RelationshipKind, RelationshipLineType } from './relation'
-import type { Color, HexColorLiteral, ThemeColor, ThemeColorValues } from './theme'
+import type { Color, ThemeColorValues } from './theme'
 import type { ElementNotation } from './view-notation'
 
 // Full-qualified-name

--- a/packages/diagram/package.json
+++ b/packages/diagram/package.json
@@ -45,6 +45,7 @@
     "clean": "run -T rimraf -v -g 'dist/*' .tsbuildinfo"
   },
   "dependencies": {
+    "@ant-design/colors": "^7.1.0",
     "@lume/kiwi": "^0.4.3",
     "@react-hookz/web": "^24.0.4",
     "@tabler/icons-react": "^3.14.0",

--- a/packages/diagram/package.json
+++ b/packages/diagram/package.json
@@ -45,7 +45,6 @@
     "clean": "run -T rimraf -v -g 'dist/*' .tsbuildinfo"
   },
   "dependencies": {
-    "@ant-design/colors": "^7.1.0",
     "@lume/kiwi": "^0.4.3",
     "@react-hookz/web": "^24.0.4",
     "@tabler/icons-react": "^3.14.0",

--- a/packages/diagram/src/LikeC4CustomColors.props.ts
+++ b/packages/diagram/src/LikeC4CustomColors.props.ts
@@ -1,5 +1,5 @@
-import { type CustomColorDefinitions } from "@likec4/core"
+import { type CustomColorDefinitions } from '@likec4/core'
 
 export interface LikeC4CustomColorsProperties {
-    customColors: CustomColorDefinitions
+  customColors: CustomColorDefinitions
 }

--- a/packages/diagram/src/LikeC4CustomColors.props.ts
+++ b/packages/diagram/src/LikeC4CustomColors.props.ts
@@ -1,0 +1,5 @@
+import { type CustomColorDefinitions } from "@likec4/core"
+
+export interface LikeC4CustomColorsProperties {
+    customColors: CustomColorDefinitions
+}

--- a/packages/diagram/src/LikeC4CustomColors.tsx
+++ b/packages/diagram/src/LikeC4CustomColors.tsx
@@ -1,34 +1,37 @@
-import { type ThemeColorValues } from "@likec4/core"
-import { entries } from "remeda";
-import { vars } from "./theme.css";
-import type { LikeC4CustomColorsProperties } from "./LikeC4CustomColors.props";
+import { type ThemeColorValues } from '@likec4/core'
+import { entries } from 'remeda'
+import type { LikeC4CustomColorsProperties } from './LikeC4CustomColors.props'
+import { vars } from './theme.css'
 
-type CSSVarFunction = `var(--${string})` | `var(--${string}, ${string | number} )`;
+type CSSVarFunction = `var(--${string})` | `var(--${string}, ${string | number} )`
 
 export function LikeC4CustomColors({ customColors }: LikeC4CustomColorsProperties) {
-    function toStyle(name: String, colorValues: ThemeColorValues): String {
-        const rules = new Array<String>(
-            ...entries(colorValues.elements).map(([key, value]) => `${stripCssVarReference(vars.element[key])}: ${value};`),
-            ...entries(colorValues.relationships).map(([key, value]) => `${stripCssVarReference(vars.relation[key])}: ${value};`))
-            .join('\n')
+  function toStyle(name: String, colorValues: ThemeColorValues): String {
+    const rules = new Array<String>(
+      ...entries(colorValues.elements).map(([key, value]) => `${stripCssVarReference(vars.element[key])}: ${value};`),
+      ...entries(colorValues.relationships).map(([key, value]) =>
+        `${stripCssVarReference(vars.relation[key])}: ${value};`
+      )
+    )
+      .join('\n')
 
-        return `:where([data-likec4-color=${name}]) {
+    return `:where([data-likec4-color=${name}]) {
             ${rules}
         }`
-    }
+  }
 
-    function stripCssVarReference(ref: CSSVarFunction): String {
-        const end = ref.indexOf(',');
-        return ref.substring(4, end == -1 ? ref.length - 1 : end);
-    }
+  function stripCssVarReference(ref: CSSVarFunction): String {
+    const end = ref.indexOf(',')
+    return ref.substring(4, end == -1 ? ref.length - 1 : end)
+  }
 
-    const styles = entries(customColors)
-        .map(([name, color]) => toStyle(name, color))
-        .join('\n');
+  const styles = entries(customColors)
+    .map(([name, color]) => toStyle(name, color))
+    .join('\n')
 
-    return <>
-        <style>
-            {styles}
-        </style>
+  return (
+    <>
+      <style type="text/css" dangerouslySetInnerHTML={{ __html: styles }} />
     </>
+  )
 }

--- a/packages/diagram/src/LikeC4CustomColors.tsx
+++ b/packages/diagram/src/LikeC4CustomColors.tsx
@@ -1,0 +1,34 @@
+import { type ThemeColorValues } from "@likec4/core"
+import { entries } from "remeda";
+import { vars } from "./theme.css";
+import type { LikeC4CustomColorsProperties } from "./LikeC4CustomColors.props";
+
+type CSSVarFunction = `var(--${string})` | `var(--${string}, ${string | number} )`;
+
+export function LikeC4CustomColors({ customColors }: LikeC4CustomColorsProperties) {
+    function toStyle(name: String, colorValues: ThemeColorValues): String {
+        const rules = new Array<String>(
+            ...entries(colorValues.elements).map(([key, value]) => `${stripCssVarReference(vars.element[key])}: ${value};`),
+            ...entries(colorValues.relationships).map(([key, value]) => `${stripCssVarReference(vars.relation[key])}: ${value};`))
+            .join('\n')
+
+        return `:where([data-likec4-color=${name}]) {
+            ${rules}
+        }`
+    }
+
+    function stripCssVarReference(ref: CSSVarFunction): String {
+        const end = ref.indexOf(',');
+        return ref.substring(4, end == -1 ? ref.length - 1 : end);
+    }
+
+    const styles = entries(customColors)
+        .map(([name, color]) => toStyle(name, color))
+        .join('\n');
+
+    return <>
+        <style>
+            {styles}
+        </style>
+    </>
+}

--- a/packages/diagram/src/LikeC4Diagram.tsx
+++ b/packages/diagram/src/LikeC4Diagram.tsx
@@ -14,6 +14,7 @@ import { SelectEdgesOnNodeFocus } from './xyflow/SelectEdgesOnNodeFocus'
 import type { XYFlowEdge, XYFlowNode } from './xyflow/types'
 import { XYFlow } from './xyflow/XYFlow'
 import { XYFlowInner } from './xyflow/XYFlowInner'
+import {LikeC4CustomColors } from './LikeC4CustomColors'
 
 export type LikeC4DiagramProps = LikeC4DiagramProperties & LikeC4DiagramEventHandlers
 export function LikeC4Diagram({
@@ -70,6 +71,7 @@ export function LikeC4Diagram({
           fitView={fitView}
           {...initialRef.current}
         >
+          <LikeC4CustomColors customColors={view.customColorDefinitions}></LikeC4CustomColors>
           <DiagramContextProvider
             view={view}
             keepAspectRatio={keepAspectRatio}

--- a/packages/diagram/src/LikeC4Diagram.tsx
+++ b/packages/diagram/src/LikeC4Diagram.tsx
@@ -1,3 +1,4 @@
+import type { DiagramView } from '@likec4/core'
 import { ReactFlowProvider as XYFlowProvider } from '@xyflow/react'
 import clsx from 'clsx'
 import { shallowEqual } from 'fast-equals'
@@ -5,6 +6,7 @@ import { domAnimation, LazyMotion } from 'framer-motion'
 import { memo, useRef } from 'react'
 import { rootClassName } from './globals.css'
 import { useDiagramState } from './hooks/useDiagramState'
+import { LikeC4CustomColors } from './LikeC4CustomColors'
 import * as css from './LikeC4Diagram.css'
 import { type LikeC4DiagramEventHandlers, type LikeC4DiagramProperties } from './LikeC4Diagram.props'
 import { EnsureMantine } from './mantine/EnsureMantine'
@@ -14,7 +16,6 @@ import { SelectEdgesOnNodeFocus } from './xyflow/SelectEdgesOnNodeFocus'
 import type { XYFlowEdge, XYFlowNode } from './xyflow/types'
 import { XYFlow } from './xyflow/XYFlow'
 import { XYFlowInner } from './xyflow/XYFlowInner'
-import {LikeC4CustomColors } from './LikeC4CustomColors'
 
 export type LikeC4DiagramProps = LikeC4DiagramProperties & LikeC4DiagramEventHandlers
 export function LikeC4Diagram({
@@ -71,7 +72,7 @@ export function LikeC4Diagram({
           fitView={fitView}
           {...initialRef.current}
         >
-          <LikeC4CustomColors customColors={view.customColorDefinitions}></LikeC4CustomColors>
+          {customColorsDefined(view) && <LikeC4CustomColors customColors={view.customColorDefinitions} />}
           <DiagramContextProvider
             view={view}
             keepAspectRatio={keepAspectRatio}
@@ -168,3 +169,7 @@ const LikeC4DiagramInnerMemo = memo<LikeC4DiagramInnerProps>(function LikeC4Diag
   )
 }, shallowEqual)
 LikeC4DiagramInnerMemo.displayName = 'LikeC4DiagramInnerMemo'
+
+function customColorsDefined(view: DiagramView) {
+  return Object.keys(view.customColorDefinitions).length > 0
+}

--- a/packages/language-server/src/__tests__/specification.spec.ts
+++ b/packages/language-server/src/__tests__/specification.spec.ts
@@ -302,6 +302,20 @@ describe.concurrent('specification', () => {
         }
       }`
 
+    test('spec with custom colors').valid`
+      specification {
+        relationship async {
+          color custom-color
+        }
+        element person {
+          style {
+            color custom-color
+          }
+        }
+
+        color custom-color #ffffff
+      }`
+
     test('spec with invalid relationshipkind color').invalid`
       specification {
         relationship async {

--- a/packages/language-server/src/__tests__/views-dynamic.spec.ts
+++ b/packages/language-server/src/__tests__/views-dynamic.spec.ts
@@ -6,6 +6,7 @@ const model = `
     element component
     tag epic-123
     tag next
+    color custom-color #ff0000
   }
   model {
     component user
@@ -77,7 +78,7 @@ describe.concurrent('dynamic views', () => {
         system.frontend <- system.backend
 
         style * {
-          color red
+          color custom-color
         }
         autoLayout BottomTop
       }

--- a/packages/language-server/src/ast.ts
+++ b/packages/language-server/src/ast.ts
@@ -52,7 +52,7 @@ export interface ParsedAstSpecification {
       head?: c4.RelationshipArrowType
       tail?: c4.RelationshipArrowType
     }
-  >,
+  >
   colors: Record<
     c4.CustomColor,
     {
@@ -253,7 +253,7 @@ const isValidatableAstNode = validatableAstNodeGuards([
   ast.isSpecificationColor,
   ast.isSpecificationRule,
   ast.isModelViews,
-  ast.isModel,  
+  ast.isModel
 ])
 type ValidatableAstNode = Guarded<typeof isValidatableAstNode>
 
@@ -449,9 +449,9 @@ export function toRelationshipStyleExcludeDefaults(
 }
 
 export function toColor(astNode: ast.ColorProperty): c4.Color | undefined {
-  return astNode?.themeColor ?? (astNode?.customColor?.$refText as (HexColorLiteral | undefined));
+  return astNode?.themeColor ?? (astNode?.customColor?.$refText as (HexColorLiteral | undefined))
 }
-    
+
 export function toAutoLayout(
   direction: ast.ViewLayoutDirection
 ): c4.ViewRuleAutoLayout['autoLayout'] {

--- a/packages/language-server/src/ast.ts
+++ b/packages/language-server/src/ast.ts
@@ -30,7 +30,7 @@ declare module './generated/ast' {
 type ParsedElementStyle = {
   shape?: c4.ElementShape
   icon?: c4.IconUrl
-  color?: c4.ThemeColor
+  color?: c4.Color
   border?: c4.BorderStyle
   opacity?: number
 }
@@ -47,10 +47,16 @@ export interface ParsedAstSpecification {
     {
       technology?: string
       notation?: string
-      color?: c4.ThemeColor
+      color?: c4.Color
       line?: c4.RelationshipLineType
       head?: c4.RelationshipArrowType
       tail?: c4.RelationshipArrowType
+    }
+  >,
+  colors: Record<
+    c4.CustomColor,
+    {
+      color: HexColorLiteral
     }
   >
 }
@@ -78,7 +84,7 @@ export interface ParsedAstRelation {
   title: string
   description?: string
   technology?: string
-  color?: c4.ThemeColor
+  color?: c4.Color
   line?: c4.RelationshipLineType
   head?: c4.RelationshipArrowType
   tail?: c4.RelationshipArrowType
@@ -178,7 +184,8 @@ export function cleanParsedModel(doc: LikeC4LangiumDocument) {
     c4Specification: {
       tags: new Set(),
       elements: {},
-      relationships: {}
+      relationships: {},
+      colors: {}
     },
     c4Elements: [],
     c4Relations: [],
@@ -243,9 +250,10 @@ const isValidatableAstNode = validatableAstNodeGuards([
   ast.isSpecificationElementKind,
   ast.isSpecificationRelationshipKind,
   ast.isSpecificationTag,
+  ast.isSpecificationColor,
   ast.isSpecificationRule,
   ast.isModelViews,
-  ast.isModel
+  ast.isModel,  
 ])
 type ValidatableAstNode = Guarded<typeof isValidatableAstNode>
 
@@ -354,8 +362,9 @@ export function toElementStyle(props: Array<ast.StyleProperty> | undefined, isVa
         break
       }
       case ast.isColorProperty(prop): {
-        if (isTruthy(prop.value)) {
-          result.color = prop.value
+        const color = toColor(prop)
+        if (isTruthy(color)) {
+          result.color = color
         }
         break
       }
@@ -386,7 +395,7 @@ export function toElementStyle(props: Array<ast.StyleProperty> | undefined, isVa
 
 export function toRelationshipStyle(props?: ast.RelationshipStyleProperty[]) {
   const result = {} as {
-    color?: c4.ThemeColor
+    color?: c4.Color
     line?: c4.RelationshipLineType
     head?: c4.RelationshipArrowType
     tail?: c4.RelationshipArrowType
@@ -396,7 +405,10 @@ export function toRelationshipStyle(props?: ast.RelationshipStyleProperty[]) {
   }
   for (const prop of props) {
     if (ast.isColorProperty(prop)) {
-      result.color = prop.value
+      const color = toColor(prop)
+      if (isTruthy(color)) {
+        result.color = color
+      }
       continue
     }
     if (ast.isLineProperty(prop)) {
@@ -436,6 +448,10 @@ export function toRelationshipStyleExcludeDefaults(
   }
 }
 
+export function toColor(astNode: ast.ColorProperty): c4.Color | undefined {
+  return astNode?.themeColor ?? (astNode?.customColor?.$refText as (HexColorLiteral | undefined));
+}
+    
 export function toAutoLayout(
   direction: ast.ViewLayoutDirection
 ): c4.ViewRuleAutoLayout['autoLayout'] {

--- a/packages/language-server/src/like-c4.langium
+++ b/packages/language-server/src/like-c4.langium
@@ -32,7 +32,7 @@ RelationshipKind:
   name=Id;
 
 CustomColor:
-  name=Id;
+  name=CustomColorId;
 
 SpecificationRule:
   name='specification' '{'
@@ -454,7 +454,7 @@ NavigateToProperty:
 LinkProperty:
   key='link' ':'? value=Uri title=String? ';'?;
 ColorProperty:
-  key='color' ':'? (themeColor=ThemeColor | customColor=[CustomColor:Id]) ';'?;
+  key='color' ':'? (themeColor=ThemeColor | customColor=[CustomColor:CustomColorId]) ';'?;
 
 OpacityProperty:
   key='opacity' ':'? value=Percent ';'?;
@@ -535,8 +535,14 @@ TagId returns string:
 DotId returns string:
   Dot Id;
 
+CustomColorId returns string:
+  IdTerminal | ElementShape | ArrowType | LineOptions | 'element' | 'model';
+
+// Used to be like bellow but it was ambiguos with CustomColorId rule
+// Id returns string:
+//  IdTerminal | ElementShape | ThemeColor | ArrowType | LineOptions | 'element' | 'model'
 Id returns string:
-  IdTerminal | ElementShape | ThemeColor | ArrowType | LineOptions | 'element' | 'model';
+  CustomColorId | ThemeColor;
 
 fragment EqOperator:
   (

--- a/packages/language-server/src/like-c4.langium
+++ b/packages/language-server/src/like-c4.langium
@@ -31,12 +31,16 @@ Tag:
 RelationshipKind:
   name=Id;
 
+CustomColor:
+  name=Id;
+
 SpecificationRule:
   name='specification' '{'
     (
       elements+=SpecificationElementKind |
       tags+=SpecificationTag |
-      relationships+=SpecificationRelationshipKind
+      relationships+=SpecificationRelationshipKind |
+      colors+=SpecificationColor
     )*
   '}';
 
@@ -53,6 +57,9 @@ SpecificationElementStringProperty:
 
 SpecificationTag:
   'tag' tag=Tag;
+
+SpecificationColor:
+  'color' name=CustomColor color=CustomColorValue;
 
 SpecificationRelationshipKind:
   'relationship' kind=RelationshipKind ('{'
@@ -447,7 +454,7 @@ NavigateToProperty:
 LinkProperty:
   key='link' ':'? value=Uri title=String? ';'?;
 ColorProperty:
-  key='color' ':'? value=ThemeColor ';'?;
+  key='color' ':'? (themeColor=ThemeColor | customColor=[CustomColor:Id]) ';'?;
 
 OpacityProperty:
   key='opacity' ':'? value=Percent ';'?;
@@ -512,6 +519,9 @@ ThemeColor returns string:
   'primary' | 'secondary' | 'muted' | 'slate' | 'blue' | 'indigo' | 'sky' | 'red' | 'gray' | 'green' | 'amber';
 ElementShape returns string:
   'rectangle' | 'person' | 'browser' | 'mobile' | 'cylinder' | 'storage' | 'queue';
+
+CustomColorValue returns string:
+  Hash (Id | Hex);
 
 IconId returns string:
   LIB_ICON;
@@ -580,3 +590,4 @@ terminal String: /"[^"]*"|'[^']*'/;
 // terminal  TagId: HASH LETTER (LETTER | DIGIT | UNDERSCORE | DASH)*;
 // terminal IdTerminal: (LETTER | UNDERSCORE+ (LETTER | DIGIT)) (LETTER | DIGIT | UNDERSCORE | DASH)*;
 terminal IdTerminal:  /[_]*[a-zA-Z][-\w]*/;
+terminal Hex: /[a-zA-Z0-9]+/;

--- a/packages/language-server/src/like-c4.langium
+++ b/packages/language-server/src/like-c4.langium
@@ -538,11 +538,8 @@ DotId returns string:
 CustomColorId returns string:
   IdTerminal | ElementShape | ArrowType | LineOptions | 'element' | 'model';
 
-// Used to be like bellow but it was ambiguos with CustomColorId rule
-// Id returns string:
-//  IdTerminal | ElementShape | ThemeColor | ArrowType | LineOptions | 'element' | 'model'
 Id returns string:
-  CustomColorId | ThemeColor;
+  IdTerminal | ElementShape | ThemeColor | ArrowType | LineOptions | 'element' | 'model';
 
 fragment EqOperator:
   (

--- a/packages/language-server/src/lsp/CompletionProvider.spec.ts
+++ b/packages/language-server/src/lsp/CompletionProvider.spec.ts
@@ -22,6 +22,7 @@ describe('LikeC4CompletionProvider', () => {
             color <|>secondary
           }
         }
+        color custom-color #ff0000
       }
     `
     const completion = expectCompletion()
@@ -46,7 +47,7 @@ describe('LikeC4CompletionProvider', () => {
     await completion({
       text,
       index: 2,
-      expectedItems: ['element', 'tag', 'relationship']
+      expectedItems: ['element', 'tag', 'relationship', 'color']
     })
     await completion({
       text,
@@ -72,6 +73,7 @@ describe('LikeC4CompletionProvider', () => {
       text,
       index: 7,
       expectedItems: [
+        'custom-color',
         'primary',
         'secondary',
         'muted',

--- a/packages/language-server/src/model-graph/compute-view/__test__/__snapshots__/legacy.spec.ts.snap
+++ b/packages/language-server/src/model-graph/compute-view/__test__/__snapshots__/legacy.spec.ts.snap
@@ -4,6 +4,7 @@ exports[`compute-element-view > view of cloud 1`] = `
 {
   "__": "element",
   "autoLayout": "TB",
+  "customColorDefinitions": {},
   "description": null,
   "edges": [
     {
@@ -238,6 +239,7 @@ exports[`compute-element-view > view of cloud.frontend 1`] = `
 {
   "__": "element",
   "autoLayout": "TB",
+  "customColorDefinitions": {},
   "description": null,
   "edges": [
     {

--- a/packages/language-server/src/model-graph/compute-view/__test__/fixture.ts
+++ b/packages/language-server/src/model-graph/compute-view/__test__/fixture.ts
@@ -1,5 +1,6 @@
 import {
   type BorderStyle,
+  type Color,
   type ComputedView,
   type CustomElementExpr as C4CustomElementExpr,
   type CustomRelationExpr as C4CustomRelationExpr,
@@ -21,8 +22,7 @@ import {
   type ViewRule,
   type ViewRulePredicate,
   type ViewRuleStyle,
-  type WhereOperator,
-  type Color
+  type WhereOperator
 } from '@likec4/core'
 import { indexBy, isString, map, prop } from 'remeda'
 import { LikeC4ModelGraph } from '../../LikeC4ModelGraph'

--- a/packages/language-server/src/model-graph/compute-view/__test__/fixture.ts
+++ b/packages/language-server/src/model-graph/compute-view/__test__/fixture.ts
@@ -17,12 +17,12 @@ import {
   type RelationshipLineType,
   type RelationWhereExpr,
   type Tag,
-  type ThemeColor,
   type ViewID,
   type ViewRule,
   type ViewRulePredicate,
   type ViewRuleStyle,
-  type WhereOperator
+  type WhereOperator,
+  type Color
 } from '@likec4/core'
 import { indexBy, isString, map, prop } from 'remeda'
 import { LikeC4ModelGraph } from '../../LikeC4ModelGraph'
@@ -220,7 +220,7 @@ const rel = <Source extends FakeElementIds, Target extends FakeElementIds>({
   target: Target
   title?: string
   kind?: string
-  color?: ThemeColor
+  color?: Color
   line?: RelationshipLineType
   head?: RelationshipArrowType
   tail?: RelationshipArrowType
@@ -372,7 +372,7 @@ export function $custom(
     description?: string
     technology?: string
     shape?: ElementShape
-    color?: ThemeColor
+    color?: Color
     border?: BorderStyle
     icon?: string
     opacity?: number

--- a/packages/language-server/src/model-graph/compute-view/__test__/fixture.ts
+++ b/packages/language-server/src/model-graph/compute-view/__test__/fixture.ts
@@ -336,6 +336,7 @@ const emptyView = {
   description: null,
   tags: null,
   links: null,
+  customColorDefinitions: {},
   rules: []
 }
 

--- a/packages/language-server/src/model-graph/compute-view/compute.ts
+++ b/packages/language-server/src/model-graph/compute-view/compute.ts
@@ -1,4 +1,5 @@
 import type {
+  Color,
   ComputedEdge,
   ComputedElementView,
   EdgeId,
@@ -212,7 +213,7 @@ export class ComputeCtx {
           description?: string | undefined
           technology?: string | undefined
           kind?: RelationshipKind | undefined
-          color?: ThemeColor | undefined
+          color?: Color | undefined
           line?: RelationshipLineType | undefined
           head?: RelationshipArrowType | undefined
           tail?: RelationshipArrowType | undefined

--- a/packages/language-server/src/model-graph/dynamic-view/__test__/fixture.ts
+++ b/packages/language-server/src/model-graph/dynamic-view/__test__/fixture.ts
@@ -10,6 +10,7 @@ const emptyView = {
   description: null,
   tags: null,
   links: null,
+  customColorDefinitions: {},
   rules: []
 }
 

--- a/packages/language-server/src/model-graph/dynamic-view/compute.ts
+++ b/packages/language-server/src/model-graph/dynamic-view/compute.ts
@@ -1,4 +1,5 @@
 import type {
+  Color,
   ComputedDynamicView,
   ComputedEdge,
   DynamicView,
@@ -38,7 +39,7 @@ export namespace DynamicViewComputeCtx {
     title: string | null
     description?: string
     technology?: string
-    color?: ThemeColor
+    color?: Color
     line?: RelationshipLineType
     head?: RelationshipArrowType
     tail?: RelationshipArrowType

--- a/packages/language-server/src/model/__snapshots__/model-builder.spec.ts.snap
+++ b/packages/language-server/src/model/__snapshots__/model-builder.spec.ts.snap
@@ -85,6 +85,7 @@ exports[`LikeC4ModelBuilder > builds model with description and technology 1`] =
     "index": {
       "__": "element",
       "autoLayout": "TB",
+      "customColorDefinitions": {},
       "description": null,
       "edges": [
         {
@@ -237,6 +238,7 @@ exports[`LikeC4ModelBuilder > builds model with extend 1`] = `
     "frontend": {
       "__": "element",
       "autoLayout": "TB",
+      "customColorDefinitions": {},
       "description": null,
       "edges": [
         {
@@ -332,6 +334,7 @@ exports[`LikeC4ModelBuilder > builds model with extend 1`] = `
     "index": {
       "__": "element",
       "autoLayout": "TB",
+      "customColorDefinitions": {},
       "description": null,
       "edges": [
         {
@@ -395,6 +398,7 @@ exports[`LikeC4ModelBuilder > builds model with extend 1`] = `
     "v1": {
       "__": "element",
       "autoLayout": "LR",
+      "customColorDefinitions": {},
       "description": null,
       "edges": [
         {
@@ -536,6 +540,7 @@ exports[`LikeC4ModelBuilder > builds model with relationship spec and tag 1`] = 
     "index": {
       "__": "element",
       "autoLayout": "TB",
+      "customColorDefinitions": {},
       "description": null,
       "edges": [
         {
@@ -655,6 +660,7 @@ exports[`LikeC4ModelBuilder > builds model with relationship spec with technolog
     "index": {
       "__": "element",
       "autoLayout": "TB",
+      "customColorDefinitions": {},
       "description": null,
       "edges": [
         {
@@ -770,6 +776,7 @@ exports[`LikeC4ModelBuilder > builds model with styled relationship 1`] = `
     "index": {
       "__": "element",
       "autoLayout": "TB",
+      "customColorDefinitions": {},
       "description": null,
       "edges": [
         {

--- a/packages/language-server/src/model/model-builder.spec.ts
+++ b/packages/language-server/src/model/model-builder.spec.ts
@@ -938,7 +938,7 @@ describe.concurrent('LikeC4ModelBuilder', () => {
     })
   })
 
-  it('parses custom color definitions', async ({expect}) => {
+  it('parses custom color definitions', async ({ expect }) => {
     const { validate, buildModel } = createTestServices()
     const { diagnostics } = await validate(`
       specification {
@@ -959,34 +959,34 @@ describe.concurrent('LikeC4ModelBuilder', () => {
     expect(indexView).toHaveProperty('customColorDefinitions', {
       'custom-color1': {
         elements: {
-          fill: '#FF00FF',
-          hiContrast: '#ffa3f3',
-          loContrast: '#ff7af2',
-          stroke: '#d200d9',
+          fill: '#ff09ff',
+          hiContrast: '#ffe8ff',
+          loContrast: '#ffceff',
+          stroke: '#e400e4'
         },
         relationships: {
-          labelBgColor: '#580066',
-          labelColor: '#ff29f8',
-          lineColor: '#FF00FF',
-        },
+          labelBgColor: '#b100b2',
+          labelColor: '#ff64ff',
+          lineColor: '#fe37fe'
+        }
       },
       'custom-color2': {
         elements: {
-          fill: '#FFFF00',
-          hiContrast: '#fff3a3',
-          loContrast: '#fff27a',
-          stroke: '#d2d900',
+          fill: '#ffff09',
+          hiContrast: '#ffffe1',
+          loContrast: '#ffffcc',
+          stroke: '#e3e300'
         },
         relationships: {
-          labelBgColor: '#586600',
-          labelColor: '#fff829',
-          lineColor: '#FFFF00',
-        },
+          labelBgColor: '#adae00',
+          labelColor: '#ffff64',
+          lineColor: '#ffff38'
+        }
       }
     })
   })
 
-  it('allows custom colors in spec', async ({expect}) => {
+  it('allows custom colors in spec', async ({ expect }) => {
     const { validate, buildModel } = createTestServices()
     const { diagnostics } = await validate(`
       specification {
@@ -1022,7 +1022,7 @@ describe.concurrent('LikeC4ModelBuilder', () => {
     expect(indexView.nodes.find(n => n.id === 'sys2')?.color).toBe('custom-color1')
   })
 
-  it('allows custom colors in relationships', async ({expect}) => {
+  it('allows custom colors in relationships', async ({ expect }) => {
     const { validate, buildModel } = createTestServices()
     const { diagnostics } = await validate(`
       specification {
@@ -1052,7 +1052,7 @@ describe.concurrent('LikeC4ModelBuilder', () => {
     expect(indexView.edges[0]?.color).toBe('custom-color1')
   })
 
-  it('allows custom colors in include expressions of view', async ({expect}) => {
+  it('allows custom colors in include expressions of view', async ({ expect }) => {
     const { validate, buildModel } = createTestServices()
     const { diagnostics } = await validate(`
       specification {

--- a/packages/language-server/src/model/model-builder.spec.ts
+++ b/packages/language-server/src/model/model-builder.spec.ts
@@ -1066,7 +1066,7 @@ describe.concurrent('LikeC4ModelBuilder', () => {
         sys1 -> sys2
       }
       views {
-        view {
+        view index {
           include sys1 with {
             color custom-color1
           }

--- a/packages/language-server/src/model/model-builder.ts
+++ b/packages/language-server/src/model/model-builder.ts
@@ -25,13 +25,13 @@ import {
   isTruthy,
   map,
   mapToObj,
+  mapValues,
   pipe,
   prop,
   reduce,
   reverse,
   sort,
-  values,
-  mapValues
+  values
 } from 'remeda'
 import type {
   ParsedAstElement,
@@ -71,10 +71,11 @@ function buildModel(services: LikeC4Services, docs: ParsedLikeC4LangiumDocument[
       return null
     }
   }
-  
+
   const customColorDefinitions: CustomColorDefinitions = mapValues(
-    c4Specification.colors, 
-    c => computeColorValues(c.color))
+    c4Specification.colors,
+    c => computeColorValues(c.color)
+  )
 
   const toModelElement = (doc: LangiumDocument) => {
     return ({

--- a/packages/language-server/src/model/model-builder.ts
+++ b/packages/language-server/src/model/model-builder.ts
@@ -1,6 +1,8 @@
 import {
   compareByFqnHierarchically,
   compareRelations,
+  computeColorValues,
+  type CustomColorDefinitions,
   isElementView,
   isScopedElementView,
   parentFqn,
@@ -28,7 +30,8 @@ import {
   reduce,
   reverse,
   sort,
-  values
+  values,
+  mapValues
 } from 'remeda'
 import type {
   ParsedAstElement,
@@ -48,12 +51,14 @@ function buildModel(services: LikeC4Services, docs: ParsedLikeC4LangiumDocument[
   const c4Specification: ParsedAstSpecification = {
     tags: new Set(),
     elements: {},
-    relationships: {}
+    relationships: {},
+    colors: {}
   }
   forEach(map(docs, prop('c4Specification')), spec => {
     spec.tags.forEach(t => c4Specification.tags.add(t))
     Object.assign(c4Specification.elements, spec.elements)
     Object.assign(c4Specification.relationships, spec.relationships)
+    Object.assign(c4Specification.colors, spec.colors)
   })
   const resolveLinks = (doc: LangiumDocument, links: c4.NonEmptyArray<c4.Link>) => {
     try {
@@ -66,6 +71,10 @@ function buildModel(services: LikeC4Services, docs: ParsedLikeC4LangiumDocument[
       return null
     }
   }
+  
+  const customColorDefinitions: CustomColorDefinitions = mapValues(
+    c4Specification.colors, 
+    c => computeColorValues(c.color))
 
   const toModelElement = (doc: LangiumDocument) => {
     return ({
@@ -225,7 +234,8 @@ function buildModel(services: LikeC4Services, docs: ParsedLikeC4LangiumDocument[
         docUri,
         description,
         title,
-        id
+        id,
+        customColorDefinitions
       }
     }
   }
@@ -240,6 +250,7 @@ function buildModel(services: LikeC4Services, docs: ParsedLikeC4LangiumDocument[
       description: null,
       tags: null,
       links: null,
+      customColorDefinitions: customColorDefinitions,
       rules: [
         {
           include: [
@@ -387,6 +398,30 @@ export class LikeC4ModelBuilder {
         await interruptAndCheck(cancelToken)
       }
       return this.syncBuildComputedModel(model)
+        const allViews = [] as c4.ComputedView[]
+        for (const view of values(model.views)) {
+          const result = isElementView(view) ? computeView(view, index) : computeDynamicView(view, index)
+
+          if (!result.isSuccess) {
+            logWarnError(result.error)
+            continue
+          }
+          allViews.push(result.view)
+        }
+        assignNavigateTo(allViews)
+        const views = mapToObj(allViews, v => {
+          const previous = this.previousViews[v.id]
+          const view = previous && eq(v, previous) ? previous : v
+          viewsCache.set(computedViewKey(v.id), view)
+          return [v.id, view] as const
+        })
+        this.previousViews = { ...views }
+        return {
+          elements: model.elements,
+          relations: model.relations,
+          views
+        }
+      })
     })
   }
 

--- a/packages/language-server/src/model/model-parser.ts
+++ b/packages/language-server/src/model/model-parser.ts
@@ -1,4 +1,10 @@
-import { type c4, invariant, isNonEmptyArray, type HexColorLiteral, nonexhaustive } from '@likec4/core'
+import {
+  type c4,
+  type HexColorLiteral,
+  invariant,
+  isNonEmptyArray,
+  nonexhaustive
+} from '@likec4/core'
 import type { AstNode, LangiumDocument } from 'langium'
 import { AstUtils, CstUtils } from 'langium'
 import { filter, flatMap, isDefined, isNonNullish, isTruthy, mapToObj, pipe } from 'remeda'
@@ -154,7 +160,7 @@ export class LikeC4ModelParser {
           logger.warn(`Custom color "${colorName}" is already defined`)
           continue
         }
-        
+
         c4Specification.colors[colorName] = {
           color: color as HexColorLiteral
         }
@@ -667,8 +673,8 @@ export class LikeC4ModelParser {
           }
           if (ast.isColorProperty(prop)) {
             const value = toColor(prop)
-            if(isTruthy(value)) {
-              step[prop.key] = value              
+            if (isTruthy(value)) {
+              step[prop.key] = value
             }
             continue
           }

--- a/packages/language-server/src/model/model-parser.ts
+++ b/packages/language-server/src/model/model-parser.ts
@@ -1,5 +1,4 @@
-import { invariant, isNonEmptyArray, nonexhaustive } from '@likec4/core'
-import type * as c4 from '@likec4/core'
+import { type c4, invariant, isNonEmptyArray, type HexColorLiteral, nonexhaustive } from '@likec4/core'
 import type { AstNode, LangiumDocument } from 'langium'
 import { AstUtils, CstUtils } from 'langium'
 import { filter, flatMap, isDefined, isNonNullish, isTruthy, mapToObj, pipe } from 'remeda'
@@ -24,6 +23,7 @@ import {
   resolveRelationPoints,
   streamModel,
   toAutoLayout,
+  toColor,
   toElementStyle,
   toRelationshipStyleExcludeDefaults,
   ViewOps
@@ -143,6 +143,23 @@ export class LikeC4ModelParser {
       const tag = tagSpec.tag.name as c4.Tag
       if (isTruthy(tag)) {
         c4Specification.tags.add(tag)
+      }
+    }
+
+    const colors_specs = specifications.flatMap(s => s.colors.filter(isValid))
+    for (const { name, color } of colors_specs) {
+      try {
+        const colorName = name.name as c4.CustomColor
+        if (colorName in c4Specification.colors) {
+          logger.warn(`Custom color "${colorName}" is already defined`)
+          continue
+        }
+        
+        c4Specification.colors[colorName] = {
+          color: color as HexColorLiteral
+        }
+      } catch (e) {
+        logWarnError(e)
       }
     }
   }
@@ -407,8 +424,9 @@ export class LikeC4ModelParser {
           return acc
         }
         if (ast.isColorProperty(prop)) {
-          if (isDefined(prop.value)) {
-            acc.custom[prop.key] = prop.value
+          const value = toColor(prop)
+          if (isDefined(value)) {
+            acc.custom[prop.key] = value
           }
           return acc
         }
@@ -508,8 +526,9 @@ export class LikeC4ModelParser {
           return acc
         }
         if (ast.isColorProperty(prop)) {
-          if (isTruthy(prop.value)) {
-            acc.customRelation[prop.key] = prop.value
+          const value = toColor(prop)
+          if (isTruthy(value)) {
+            acc.customRelation[prop.key] = value
           }
           return acc
         }
@@ -647,7 +666,10 @@ export class LikeC4ModelParser {
             continue
           }
           if (ast.isColorProperty(prop)) {
-            step[prop.key] = prop.value
+            const value = toColor(prop)
+            if(isTruthy(value)) {
+              step[prop.key] = value              
+            }
             continue
           }
           if (ast.isLineProperty(prop)) {

--- a/packages/language-server/src/references/scope-computation.ts
+++ b/packages/language-server/src/references/scope-computation.ts
@@ -106,7 +106,8 @@ export class LikeC4ScopeComputation extends DefaultScopeComputation {
       const spec of specifications.flatMap(s => [
         ...s.elements,
         ...s.relationships,
-        ...s.tags
+        ...s.tags,
+        ...s.colors
       ])
     ) {
       try {
@@ -132,6 +133,14 @@ export class LikeC4ScopeComputation extends DefaultScopeComputation {
               docExports.push(
                 this.descriptions.createDescription(spec.kind, spec.kind.name, document),
                 this.descriptions.createDescription(spec.kind, '.' + spec.kind.name, document)
+              )
+            }
+            continue
+          }
+          case ast.isSpecificationColor(spec): {
+            if (isTruthy(spec.name.name)) {
+              docExports.push(
+                this.descriptions.createDescription(spec.name, spec.name.name, document)
               )
             }
             continue

--- a/packages/layouts/src/graphviz/DotPrinter.ts
+++ b/packages/layouts/src/graphviz/DotPrinter.ts
@@ -2,13 +2,13 @@ import {
   compareFqnHierarchically,
   DefaultRelationshipColor,
   defaultTheme as Theme,
+  DefaultThemeColor,
   invariant,
+  isThemeColor,
   nameFromFqn,
   nonNullable,
   parentFqn,
-  parentFqnPredicate,
-  isThemeColor,
-  DefaultThemeColor
+  parentFqnPredicate
 } from '@likec4/core'
 import type {
   Color,
@@ -509,13 +509,13 @@ export abstract class DotPrinter<V extends ComputedView = ComputedView> {
     return this
   }
   protected getRelationshipColorValues(color: Color): RelationshipThemeColorValues {
-    return isThemeColor(color) 
-      ? Theme.relationships[color] 
-      : this.view.customColorDefinitions[color]?.relationships ?? Theme.relationships[DefaultThemeColor];
+    return isThemeColor(color)
+      ? Theme.relationships[color]
+      : this.view.customColorDefinitions[color]?.relationships ?? Theme.relationships[DefaultThemeColor]
   }
   protected getElementColorValues(color: Color): ElementThemeColorValues {
-    return isThemeColor(color) 
-      ? Theme.elements[color] 
-      : this.view.customColorDefinitions[color]?.elements ?? Theme.elements[DefaultThemeColor];
+    return isThemeColor(color)
+      ? Theme.elements[color]
+      : this.view.customColorDefinitions[color]?.elements ?? Theme.elements[DefaultThemeColor]
   }
 }

--- a/packages/layouts/src/graphviz/DotPrinter.ts
+++ b/packages/layouts/src/graphviz/DotPrinter.ts
@@ -6,9 +6,23 @@ import {
   nameFromFqn,
   nonNullable,
   parentFqn,
-  parentFqnPredicate
+  parentFqnPredicate,
+  isThemeColor,
+  DefaultThemeColor
 } from '@likec4/core'
-import type { ComputedEdge, ComputedNode, ComputedView, EdgeId, Fqn, RelationshipLineType, XYPoint } from '@likec4/core'
+import type {
+  Color,
+  ComputedEdge,
+  ComputedNode,
+  ComputedView,
+  EdgeId,
+  ElementThemeColorValues,
+  Fqn,
+  RelationshipLineType,
+  RelationshipThemeColorValues,
+  ThemeColorValues,
+  XYPoint
+} from '@likec4/core/types'
 import { logger } from '@likec4/log'
 import { filter, isNullish, isNumber, isTruthy, map, pipe, reverse, sort, take } from 'remeda'
 import {
@@ -227,13 +241,14 @@ export abstract class DotPrinter<V extends ComputedView = ComputedView> {
   protected elementToSubgraph(compound: ComputedNode, subgraph: SubgraphModel) {
     invariant(isCompound(compound), 'node should be compound')
     invariant(isNumber(compound.depth), 'node.depth should be defined')
-    const textColor = compoundLabelColor(Theme.elements[compound.color].loContrast)
+    const colorValues = this.getElementColorValues(compound.color)
+    const textColor = compoundLabelColor(colorValues.loContrast)
     subgraph.apply({
       [_.likec4_id]: compound.id,
       [_.likec4_level]: compound.level,
       [_.likec4_depth]: compound.depth,
-      [_.fillcolor]: compoundColor(Theme.elements[compound.color].fill, compound.depth),
-      [_.color]: compoundColor(Theme.elements[compound.color].stroke, compound.depth),
+      [_.fillcolor]: compoundColor(colorValues.fill, compound.depth),
+      [_.color]: compoundColor(colorValues.stroke, compound.depth),
       [_.style]: 'filled',
       [_.margin]: pxToPoints(32),
       [_.label]: compoundLabel(compound, textColor)
@@ -244,12 +259,13 @@ export abstract class DotPrinter<V extends ComputedView = ComputedView> {
   protected elementToNode(element: ComputedNode, node: NodeModel) {
     invariant(!isCompound(element), 'node should not be compound')
     const hasIcon = isTruthy(element.icon)
+    const colorValues = this.getElementColorValues(element.color)
     node.attributes.apply({
       [_.likec4_id]: element.id,
       [_.likec4_level]: element.level,
-      [_.fillcolor]: Theme.elements[element.color].fill,
-      [_.fontcolor]: Theme.elements[element.color].hiContrast,
-      [_.color]: Theme.elements[element.color].stroke,
+      [_.fillcolor]: colorValues.fill,
+      [_.fontcolor]: colorValues.hiContrast,
+      [_.color]: colorValues.stroke,
       [_.margin]: `${pxToInch(hasIcon ? 10 : 26)},${pxToInch(26)}`
     })
     switch (element.shape) {
@@ -286,7 +302,7 @@ export abstract class DotPrinter<V extends ComputedView = ComputedView> {
         break
     }
     // add label to the end
-    node.attributes.set(_.label, nodeLabel(element))
+    node.attributes.set(_.label, nodeLabel(element, colorValues))
     return node
   }
 
@@ -491,5 +507,15 @@ export abstract class DotPrinter<V extends ComputedView = ComputedView> {
     this.graphvizModel.delete(_.packmode)
     this.graphvizModel.attributes.graph.delete(_.margin)
     return this
+  }
+  protected getRelationshipColorValues(color: Color): RelationshipThemeColorValues {
+    return isThemeColor(color) 
+      ? Theme.relationships[color] 
+      : this.view.customColorDefinitions[color]?.relationships ?? Theme.relationships[DefaultThemeColor];
+  }
+  protected getElementColorValues(color: Color): ElementThemeColorValues {
+    return isThemeColor(color) 
+      ? Theme.elements[color] 
+      : this.view.customColorDefinitions[color]?.elements ?? Theme.elements[DefaultThemeColor];
   }
 }

--- a/packages/layouts/src/graphviz/DynamicViewPrinter.ts
+++ b/packages/layouts/src/graphviz/DynamicViewPrinter.ts
@@ -34,9 +34,10 @@ export class DynamicViewPrinter extends DotPrinter<ComputedDynamicView> {
     ltail && e.attributes.set(_.ltail, ltail)
 
     if (edge.color && edge.color !== DefaultRelationshipColor) {
+      const colorValues = this.getRelationshipColorValues(edge.color)
       e.attributes.apply({
-        [_.color]: Theme.relationships[edge.color].lineColor,
-        [_.fontcolor]: Theme.relationships[edge.color].labelColor
+        [_.color]: colorValues.lineColor,
+        [_.fontcolor]: colorValues.labelColor
       })
     }
 

--- a/packages/layouts/src/graphviz/ElementViewPrinter.ts
+++ b/packages/layouts/src/graphviz/ElementViewPrinter.ts
@@ -115,9 +115,10 @@ export class ElementViewPrinter extends DotPrinter<ComputedElementView> {
       }
     }
     if (edge.color) {
+      const colorValues = this.getRelationshipColorValues(edge.color)
       e.attributes.apply({
-        [_.color]: Theme.relationships[edge.color].lineColor,
-        [_.fontcolor]: Theme.relationships[edge.color].labelColor
+        [_.color]: colorValues.lineColor,
+        [_.fontcolor]: colorValues.labelColor
       })
     }
 

--- a/packages/layouts/src/graphviz/__fixtures__/model.ts
+++ b/packages/layouts/src/graphviz/__fixtures__/model.ts
@@ -218,6 +218,7 @@ export const indexView = {
   description: null,
   tags: null,
   links: null,
+  customColorDefinitions: {},
   rules: [
     {
       include: [
@@ -236,6 +237,7 @@ export const cloudView = {
   description: null,
   tags: null,
   links: null,
+  customColorDefinitions: {},
   viewOf: 'cloud' as Fqn,
   rules: [
     {
@@ -252,6 +254,7 @@ export const cloud3levels = {
   description: null,
   tags: null,
   links: null,
+  customColorDefinitions: {},
   rules: [
     {
       include: [
@@ -280,6 +283,7 @@ export const amazonView = {
   description: null,
   tags: null,
   links: null,
+  customColorDefinitions: {},
   rules: [
     {
       include: [
@@ -304,6 +308,7 @@ export const issue577View = (icon: string) => ({
   description: null,
   tags: null,
   links: null,
+  customColorDefinitions: {},
   viewOf: 'amazon' as Fqn,
   rules: [
     {

--- a/packages/layouts/src/graphviz/dot-labels.ts
+++ b/packages/layouts/src/graphviz/dot-labels.ts
@@ -3,7 +3,8 @@ import {
   type ComputedNode,
   DefaultRelationshipColor,
   defaultTheme as Theme,
-  ElementColors as Colors
+  ElementColors as Colors,
+  type ElementThemeColorValues
 } from '@likec4/core'
 import { isEmpty, isTruthy } from 'remeda'
 import wordWrap from 'word-wrap'
@@ -51,7 +52,7 @@ export function nodeIcon() {
   return `<TABLE FIXEDSIZE="TRUE" BGCOLOR="#112233" WIDTH="${IconSizePoints}" HEIGHT="${IconSizePoints}" BORDER="0" CELLPADDING="0" CELLSPACING="0"><TR><TD> </TD></TR></TABLE>`
 }
 
-export function nodeLabel(node: ComputedNode) {
+export function nodeLabel(node: ComputedNode, colorValues: ElementThemeColorValues) {
   const hasIcon = isTruthy(node.icon)
   const lines = [
     wrapWithFont({
@@ -66,7 +67,7 @@ export function nodeLabel(node: ComputedNode) {
         text: node.technology,
         fontsize: 12,
         maxchars: hasIcon ? 35 : 45,
-        color: Colors[node.color].loContrast
+        color: colorValues.loContrast
       })
     )
   }
@@ -76,7 +77,7 @@ export function nodeLabel(node: ComputedNode) {
         text: node.description,
         fontsize: 14,
         maxchars: hasIcon ? 35 : 45,
-        color: Colors[node.color].loContrast
+        color: colorValues.loContrast
       })
     )
   }

--- a/packages/layouts/src/graphviz/wasm/__snapshots__/GraphvizWasmAdapter.spec.ts.snap
+++ b/packages/layouts/src/graphviz/wasm/__snapshots__/GraphvizWasmAdapter.spec.ts.snap
@@ -10,6 +10,7 @@ exports[`GraphvizWasmAdapter: > computedAmazonView 1`] = `
     "x": 0,
     "y": 0,
   },
+  "customColorDefinitions": {},
   "description": null,
   "edges": [
     {
@@ -200,6 +201,7 @@ exports[`GraphvizWasmAdapter: > computedCloud3levels 1`] = `
     "x": 0,
     "y": 0,
   },
+  "customColorDefinitions": {},
   "description": null,
   "edges": [
     {
@@ -758,6 +760,7 @@ exports[`GraphvizWasmAdapter: > computedCloudView 1`] = `
     "x": 0,
     "y": 0,
   },
+  "customColorDefinitions": {},
   "description": null,
   "edges": [
     {
@@ -1122,6 +1125,7 @@ exports[`GraphvizWasmAdapter: > computedIndexView 1`] = `
     "x": 0,
     "y": 0,
   },
+  "customColorDefinitions": {},
   "description": null,
   "edges": [
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -993,13 +993,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ctrl/tinycolor@npm:^3.6.1":
-  version: 3.6.1
-  resolution: "@ctrl/tinycolor@npm:3.6.1"
-  checksum: 10c0/444d81612cd8c5c802a3d1253df83d5f77d3db87f351861655683a4743990e6b38976bf2e4129591c5a258607b63574b3c7bed702cf6a0eb7912222edf4570e9
-  languageName: node
-  linkType: hard
-
 "@ctrl/tinycolor@npm:^4.0.4":
   version: 4.1.0
   resolution: "@ctrl/tinycolor@npm:4.1.0"
@@ -2201,6 +2194,9 @@ __metadata:
   resolution: "@likec4/core@workspace:packages/core"
   dependencies:
     "@likec4/tsconfig": "workspace:*"
+    "@mantine/colors-generator": "npm:^7.12.2"
+    "@total-typescript/ts-reset": "npm:^0.5.1"
+    chroma-js: "npm:^3.0.0"
     execa: "npm:^9.3.1"
     remeda: "npm:^2.11.0"
     type-fest: "npm:^4.21.0"
@@ -2214,7 +2210,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@likec4/diagram@workspace:packages/diagram"
   dependencies:
-    "@ant-design/colors": "npm:^7.1.0"
     "@likec4/core": "workspace:*"
     "@likec4/tsconfig": "workspace:*"
     "@lume/kiwi": "npm:^0.4.3"
@@ -2508,6 +2503,15 @@ __metadata:
   version: 0.4.3
   resolution: "@lume/kiwi@npm:0.4.3"
   checksum: 10c0/a8a54e71f4a6a90000db5b195b5d67e3557e816b5a35e3a75e05d34065a9c2143ed70fee5af32ad64540a57667ee286b20b79e6022405d263efdfbc141da6679
+  languageName: node
+  linkType: hard
+
+"@mantine/colors-generator@npm:^7.12.2":
+  version: 7.12.2
+  resolution: "@mantine/colors-generator@npm:7.12.2"
+  peerDependencies:
+    chroma-js: ^2.4.2
+  checksum: 10c0/4c3ed0e72f568b496ec25836214c0154b8436e08e51663ac5191b95767da3983711e17d5ed740adc95d7350aa2fba7ef2e9dd365cba46124eb55314c033f25d5
   languageName: node
   linkType: hard
 
@@ -5339,6 +5343,13 @@ __metadata:
   version: 2.0.0
   resolution: "chownr@npm:2.0.0"
   checksum: 10c0/594754e1303672171cc04e50f6c398ae16128eb134a88f801bf5354fd96f205320f23536a045d9abd8b51024a149696e51231565891d4efdab8846021ecf88e6
+  languageName: node
+  linkType: hard
+
+"chroma-js@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "chroma-js@npm:3.0.0"
+  checksum: 10c0/b7aade3f6e20d5f1f3e07a890fbdc6e6390663affeb0071330d0325368915612b6133124aeb0b29b56d6bcdff489b0223deba8cc86a656bb601c6bc3f06e2c7c
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -993,6 +993,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ctrl/tinycolor@npm:^3.6.1":
+  version: 3.6.1
+  resolution: "@ctrl/tinycolor@npm:3.6.1"
+  checksum: 10c0/444d81612cd8c5c802a3d1253df83d5f77d3db87f351861655683a4743990e6b38976bf2e4129591c5a258607b63574b3c7bed702cf6a0eb7912222edf4570e9
+  languageName: node
+  linkType: hard
+
 "@ctrl/tinycolor@npm:^4.0.4":
   version: 4.1.0
   resolution: "@ctrl/tinycolor@npm:4.1.0"
@@ -2207,6 +2214,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@likec4/diagram@workspace:packages/diagram"
   dependencies:
+    "@ant-design/colors": "npm:^7.1.0"
     "@likec4/core": "workspace:*"
     "@likec4/tsconfig": "workspace:*"
     "@lume/kiwi": "npm:^0.4.3"


### PR DESCRIPTION
Custom colors could be defined in spec with given name and hex value.
The defined color then could be used as one of a theme color.

Stylesheet with cssvars for custom colors is rendered in diagram component. Thees styles uses same ':where[data-likec4-color=<color-name>]' selector as theme styles.
Also tried [alternative](https://github.com/pavelpykhtin/likec4/tree/feat/custom-colors) with inline definition (use hex value instead of color name) but there are some problems with passing overridden cssvars into m.div component. Moreover, such implementation seems to be pretty messy.