### PR TITLE
feat: style definition applicable to all views

### DIFF
--- a/apps/docs/src/content/docs/dsl/views.mdx
+++ b/apps/docs/src/content/docs/dsl/views.mdx
@@ -523,11 +523,46 @@ view apiApp of internetBankingSystem.apiApplication {
   // apply to elements not tagged
   style element.tag != #deprecated {
     opacity 20%
-  }  
+  }
 }
 ```
 
 Please note, that [overrides](#with-overrides) have higher priority.
+
+Styles can be also applied to all views
+
+```likec4
+views {
+  // apply to all elements in all views
+  style * {
+    color muted
+    opacity 10%
+  }
+
+  // apply in all views to elements with specific tag
+  style element.tag = #deprecated {
+    color muted
+  }
+
+  // apply in all views to elements not tagged
+  style element.tag != #deprecated {
+    opacity 20%
+  }
+
+  view apiApp of internetBankingSystem.apiApplication {
+    include *
+
+    // override global style
+    style element.tag = #deprecated {
+      color red
+    }
+  }
+
+  view storeConnector of internetBankingSystem.storeConnector {
+    include *
+  }
+}
+```
 
 ### Extend views
 

--- a/packages/core/src/types/model.ts
+++ b/packages/core/src/types/model.ts
@@ -1,7 +1,7 @@
 import type { UnwrapTagged } from 'type-fest'
 import type { Element, ElementKind, ElementKindSpecification, Fqn, Tag } from './element'
 import type { Relation, RelationID, RelationshipKindSpecification } from './relation'
-import type { ComputedView, DiagramView, LikeC4View, ViewID } from './view'
+import type { ComputedView, DiagramView, LikeC4View, ViewID, ViewRule } from './view'
 
 /**
  * Parsed elements, relations, and views.
@@ -15,6 +15,7 @@ export interface ParsedLikeC4Model {
   elements: Record<Fqn, Element>
   relations: Record<RelationID, Relation>
   views: Record<ViewID, LikeC4View>
+  global_rules?: ViewRule[]
 }
 
 /**

--- a/packages/language-server/src/__tests__/views.spec.ts
+++ b/packages/language-server/src/__tests__/views.spec.ts
@@ -233,6 +233,21 @@ describe.concurrent('views', () => {
       }
     }`
 
+  test('global ViewStyleRules - valid').valid`${model}
+    views {
+      style * {
+        color: secondary
+      }
+      view {
+        include *
+        exclude -> frontend
+      }
+      style backend, infra {
+        color: muted
+      }
+    }
+    `
+
   test('trailing comma in predicates').valid`${model}
     views {
       view {

--- a/packages/language-server/src/ast.ts
+++ b/packages/language-server/src/ast.ts
@@ -131,6 +131,13 @@ export const ViewOps = {
   }
 }
 
+export interface ParsedAstGlobalRule {
+  __: 'global_rule'
+  rules: c4.ViewRule[]
+}
+
+export type ParsedAstViewOrRule = ParsedAstView | ParsedAstGlobalRule
+
 export interface ParsedLink {
   title?: string
   url: string
@@ -164,6 +171,7 @@ export interface LikeC4DocumentProps {
   c4Elements?: ParsedAstElement[]
   c4Relations?: ParsedAstRelation[]
   c4Views?: ParsedAstView[]
+  c4GlobalRules?: c4.ViewRule[]
   // Fqn -> Element
   c4fqnIndex?: MultiMap<c4.Fqn, DocFqnIndexAstNodeDescription>
 }
@@ -190,7 +198,8 @@ export function cleanParsedModel(doc: LikeC4LangiumDocument) {
     },
     c4Elements: [],
     c4Relations: [],
-    c4Views: []
+    c4Views: [],
+    c4GlobalRules: []
   }
   return Object.assign(doc, props) as ParsedLikeC4LangiumDocument
 }
@@ -213,6 +222,7 @@ export function isParsedLikeC4LangiumDocument(
     && !!doc.c4Elements
     && !!doc.c4Relations
     && !!doc.c4Views
+    && !!doc.c4GlobalRules
     && !!doc.c4fqnIndex
   )
 }

--- a/packages/language-server/src/like-c4.langium
+++ b/packages/language-server/src/like-c4.langium
@@ -199,8 +199,9 @@ ModelViews:
   '}';
 
 type LikeC4View = ElementView | DynamicView;
-LikeC4ViewRule returns LikeC4View:
-  ElementView | DynamicView;
+type LikeC4ViewOrRule = LikeC4View | ViewRule;
+LikeC4ViewRule returns LikeC4ViewOrRule:
+  ElementView | DynamicView | ViewRule;
 
 ElementView:
   'view' name=Id? (

--- a/packages/language-server/src/lsp/CodeLensProvider.ts
+++ b/packages/language-server/src/lsp/CodeLensProvider.ts
@@ -1,7 +1,7 @@
 import { DocumentState, type LangiumDocument, type MaybePromise } from 'langium'
 import type { CodeLensProvider } from 'langium/lsp'
 import type { CancellationToken, CodeLens, CodeLensParams } from 'vscode-languageserver'
-import { isParsedLikeC4LangiumDocument, ViewOps } from '../ast'
+import { ast, isParsedLikeC4LangiumDocument, ViewOps } from '../ast'
 import { logger } from '../logger'
 import type { LikeC4Services } from '../module'
 
@@ -23,7 +23,7 @@ export class LikeC4CodeLensProvider implements CodeLensProvider {
     if (!isParsedLikeC4LangiumDocument(doc)) {
       return
     }
-    const views = doc.parseResult.value.views.flatMap(v => v.views)
+    const views = doc.parseResult.value.views.flatMap(v => v.views).filter(v => ast.isLikeC4View(v))
     return views.flatMap<CodeLens>(ast => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const viewId = ViewOps.readId(ast)

--- a/packages/language-server/src/lsp/DocumentSymbolProvider.ts
+++ b/packages/language-server/src/lsp/DocumentSymbolProvider.ts
@@ -168,7 +168,7 @@ export class LikeC4DocumentSymbolProvider implements DocumentSymbolProvider {
         name: astViews.name,
         range: cst.range,
         selectionRange: nameNode.range,
-        children: astViews.views.flatMap(e => this.getViewSymbol(e))
+        children: astViews.views.filter(e => ast.isLikeC4View(e)).flatMap(e => this.getViewSymbol(e))
       }
     ]
   }

--- a/packages/language-server/src/model-graph/compute-view/compute.ts
+++ b/packages/language-server/src/model-graph/compute-view/compute.ts
@@ -14,6 +14,7 @@ import type {
   RelationshipLineType,
   Tag,
   ViewID,
+  ViewRule,
   ViewRulePredicate
 } from '@likec4/core'
 import {
@@ -92,13 +93,14 @@ export class ComputeCtx {
   private implicits = new Set<Element>()
   private ctxEdges = [] as ComputeCtx.Edge[]
 
-  public static elementView(view: ElementView, graph: LikeC4ModelGraph) {
-    return new ComputeCtx(view, graph).compute()
+  public static elementView(view: ElementView, graph: LikeC4ModelGraph, global_rules: ViewRule[] = []) {
+    return new ComputeCtx(view, graph, global_rules).compute()
   }
 
   private constructor(
     protected view: ElementView,
-    protected graph: LikeC4ModelGraph
+    protected graph: LikeC4ModelGraph,
+    protected global_rules: ViewRule[],
   ) {}
 
   protected compute(): ComputedElementView {
@@ -157,11 +159,14 @@ export class ComputeCtx {
       rules,
       applyViewRuleStyles(
         rules,
-        // Build graph and apply postorder sort
-        sortNodes({
-          nodes: initialSort,
-          edges
-        })
+        applyViewRuleStyles(
+          this.global_rules,
+          // Build graph and apply postorder sort
+          sortNodes({
+            nodes: initialSort,
+            edges
+          })
+        )
       )
     )
     const sortedEdges = new Set([

--- a/packages/language-server/src/model-graph/compute-view/index.ts
+++ b/packages/language-server/src/model-graph/compute-view/index.ts
@@ -1,9 +1,9 @@
-import { type ComputedElementView, type ElementView } from '@likec4/core'
+import type { ComputedElementView, ElementView, ViewRule } from '@likec4/core'
 import type { LikeC4ModelGraph } from '../LikeC4ModelGraph'
 import { ComputeCtx } from './compute'
 
-export function computeElementView(view: ElementView, graph: LikeC4ModelGraph) {
-  return ComputeCtx.elementView(view, graph)
+export function computeElementView(view: ElementView, graph: LikeC4ModelGraph, global_rules?: ViewRule[]) {
+  return ComputeCtx.elementView(view, graph, global_rules)
 }
 
 type ComputeViewResult =
@@ -17,11 +17,11 @@ type ComputeViewResult =
     view: undefined
   }
 
-export function computeView(view: ElementView, graph: LikeC4ModelGraph): ComputeViewResult {
+export function computeView(view: ElementView, graph: LikeC4ModelGraph, global_rules?: ViewRule[]): ComputeViewResult {
   try {
     return {
       isSuccess: true,
-      view: computeElementView(view, graph)
+      view: computeElementView(view, graph, global_rules)
     }
   } catch (e) {
     return {

--- a/packages/language-server/src/model/fqn-index.ts
+++ b/packages/language-server/src/model/fqn-index.ts
@@ -33,6 +33,7 @@ export class FqnIndex {
             delete doc.c4Specification
             delete doc.c4Relations
             delete doc.c4Views
+            delete doc.c4GlobalRules
             try {
               computeDocumentFqn(doc, services)
             } catch (e) {

--- a/packages/language-server/src/model/model-builder.ts
+++ b/packages/language-server/src/model/model-builder.ts
@@ -279,6 +279,15 @@ function buildModel(services: LikeC4Services, docs: ParsedLikeC4LangiumDocument[
     resolveRulesExtendedViews
   )
 
+  function toC4GlobalRule(doc: LangiumDocument) {
+    return (parsedAstView: c4.ViewRule): c4.ViewRule => {
+      return parsedAstView
+    }
+  }
+
+  const parsedGlobalRules = docs.flatMap(d => map(d.c4GlobalRules, toC4GlobalRule(d)))
+  const global_rules = parsedGlobalRules
+
   return {
     specification: {
       tags: Array.from(c4Specification.tags),
@@ -287,7 +296,8 @@ function buildModel(services: LikeC4Services, docs: ParsedLikeC4LangiumDocument[
     },
     elements,
     relations,
-    views
+    views,
+    global_rules
   }
 }
 
@@ -377,7 +387,8 @@ export class LikeC4ModelBuilder {
 
       const allViews = [] as c4.ComputedView[]
       for (const view of values(model.views)) {
-        const result = isElementView(view) ? computeView(view, index) : computeDynamicView(view, index)
+        const global_rules = model?.global_rules
+        const result = isElementView(view) ? computeView(view, index, global_rules) : computeDynamicView(view, index)
         if (!result.isSuccess) {
           logWarnError(result.error)
           continue
@@ -441,7 +452,8 @@ export class LikeC4ModelBuilder {
           return null
         }
         const index = new LikeC4ModelGraph(model)
-        const result = isElementView(view) ? computeView(view, index) : computeDynamicView(view, index)
+        const global_rules = model?.global_rules
+        const result = isElementView(view) ? computeView(view, index, global_rules) : computeDynamicView(view, index)
         if (!result.isSuccess) {
           logError(result.error)
           return null

--- a/packages/language-server/src/model/model-parser.ts
+++ b/packages/language-server/src/model/model-parser.ts
@@ -283,15 +283,21 @@ export class LikeC4ModelParser {
   }
 
   private parseViews(doc: ParsedLikeC4LangiumDocument, isValid: IsValidFn) {
-    const views = doc.parseResult.value.views.flatMap(v => isValid(v) ? v.views : [])
-    for (const view of views) {
+    const views_and_rules = doc.parseResult.value.views.flatMap(v => isValid(v) ? v.views : [])
+    for (const view_or_rule of views_and_rules) {
       try {
-        if (!isValid(view)) {
+        if (!isValid(view_or_rule)) {
           continue
         }
-        doc.c4Views.push(
-          ast.isElementView(view) ? this.parseElementView(view, isValid) : this.parseDynamicElementView(view, isValid)
-        )
+        if (ast.isLikeC4View(view_or_rule)) {
+          const view = view_or_rule
+          doc.c4Views.push(
+            ast.isElementView(view) ? this.parseElementView(view, isValid) : this.parseDynamicElementView(view, isValid)
+          )
+        } else if (ast.isViewRule(view_or_rule)) {
+          const rule = view_or_rule
+          doc.c4GlobalRules.push(this.parseViewRule(rule, isValid))
+        }
       } catch (e) {
         logWarnError(e)
       }

--- a/packages/language-server/src/references/scope-computation.ts
+++ b/packages/language-server/src/references/scope-computation.ts
@@ -47,7 +47,7 @@ export class LikeC4ScopeComputation extends DefaultScopeComputation {
     if (isNullish(views) || views.length === 0) {
       return
     }
-    for (const viewAst of views.flatMap(v => v.views)) {
+    for (const viewAst of views.flatMap(v => v.views).filter(v => ast.isLikeC4View(v))) {
       try {
         if (isTruthy(viewAst.name)) {
           docExports.push(this.descriptions.createDescription(viewAst, viewAst.name, document))


### PR DESCRIPTION
Add a feature to define a style applicable to all views. It is useful to define in a unified way how e.g. elements tagged as #deprecated are styled in all the diagrams.

Please note, I'm an embedded developer and I was learning about TypeScript on the go. I'm happy to fix any issues in my code and broaden my higher-level language horizons :)

This is intended to fix https://github.com/likec4/likec4/discussions/961