### PR TITLE
fix: derived connection from multiple relationships with same endpoints always picks the last relationship

### DIFF
--- a/packages/core/src/types/_common.ts
+++ b/packages/core/src/types/_common.ts
@@ -2,6 +2,8 @@ import type { Tagged } from 'type-fest'
 
 export type NonEmptyArray<T> = [T, ...T[]]
 
+export type NonEmptyReadonlyArray<T> = readonly [T, ...T[]]
+
 export type IconUrl = Tagged<string, 'IconUrl'>
 
 export type CustomColor = string

--- a/packages/language-server/src/model-graph/compute-view/__test__/__snapshots__/legacy.spec.ts.snap
+++ b/packages/language-server/src/model-graph/compute-view/__test__/__snapshots__/legacy.spec.ts.snap
@@ -53,8 +53,8 @@ exports[`compute-element-view > view of cloud 1`] = `
       "source": "cloud.backend",
       "tags": [
         "aws",
-        "storage",
         "legacy",
+        "storage",
       ],
       "target": "amazon",
     },

--- a/packages/language-server/src/model-graph/compute-view/__test__/custom-relation-expr.spec.ts
+++ b/packages/language-server/src/model-graph/compute-view/__test__/custom-relation-expr.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { $customRelation, $include, $style, computeView } from './fixture'
+import { $customRelation, $include, computeView } from './fixture'
 
 describe('custom-relation-expr', () => {
   it('include edge and apply props', () => {
@@ -152,8 +152,8 @@ describe('custom-relation-expr', () => {
         "source": "cloud.backend",
         "tags": [
           "aws",
-          "storage",
           "legacy",
+          "storage",
         ],
         "target": "amazon.s3",
       }

--- a/packages/language-server/src/model-graph/utils/uniqueTags.test.ts
+++ b/packages/language-server/src/model-graph/utils/uniqueTags.test.ts
@@ -1,0 +1,42 @@
+import { compareNatural } from '@likec4/core'
+import { describe, expect, it } from 'vitest'
+import { uniqueTags } from './uniqueTags'
+
+describe('uniqueTags function', () => {
+  it('returns unique tags from an array of elements', () => {
+    const input = [
+      { tags: ['tag1', 'tag2', 'tag3'] },
+      { tags: ['tag2', 'tag3', 'tag4'] },
+      { tags: ['tag3', 'tag4', 'tag5'] }
+    ] as const
+    const result = uniqueTags(input)
+    expect(result).toEqual(['tag1', 'tag2', 'tag3', 'tag4', 'tag5'])
+  })
+
+  it('should return unique tags naturally sorted', () => {
+    const input = [
+      { tags: ['tag1', 'tag20', 'tag30'] },
+      { tags: ['tag2', 'tag23', 'tag34'] },
+      { tags: ['tag3'] }
+    ] as const
+    const result = uniqueTags(input)
+    expect(result).toEqual([
+      'tag1',
+      'tag2',
+      'tag3',
+      'tag20',
+      'tag23',
+      'tag30',
+      'tag34'
+    ].sort(compareNatural))
+  })
+
+  it('returns null if the tags array is null', () => {
+    const input = [
+      { tags: null },
+      {}
+    ]
+    const result = uniqueTags(input)
+    expect(result).toBeNull()
+  })
+})

--- a/packages/language-server/src/model-graph/utils/uniqueTags.ts
+++ b/packages/language-server/src/model-graph/utils/uniqueTags.ts
@@ -1,0 +1,19 @@
+import { compareNatural, hasAtLeast, type NonEmptyReadonlyArray, type Tag } from '@likec4/core'
+import { flatMap, pipe, sort, unique } from 'remeda'
+import type { LiteralUnion } from 'type-fest'
+
+/**
+ * Extracts unique tags from an array of elements.
+ * and sort in natural order; returns null if no tags are present.
+ */
+export function uniqueTags<T extends { tags?: NonEmptyReadonlyArray<LiteralUnion<Tag, string>> | null }>(
+  elements: ReadonlyArray<T>
+) {
+  const tags = pipe(
+    elements,
+    flatMap(e => e.tags ?? []),
+    unique(),
+    sort(compareNatural)
+  )
+  return hasAtLeast(tags, 1) ? tags : null
+}


### PR DESCRIPTION
Fixes #990 