### PR TITLE
Fix long node names overflow in the node options panel

### DIFF
--- a/packages/diagram/src/ui/options/NodeOptions.tsx
+++ b/packages/diagram/src/ui/options/NodeOptions.tsx
@@ -92,7 +92,7 @@ export const NodeOptions = memo<{ selectedNodeIds: string[] }>(({ selectedNodeId
   return (
     <Stack gap={'xs'}>
       <Group wrap="nowrap" align="flex-start">
-        <Box flex={1}>
+        <Box flex={1} miw={0}>
           <Text fz={rem(9)} fw={'500'} c={'dimmed'}>
             ELEMENT{rest.length > 0 ? 'S' : ``}
           </Text>


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/471def09-e1b9-4364-af9b-853e76ff4096)

After:
![image](https://github.com/user-attachments/assets/25470b0b-af34-4517-996d-1bd9d8fd165f)
