### PR TITLE
Fixed space being inserted into relation's source

### DIFF
--- a/packages/language-server/src/formatting/LikeC4Formatter.spec.ts
+++ b/packages/language-server/src/formatting/LikeC4Formatter.spec.ts
@@ -131,13 +131,20 @@ model {
     .http    system2
   }
   component system2
+  system2   ->   system1
   system2   -[   http   ]->   system1
-  system2  .http   system1   'title'  'http'    #tag1
+
+  system2.module1   ->     system1.module1
+  system2.module1.lib1   ->system1.module1.lib1
+  system2.module1   -[   http   ]->   system1.module1
+  system2.module1  .http   system1.module1   'title'  'http'    #tag1  
 }
 views {
   view index {
     include system1<->*
     include *->, ->*
+    include system1.module1<->*
+    include ->    system1.module1   ->
   }
 }`
         )
@@ -153,13 +160,20 @@ views {
             .http system2
           }
           component system2
+          system2 -> system1
           system2 -[http]-> system1
-          system2 .http system1 'title' 'http' #tag1
+
+          system2.module1 -> system1.module1
+          system2.module1.lib1 -> system1.module1.lib1
+          system2.module1 -[http]-> system1.module1
+          system2.module1 .http system1.module1 'title' 'http' #tag1
         }
         views {
           view index {
             include system1 <-> *
             include * ->, -> *
+            include system1.module1 <-> *
+            include -> system1.module1 ->
           }
         }"
       `

--- a/packages/language-server/src/formatting/LikeC4Formatter.ts
+++ b/packages/language-server/src/formatting/LikeC4Formatter.ts
@@ -46,7 +46,9 @@ export class LikeC4Formatter extends AbstractFormatter {
 
   protected formatRelation(node: AstNode) {
     this.on(node, ast.isRelation, (n, f) => {
-      f.property('source').append(FormattingOptions.oneSpace)
+      const sourceNodes = n?.source?.$cstNode ? [n?.source?.$cstNode] : []
+
+      f.cst(sourceNodes).append(FormattingOptions.oneSpace)
       f.keywords(']->').prepend(FormattingOptions.noSpace)
       f.keywords('-[').append(FormattingOptions.noSpace)
 
@@ -73,7 +75,7 @@ export class LikeC4Formatter extends AbstractFormatter {
       ?.keywords('->').append(FormattingOptions.oneSpace)
 
     this.on(node, ast.isInOutRelationExpression)
-      ?.property('inout').append(FormattingOptions.oneSpace)
+      ?.keyword('->').prepend(FormattingOptions.oneSpace)
   }
 
   protected removeIndentFromTopLevelStatements(node: AstNode) {


### PR DESCRIPTION
The second part of a composite identifier was interpreted as a kind of relation. This turned
``` 
sys1.comp1 -> sys2
```
into
```
sys1 .comp1 -> sys2
```