### PR TITLE
Fix edge changes being reverted on mouse up (#1002)

### DIFF
--- a/packages/diagram/src/xyflow/edges/RelationshipEdge.tsx
+++ b/packages/diagram/src/xyflow/edges/RelationshipEdge.tsx
@@ -307,7 +307,12 @@ export const RelationshipEdge = /* @__PURE__ */ memo<EdgeProps<XYFlowEdge>>(func
     if (!domNode || e.pointerType !== 'mouse') {
       return
     }
+
     const { xyflow } = diagramStore.getState()
+
+    // Select edge before any changes
+    xyflow.setEdges((edges) => edges.map(x => ({ ...x, ...(x.id == id && { selected: true }) })))
+
     if (e.button === 2 && controlPoints.length > 1) {
       const newControlPoints = controlPoints.slice()
       newControlPoints.splice(index, 1)

--- a/packages/diagram/src/xyflow/edges/RelationshipEdge.tsx
+++ b/packages/diagram/src/xyflow/edges/RelationshipEdge.tsx
@@ -303,16 +303,13 @@ export const RelationshipEdge = /* @__PURE__ */ memo<EdgeProps<XYFlowEdge>>(func
   }
 
   const onControlPointerDown = (index: number, e: ReactPointerEvent<SVGCircleElement>) => {
-    const { domNode } = xyflowStore.getState()
+    const { domNode, addSelectedEdges } = xyflowStore.getState()
     if (!domNode || e.pointerType !== 'mouse') {
       return
     }
+    addSelectedEdges([id])
 
-    const { xyflow } = diagramStore.getState()
-
-    // Select edge before any changes
-    xyflow.setEdges((edges) => edges.map(x => ({ ...x, ...(x.id == id && { selected: true }) })))
-
+    const { xyflow} = diagramStore.getState()    
     if (e.button === 2 && controlPoints.length > 1) {
       const newControlPoints = controlPoints.slice()
       newControlPoints.splice(index, 1)


### PR DESCRIPTION
It seems that the problem described in #1002 (at least one) is caused by the xyflow state being reset to initial state on mouse up.
My guess is that xyflow state is overwritten by diagram state on edge selection, which is part of the xyflow component.

As a short term solution, I've added selection of the edge before any changes are made.

As a long term solution, it seems that some changes in diagram state management should be made. As far as I can understand, the actual cause of the problem is that there are two versions of the state: one is the current state of the xyflow component (used for rendering), the other is the previous state (stored in file? or in a some intermediate object?). Thus, those two versions are must be merged into one or the sync procedure must be improved. Unfortunately, I don't have deep enough understanding of the current implementation and xyflow library particularly to implement this. @davydkov , may be you have some ideas on this?