### PR TITLE
feat: global rules

### DIFF
--- a/apps/docs/src/content/docs/dsl/views.mdx
+++ b/apps/docs/src/content/docs/dsl/views.mdx
@@ -469,6 +469,35 @@ Together with [extend views](#extend-views) you may define a "baseline" view (in
 
 :::
 
+#### Global predicates
+
+Predicates can be defined in global groups.
+Eache global group can be applied to multiple views.
+When a group is applied to a view, all predicates from the group are applied.
+
+```likec4
+global {
+  predicateGroup new_cloud_service {
+    include cloud.*
+      where kind is microservice
+    exclude *
+      where tag is #deprecated
+  }
+}
+
+views {
+  view of newServices {
+    include *
+    global predicate new_cloud_service
+  }
+
+  view of newBackendServices {
+    include *
+    global predicate new_cloud_service
+  }
+}
+```
+
 ### Auto-layout
 
 ```likec4

--- a/apps/docs/src/content/docs/dsl/views.mdx
+++ b/apps/docs/src/content/docs/dsl/views.mdx
@@ -523,11 +523,57 @@ view apiApp of internetBankingSystem.apiApplication {
   // apply to elements not tagged
   style element.tag != #deprecated {
     opacity 20%
-  }  
+  }
 }
 ```
 
 Please note, that [overrides](#with-overrides) have higher priority.
+
+#### Global style predicates
+
+Style predicates can be defined globally and applied to multiple views.
+
+```likec4
+global {
+  // apply to all elements
+  style all_elements * {
+    color muted
+    opacity 10%
+  }
+
+  // apply only to these elements
+  style applications singlePageApplication, mobileApp {
+    color secondary
+  }
+
+  // apply only to elements with specific tag
+  style deprecated element.tag = #deprecated {
+    color muted
+  }
+}
+
+views {
+  view apiApp of internetBankingSystem.apiApplication {
+
+    include *
+
+    global style all_elements
+
+    global style applications
+
+    // apply only to nested of apiApplication
+    style apiApplication.* {
+      color primary
+    }
+
+    global style deprecated
+
+    style element.tag != #deprecated {
+      opacity 20%
+    }
+  }
+}
+```
 
 ### Extend views
 

--- a/apps/docs/src/content/docs/dsl/views.mdx
+++ b/apps/docs/src/content/docs/dsl/views.mdx
@@ -529,6 +529,28 @@ view apiApp of internetBankingSystem.apiApplication {
 
 Please note, that [overrides](#with-overrides) have higher priority.
 
+#### Local style predicates
+
+Style predicates can be defined for a `views` group.
+
+```likec4
+views {
+  // apply to all elements in all views in this views block
+  style * {
+    color muted
+    opacity 10%
+  }
+
+  view apiApp of internetBankingSystem.apiApplication {
+    include *
+  }
+
+  view mobileApp of internetBankingSystem.mobileApplication {
+    include *
+  }
+}
+```
+
 #### Global style predicates
 
 Style predicates can be defined globally and applied to multiple views.
@@ -571,6 +593,35 @@ views {
     style element.tag != #deprecated {
       opacity 20%
     }
+  }
+}
+```
+
+##### Global style predicates as local styles
+
+Global style predicates can be used as local styles:
+
+```likec4
+global {
+  // apply only to elements with specific tag
+  style deprecated element.tag = #deprecated {
+    color muted
+  }
+
+  // apply to all elements
+  style all_elements * {
+    color muted
+    opacity 10%
+  }
+}
+
+views {
+  global style deprecated
+
+  view apiApp of internetBankingSystem.apiApplication {
+    include *
+
+    global style all_elements
   }
 }
 ```
@@ -622,6 +673,45 @@ views {
 
     style element.tag != #deprecated {
       opacity 20%
+    }
+  }
+}
+```
+
+##### Global style groups as local styles
+
+Global style groups can be used as local styles:
+
+```likec4
+global {
+  styleGroup common_styles {
+    style all_elements * {
+      color amber
+    }
+
+    style element.tag = #deprecated {
+      color muted
+    }
+
+    style element.tag != #undefined {
+      opacity 50%
+    }
+  }
+}
+
+views {
+  global style common_styles
+
+  view mobileApp of internetBankingSystem.mobileApplication {
+    include *
+  }
+
+  view apiApp of internetBankingSystem.apiApplication {
+    include *
+
+    // view-specific style predicates
+    style apiApplication.* {
+      color primary
     }
   }
 }

--- a/apps/docs/src/content/docs/dsl/views.mdx
+++ b/apps/docs/src/content/docs/dsl/views.mdx
@@ -575,6 +575,58 @@ views {
 }
 ```
 
+#### Global style groups
+
+Global style predicates can be grouped.
+When a group is applied to a view, all predicates from the group are applied.
+A group can be applied to multiple views
+
+```likec4
+global {
+  styleGroup common_styles {
+    // apply to all elements
+    style all_elements * {
+      color muted
+      opacity 10%
+    }
+
+    // apply only to these elements
+    style singlePageApplication, mobileApp {
+      color secondary
+    }
+
+    // apply only to elements with specific tag
+    style element.tag = #deprecated {
+      color muted
+    }
+  }
+}
+
+views {
+  view mobileApp of internetBankingSystem.mobileApplication {
+    include *
+
+    global style common_styles
+  }
+
+  view apiApp of internetBankingSystem.apiApplication {
+
+    include *
+
+    global style common_styles
+
+    // view-specific style predicates
+    style apiApplication.* {
+      color primary
+    }
+
+    style element.tag != #deprecated {
+      opacity 20%
+    }
+  }
+}
+```
+
 ### Extend views
 
 Views can be extended to avoid duplication, to create a "baseline" or, for example, "slides" for a presentation:

--- a/packages/core/src/types/view.ts
+++ b/packages/core/src/types/view.ts
@@ -10,6 +10,8 @@ import type { ElementNotation } from './view-notation'
 // Full-qualified-name
 export type ViewID = Tagged<string, 'ViewID'>
 
+export type GlobalStyleID = Tagged<string, 'GlobalStyleID'>
+
 export type ViewRulePredicate =
   | {
     include: Expression[]

--- a/packages/language-server/src/ast.ts
+++ b/packages/language-server/src/ast.ts
@@ -226,6 +226,8 @@ function validatableAstNodeGuards<const Predicates extends Guard<AstNode>[]>(
   return (n: AstNode): n is Guarded<Predicates[number]> => predicates.some(p => p(n))
 }
 const isValidatableAstNode = validatableAstNodeGuards([
+  ast.isGlobalRules,
+  ast.isGlobalStyle,
   ast.isDynamicViewPredicateIterator,
   ast.isElementPredicateWith,
   ast.isRelationPredicateWith,

--- a/packages/language-server/src/like-c4.langium
+++ b/packages/language-server/src/like-c4.langium
@@ -442,7 +442,7 @@ ViewRuleStyle:
   '}';
 
 ViewRuleGlobalStyle:
-  'global' 'style' style=[GlobalStyle];
+  'global' 'style' style=[GlobalStyleId];
 
 ViewRuleAutoLayout:
   'autoLayout' direction=ViewLayoutDirection;
@@ -487,18 +487,26 @@ GlobalRules:
   name='global' '{'
     (
       styles+=GlobalStyle*
-      //style_groups
+      style_groups+=GlobalStyleGroup*
       //predicates
       //predicate_groups
     )*
   '}';
 
+GlobalStyleId:
+  name=IdTerminal;
+
 GlobalStyle:
-  'style' name=IdTerminal target=ElementExpressionsIterator '{'
+  'style' id=GlobalStyleId target=ElementExpressionsIterator '{'
     props+=(
       StyleProperty |
       NotationProperty
     )*
+  '}';
+
+GlobalStyleGroup:
+  'styleGroup' id=GlobalStyleId '{'
+    styles+=ViewRuleStyle*
   '}';
 
 // Common properties -------------------------------------

--- a/packages/language-server/src/like-c4.langium
+++ b/packages/language-server/src/like-c4.langium
@@ -270,6 +270,7 @@ ViewRule:
   ViewRulePredicate |
   ViewRuleStyle |
   ViewRuleGlobalStyle |
+  ViewRuleGlobalPredicate |
   ViewRuleAutoLayout
 ;
 
@@ -277,6 +278,7 @@ DynamicViewRule:
   DynamicViewIncludePredicate |
   ViewRuleStyle |
   ViewRuleGlobalStyle |
+  DynamicViewRuleGlobalPredicate |
   ViewRuleAutoLayout
 ;
 
@@ -447,6 +449,12 @@ ViewRuleStyle:
 ViewRuleGlobalStyle:
   'global' 'style' style=[GlobalStyleId];
 
+ViewRuleGlobalPredicate:
+  'global' 'predicate' predicate=[GlobalPredicateGroup];
+
+DynamicViewRuleGlobalPredicate:
+  'global' 'predicate' predicate=[GlobalDynamicPredicateGroup];
+
 ViewRuleAutoLayout:
   'autoLayout' direction=ViewLayoutDirection;
 
@@ -492,7 +500,8 @@ GlobalRules:
       styles+=GlobalStyle*
       style_groups+=GlobalStyleGroup*
       //predicates
-      //predicate_groups
+      predicate_groups+=GlobalPredicateGroup*
+      dynamic_predicate_groups+=GlobalDynamicPredicateGroup*
     )*
   '}';
 
@@ -510,6 +519,16 @@ GlobalStyle:
 GlobalStyleGroup:
   'styleGroup' id=GlobalStyleId '{'
     styles+=ViewRuleStyle*
+  '}';
+
+GlobalPredicateGroup:
+  'predicateGroup' name=IdTerminal '{'
+    predicates+=ViewRulePredicate*
+  '}';
+
+GlobalDynamicPredicateGroup:
+  'dynamicPredicateGroup' name=IdTerminal '{'
+    predicates+=DynamicViewRule*
   '}';
 
 // Common properties -------------------------------------

--- a/packages/language-server/src/like-c4.langium
+++ b/packages/language-server/src/like-c4.langium
@@ -5,6 +5,7 @@ entry LikeC4Grammar:
     specifications+=SpecificationRule |
     models+=Model  |
     views+=ModelViews |
+    global_rules+=GlobalRules |
     likec4lib+=LikeC4Lib
   )*
 ;
@@ -265,12 +266,14 @@ ViewLayoutDirection returns string:
 ViewRule:
   ViewRulePredicate |
   ViewRuleStyle |
+  ViewRuleGlobalStyle |
   ViewRuleAutoLayout
 ;
 
 DynamicViewRule:
   DynamicViewIncludePredicate |
   ViewRuleStyle |
+  ViewRuleGlobalStyle |
   ViewRuleAutoLayout
 ;
 
@@ -438,6 +441,9 @@ ViewRuleStyle:
     )*
   '}';
 
+ViewRuleGlobalStyle:
+  'global' 'style' style=[GlobalStyle];
+
 ViewRuleAutoLayout:
   'autoLayout' direction=ViewLayoutDirection;
 
@@ -474,6 +480,26 @@ NavigateToProperty:
 
 RelationNavigateToProperty:
   key='navigateTo' value=DynamicViewRef;
+
+// Global -------------------------------------
+
+GlobalRules:
+  name='global' '{'
+    (
+      styles+=GlobalStyle*
+      //style_groups
+      //predicates
+      //predicate_groups
+    )*
+  '}';
+
+GlobalStyle:
+  'style' name=IdTerminal target=ElementExpressionsIterator '{'
+    props+=(
+      StyleProperty |
+      NotationProperty
+    )*
+  '}';
 
 // Common properties -------------------------------------
 

--- a/packages/language-server/src/like-c4.langium
+++ b/packages/language-server/src/like-c4.langium
@@ -195,8 +195,11 @@ MetadataAttribute:
 // Views -------------------------------------
 
 ModelViews:
-  name='views' '{'
-    views+=LikeC4ViewRule*
+  name='views' '{' (
+      views+=LikeC4ViewRule |
+      styles+=ViewRuleStyle |
+      global_styles+=ViewRuleGlobalStyle
+    )*
   '}';
 
 type LikeC4View = ElementView | DynamicView;

--- a/packages/language-server/src/lsp/CompletionProvider.spec.ts
+++ b/packages/language-server/src/lsp/CompletionProvider.spec.ts
@@ -34,6 +34,7 @@ describe('LikeC4CompletionProvider', () => {
         'specification',
         'model',
         'views',
+        'global',
         'likec4lib'
       ]
     })
@@ -356,6 +357,7 @@ describe('LikeC4CompletionProvider', () => {
         'include',
         'exclude',
         'style',
+        'global',
         'autoLayout'
       ],
       disposeAfterCheck: true
@@ -464,6 +466,7 @@ describe('LikeC4CompletionProvider', () => {
         'include',
         'exclude',
         'style',
+        'global',
         'autoLayout'
       ],
       disposeAfterCheck: true
@@ -525,6 +528,7 @@ describe('LikeC4CompletionProvider', () => {
         'include',
         'exclude',
         'style',
+        'global',
         'autoLayout'
       ],
       disposeAfterCheck: true

--- a/packages/language-server/src/model/model-builder.spec.ts
+++ b/packages/language-server/src/model/model-builder.spec.ts
@@ -1577,4 +1577,204 @@ describe.concurrent('LikeC4ModelBuilder', () => {
     //       groups do not overwrite applied styles
     expect(indexView.nodes.find(n => n.id === 'sys1')?.color).toBe('red')
   })
+
+  it('local styles are applied to all views', async ({ expect }) => {
+    const { validate, buildModel } = createTestServices()
+    const { diagnostics } = await validate(`
+      specification {
+        element component
+      }
+      model {
+        component sys1
+        component sys2
+        sys1 -> sys2
+      }
+      views {
+        view index {
+          include sys1
+        }
+
+        view sys2 {
+          include sys2
+        }
+
+        style * {
+          color green
+        }
+      }
+    `)
+    expect(diagnostics.length).toBe(0)
+    const model = await buildModel()
+    const indexView = model?.views['index' as ViewID]!
+    expect(indexView).toBeDefined()
+    expect(indexView.nodes.find(n => n.id === 'sys1')?.color).toBe('green')
+
+    const sys2View = model?.views['sys2' as ViewID]!
+    expect(sys2View).toBeDefined()
+    expect(sys2View.nodes.find(n => n.id === 'sys2')?.color).toBe('green')
+  })
+
+  it('local styles are overwritten by internal view styles', async ({ expect }) => {
+    const { validate, buildModel } = createTestServices()
+    const { diagnostics } = await validate(`
+      specification {
+        element component
+      }
+      model {
+        component sys1
+        component sys2
+        sys1 -> sys2
+      }
+      views {
+        view index {
+          include sys1
+
+          style * {
+            color red
+          }
+        }
+
+        view sys2 {
+          include sys2
+        }
+
+        style * {
+          color green
+        }
+      }
+    `)
+    expect(diagnostics.length).toBe(0)
+    const model = await buildModel()
+    const indexView = model?.views['index' as ViewID]!
+    expect(indexView).toBeDefined()
+    expect(indexView.nodes.find(n => n.id === 'sys1')?.color).toBe('red')
+
+    const sys2View = model?.views['sys2' as ViewID]!
+    expect(sys2View).toBeDefined()
+    expect(sys2View.nodes.find(n => n.id === 'sys2')?.color).toBe('green')
+  })
+
+  it('local styles can apply global styles', async ({ expect }) => {
+    const { validate, buildModel } = createTestServices()
+    const { diagnostics } = await validate(`
+      specification {
+        element component
+      }
+      model {
+        component sys1
+        component sys2
+        sys1 -> sys2
+      }
+      views {
+        view index {
+          include sys1
+        }
+
+        view sys2 {
+          include sys2
+        }
+      
+        global style global_style_name
+      }
+      global {
+        style global_style_name * {
+          color amber
+        }
+      }
+    `)
+    expect(diagnostics.length).toBe(0)
+    const model = await buildModel()
+    const indexView = model?.views['index' as ViewID]!
+    expect(indexView).toBeDefined()
+    expect(indexView.nodes.find(n => n.id === 'sys1')?.color).toBe('amber')
+
+    const sys2View = model?.views['sys2' as ViewID]!
+    expect(sys2View).toBeDefined()
+    expect(sys2View.nodes.find(n => n.id === 'sys2')?.color).toBe('amber')
+  })
+
+  it('local styles can apply global style groups', async ({ expect }) => {
+    const { validate, buildModel } = createTestServices()
+    const { diagnostics } = await validate(`
+      specification {
+        element component
+      }
+      model {
+        component sys1
+        component sys2
+        sys1 -> sys2
+      }
+      views {
+        view index {
+          include sys1
+        }
+
+        view sys2 {
+          include sys2
+        }
+      
+        global style global_style_group_name
+      }
+      global {
+        styleGroup global_style_group_name {
+          style * {
+            color amber
+          }
+        }
+      }
+    `)
+    expect(diagnostics.length).toBe(0)
+    const model = await buildModel()
+    const indexView = model?.views['index' as ViewID]!
+    expect(indexView).toBeDefined()
+    expect(indexView.nodes.find(n => n.id === 'sys1')?.color).toBe('amber')
+
+    const sys2View = model?.views['sys2' as ViewID]!
+    expect(sys2View).toBeDefined()
+    expect(sys2View.nodes.find(n => n.id === 'sys2')?.color).toBe('amber')
+  })
+
+  it('local styles are applied in order', async ({ expect }) => {
+    const { validate, buildModel } = createTestServices()
+    const { diagnostics } = await validate(`
+      specification {
+        element component
+      }
+      model {
+        component sys1
+        component sys2
+        sys1 -> sys2
+      }
+      views {
+        view index {
+          include sys1
+        }
+
+        view sys2 {
+          include sys2
+        }
+      
+        global style global_style_red
+        global style global_style_green
+      }
+      global {
+        style global_style_green * {
+          color green
+        }
+
+        style global_style_red * {
+          color red
+        }
+      }
+    `)
+    expect(diagnostics.length).toBe(0)
+    const model = await buildModel()
+    const indexView = model?.views['index' as ViewID]!
+    expect(indexView).toBeDefined()
+    expect(indexView.nodes.find(n => n.id === 'sys1')?.color).toBe('green')
+
+    const sys2View = model?.views['sys2' as ViewID]!
+    expect(sys2View).toBeDefined()
+    expect(sys2View.nodes.find(n => n.id === 'sys2')?.color).toBe('green')
+  })
 })

--- a/packages/language-server/src/model/model-parser.ts
+++ b/packages/language-server/src/model/model-parser.ts
@@ -36,7 +36,7 @@ import { stringHash } from '../utils'
 import { deserializeFromComment, hasManualLayout } from '../view-utils/manual-layout'
 import type { FqnIndex } from './fqn-index'
 import { parseWhereClause } from './model-parser-where'
-import type { NotationProperty } from '../generated/ast'
+import { isGlobalStyle, isGlobalStyleGroup, type NotationProperty } from '../generated/ast'
 
 const { getDocument } = AstUtils
 
@@ -635,8 +635,17 @@ export class LikeC4ModelParser {
     if (globalRule === undefined) {
       return []
     }
-    const styleToApply = this.parseGlobalStyle(globalRule, isValid)
-    return [styleToApply]
+    const globalStyleNode = globalRule.$container
+    if (isGlobalStyle(globalStyleNode)) {
+      const styleToApply = this.parseGlobalStyle(globalStyleNode, isValid)
+      return [styleToApply]
+    }
+    if (isGlobalStyleGroup(globalStyleNode)) {
+      const stylesToApply = globalStyleNode.styles
+        .map(s => this.parseViewRuleStyle(s, isValid))
+      return stylesToApply
+    }
+    nonexhaustive(globalStyleNode)
   }
 
   private parseGlobalStyle(node: ast.GlobalStyle, isValid: IsValidFn): c4.ViewRuleStyle {

--- a/packages/language-server/src/model/model-parser.ts
+++ b/packages/language-server/src/model/model-parser.ts
@@ -36,6 +36,7 @@ import { stringHash } from '../utils'
 import { deserializeFromComment, hasManualLayout } from '../view-utils/manual-layout'
 import type { FqnIndex } from './fqn-index'
 import { parseWhereClause } from './model-parser-where'
+import type { NotationProperty } from '../generated/ast'
 
 const { getDocument } = AstUtils
 
@@ -591,28 +592,59 @@ export class LikeC4ModelParser {
     nonexhaustive(astNode)
   }
 
-  private parseViewRule(astRule: ast.ViewRule, isValid: IsValidFn): c4.ViewRule {
+  private parseViewRule(astRule: ast.ViewRule, isValid: IsValidFn): c4.ViewRule[] {
     if (ast.isViewRulePredicate(astRule)) {
-      return this.parseViewRulePredicate(astRule, isValid)
+      return [this.parseViewRulePredicate(astRule, isValid)]
     }
     if (ast.isViewRuleStyle(astRule)) {
-      const styleProps = toElementStyle(astRule.props.filter(ast.isStyleProperty), isValid)
-      const notation = removeIndent(astRule.props.find(ast.isNotationProperty)?.value)
-      const targets = this.parseElementExpressionsIterator(astRule.target)
-      return {
-        targets,
-        ...(notation && { notation }),
-        style: {
-          ...styleProps
-        }
-      }
+      return [this.parseViewRuleStyle(astRule, isValid)]
     }
     if (ast.isViewRuleAutoLayout(astRule)) {
-      return {
+      return [{
         autoLayout: toAutoLayout(astRule.direction)
-      }
+      }]
+    }
+    if (ast.isViewRuleGlobalStyle(astRule)) {
+      return this.parseViewRuleGlobalStyle(astRule, isValid)
     }
     nonexhaustive(astRule)
+  }
+
+  private parseViewRuleStyle(astRule: ast.ViewRuleStyle, isValid: IsValidFn): c4.ViewRuleStyle {
+    const styleProps = astRule.props.filter(ast.isStyleProperty)
+    const targets = astRule.target
+    const notation = astRule.props.find(ast.isNotationProperty)
+    return this.parseRuleStyle(styleProps, targets, isValid, notation)
+  }
+
+  private parseRuleStyle(styleProperties: ast.StyleProperty[], elementExpressionsIterator: ast.ElementExpressionsIterator, isValid: IsValidFn, notationProperty?: NotationProperty): c4.ViewRuleStyle {
+    const styleProps = toElementStyle(styleProperties, isValid)
+    const notation = removeIndent(notationProperty?.value)
+    const targets = this.parseElementExpressionsIterator(elementExpressionsIterator)
+    return {
+      targets,
+      ...(notation && { notation }),
+      style: {
+        ...styleProps
+      }
+    }
+  }
+
+  private parseViewRuleGlobalStyle(astRule: ast.ViewRuleGlobalStyle, isValid: IsValidFn): c4.ViewRuleStyle[] {
+    const globalRule = astRule.style.ref
+    if (globalRule === undefined) {
+      return []
+    }
+    const styleToApply = this.parseGlobalStyle(globalRule, isValid)
+    return [styleToApply]
+  }
+
+  private parseGlobalStyle(node: ast.GlobalStyle, isValid: IsValidFn): c4.ViewRuleStyle {
+    const styleProps = node.props.filter(ast.isStyleProperty)
+    const targets = node.target
+    const notation = node.props.find(ast.isNotationProperty)
+    let style = this.parseRuleStyle(styleProps, targets, isValid, notation)
+    return style
   }
 
   private parseViewManualLaout(node: ast.DynamicView | ast.ElementView): c4.ViewManualLayout | undefined {
@@ -809,55 +841,12 @@ export class LikeC4ModelParser {
       description,
       tags,
       links: isNonEmptyArray(links) ? links : null,
-      rules: body.rules.reduce((acc, n) => {
-        if (!isValid(n)) {
-          return acc
-        }
+      rules: body.rules.flatMap(n => {
         try {
-          if (ast.isDynamicViewIncludePredicate(n)) {
-            const include = [] as c4.ElementPredicateExpression[]
-            let iter: ast.DynamicViewPredicateIterator | undefined = n.predicates
-            while (iter) {
-              try {
-                if (isValid(iter.value as any)) {
-                  const c4expr = this.parseElementPredicate(iter.value, isValid)
-                  include.unshift(c4expr)
-                }
-              } catch (e) {
-                logWarnError(e)
-              }
-              iter = iter.prev
-            }
-            if (include.length > 0) {
-              acc.push({ include })
-            }
-            return acc
-          }
-          if (ast.isViewRuleStyle(n)) {
-            const styleProps = toElementStyle(n.props.filter(ast.isStyleProperty), isValid)
-            const notation = removeIndent(n.props.find(ast.isNotationProperty)?.value)
-            const targets = this.parseElementExpressionsIterator(n.target)
-            if (targets.length > 0) {
-              acc.push({
-                targets,
-                ...(notation && { notation }),
-                style: {
-                  ...styleProps
-                }
-              })
-            }
-            return acc
-          }
-          if (ast.isViewRuleAutoLayout(n)) {
-            acc.push({
-              autoLayout: toAutoLayout(n.direction)
-            })
-            return acc
-          }
-          nonexhaustive(n)
+          return isValid(n) ? this.parseDynamicViewRule(n, isValid) : []
         } catch (e) {
           logWarnError(e)
-          return acc
+          return []
         }
       }, [] as Array<c4.DynamicViewRule>),
       steps: body.steps.reduce((acc, n) => {
@@ -876,6 +865,37 @@ export class LikeC4ModelParser {
       }, [] as c4.DynamicViewStepOrParallel[]),
       ...(manualLayout && { manualLayout })
     }
+  }
+
+  private parseDynamicViewRule(astRule: ast.DynamicViewRule, isValid: IsValidFn): c4.DynamicViewRule[] {
+    if (ast.isDynamicViewIncludePredicate(astRule)) {
+      const include = [] as c4.ElementPredicateExpression[]
+      let iter: ast.DynamicViewPredicateIterator | undefined = astRule.predicates
+      while (iter) {
+        try {
+          if (isValid(iter.value as any)) {
+            const c4expr = this.parseElementPredicate(iter.value, isValid)
+            include.unshift(c4expr)
+          }
+        } catch (e) {
+          logWarnError(e)
+        }
+        iter = iter.prev
+      }
+      return [{ include }]
+    }
+    if (ast.isViewRuleStyle(astRule)) {
+      return [this.parseViewRuleStyle(astRule, isValid)]
+    }
+    if (ast.isViewRuleAutoLayout(astRule)) {
+      return [{
+        autoLayout: toAutoLayout(astRule.direction)
+      }]
+    }
+    if (ast.isViewRuleGlobalStyle(astRule)) {
+      return this.parseViewRuleGlobalStyle(astRule, isValid)
+    }
+    nonexhaustive(astRule)
   }
 
   protected resolveFqn(node: ast.Element | ast.ExtendElement) {

--- a/packages/language-server/src/references/scope-computation.ts
+++ b/packages/language-server/src/references/scope-computation.ts
@@ -20,7 +20,7 @@ export class LikeC4ScopeComputation extends DefaultScopeComputation {
   ): Promise<AstNodeDescription[]> {
     const docExports: AstNodeDescription[] = []
     try {
-      const { specifications, models, views, likec4lib } = document.parseResult.value
+      const { specifications, models, views, global_rules, likec4lib } = document.parseResult.value
 
       // Process library
       this.exportLibrary(likec4lib, docExports, document)
@@ -33,6 +33,9 @@ export class LikeC4ScopeComputation extends DefaultScopeComputation {
 
       // Process views
       this.exportViews(views, docExports, document)
+
+      // Process global
+      this.exportGlobalRules(global_rules, docExports, document)
     } catch (e) {
       logError(e)
     }
@@ -51,6 +54,25 @@ export class LikeC4ScopeComputation extends DefaultScopeComputation {
       try {
         if (isTruthy(viewAst.name)) {
           docExports.push(this.descriptions.createDescription(viewAst, viewAst.name, document))
+        }
+      } catch (e) {
+        logError(e)
+      }
+    }
+  }
+
+  private exportGlobalRules(
+    globalRules: ast.GlobalRules[] | undefined,
+    docExports: AstNodeDescription[],
+    document: LikeC4LangiumDocument
+  ) {
+    if (isNullish(globalRules) || globalRules.length === 0) {
+      return
+    }
+    for (const globalStyleAst of globalRules.flatMap(g => g.styles)) {
+      try {
+        if (isTruthy(globalStyleAst.name)) {
+          docExports.push(this.descriptions.createDescription(globalStyleAst, globalStyleAst.name, document))
         }
       } catch (e) {
         logError(e)

--- a/packages/language-server/src/references/scope-computation.ts
+++ b/packages/language-server/src/references/scope-computation.ts
@@ -89,6 +89,24 @@ export class LikeC4ScopeComputation extends DefaultScopeComputation {
         logError(e)
       }
     }
+    for (const globalPredicateGroupAst of globalRules.flatMap(g => g.predicate_groups)) {
+      try {
+        if (isTruthy(globalPredicateGroupAst.name)) {
+          docExports.push(this.descriptions.createDescription(globalPredicateGroupAst, globalPredicateGroupAst.name, document))
+        }
+      } catch (e) {
+        logError(e)
+      }
+    }
+    for (const globalDynamicPredicateGroupAst of globalRules.flatMap(g => g.dynamic_predicate_groups)) {
+      try {
+        if (isTruthy(globalDynamicPredicateGroupAst.name)) {
+          docExports.push(this.descriptions.createDescription(globalDynamicPredicateGroupAst, globalDynamicPredicateGroupAst.name, document))
+        }
+      } catch (e) {
+        logError(e)
+      }
+    }
   }
 
   private exportModel(

--- a/packages/language-server/src/references/scope-computation.ts
+++ b/packages/language-server/src/references/scope-computation.ts
@@ -71,8 +71,19 @@ export class LikeC4ScopeComputation extends DefaultScopeComputation {
     }
     for (const globalStyleAst of globalRules.flatMap(g => g.styles)) {
       try {
-        if (isTruthy(globalStyleAst.name)) {
-          docExports.push(this.descriptions.createDescription(globalStyleAst, globalStyleAst.name, document))
+        const id = globalStyleAst.id
+        if (isTruthy(id.name)) {
+          docExports.push(this.descriptions.createDescription(id, id.name, document))
+        }
+      } catch (e) {
+        logError(e)
+      }
+    }
+    for (const globalStyleGroupAst of globalRules.flatMap(g => g.style_groups)) {
+      try {
+        const id = globalStyleGroupAst.id
+        if (isTruthy(id.name)) {
+          docExports.push(this.descriptions.createDescription(id, id.name, document))
         }
       } catch (e) {
         logError(e)

--- a/packages/language-server/src/validation/index.ts
+++ b/packages/language-server/src/validation/index.ts
@@ -8,6 +8,8 @@ import { iconPropertyRuleChecks, notesPropertyRuleChecks, opacityPropertyRuleChe
 import { relationBodyChecks, relationChecks } from './relation'
 import {
   elementKindChecks,
+  globalRuleChecks,
+  globalStyleChecks,
   modelRuleChecks,
   modelViewsChecks,
   relationshipChecks,
@@ -33,6 +35,8 @@ export function registerValidationChecks(services: LikeC4Services) {
     SpecificationRule: specificationRuleChecks(services),
     Model: modelRuleChecks(services),
     ModelViews: modelViewsChecks(services),
+    GlobalRules: globalRuleChecks(services),
+    GlobalStyle: globalStyleChecks(services),
     DynamicViewStep: dynamicViewStep(services),
     LikeC4View: viewChecks(services),
     Element: elementChecks(services),

--- a/packages/language-server/src/validation/index.ts
+++ b/packages/language-server/src/validation/index.ts
@@ -9,7 +9,7 @@ import { relationBodyChecks, relationChecks } from './relation'
 import {
   elementKindChecks,
   globalRuleChecks,
-  globalStyleChecks,
+  globalStyleIdChecks,
   modelRuleChecks,
   modelViewsChecks,
   relationshipChecks,
@@ -36,7 +36,7 @@ export function registerValidationChecks(services: LikeC4Services) {
     Model: modelRuleChecks(services),
     ModelViews: modelViewsChecks(services),
     GlobalRules: globalRuleChecks(services),
-    GlobalStyle: globalStyleChecks(services),
+    GlobalStyleId: globalStyleIdChecks(services),
     DynamicViewStep: dynamicViewStep(services),
     LikeC4View: viewChecks(services),
     Element: elementChecks(services),

--- a/packages/language-server/src/validation/specification.ts
+++ b/packages/language-server/src/validation/specification.ts
@@ -141,18 +141,18 @@ export const relationshipChecks = (
   }
 }
 
-export const globalStyleChecks = (
+export const globalStyleIdChecks = (
   services: LikeC4Services
-): ValidationCheck<ast.GlobalStyle> => {
+): ValidationCheck<ast.GlobalStyleId> => {
   const index = services.shared.workspace.IndexManager
   return (node, accept) => {
     const sameName = index
-      .allElements(ast.GlobalStyle)
+      .allElements(ast.GlobalStyleId)
       .filter(s => s.name === node.name)
       .limit(2)
       .count()
     if (sameName > 1) {
-      accept('error', `Duplicate GlobalStyle name '${node.name}'`, {
+      accept('error', `Duplicate GlobalStyleId name '${node.name}'`, {
         node: node,
         property: 'name'
       })

--- a/packages/language-server/src/validation/specification.ts
+++ b/packages/language-server/src/validation/specification.ts
@@ -38,6 +38,17 @@ export const modelViewsChecks = (_: LikeC4Services): ValidationCheck<ast.ModelVi
   }
 }
 
+export const globalRuleChecks = (_: LikeC4Services): ValidationCheck<ast.GlobalRules> => {
+  return (node, accept) => {
+    if (node.$containerIndex && node.$containerIndex > 0) {
+      accept('warning', `Prefer one global block per document`, {
+        node: node,
+        property: 'name'
+      })
+    }
+  }
+}
+
 export const elementKindChecks = (services: LikeC4Services): ValidationCheck<ast.ElementKind> => {
   const index = services.shared.workspace.IndexManager
   return tryOrLog((node, accept) => {
@@ -123,6 +134,25 @@ export const relationshipChecks = (
       .count()
     if (sameKinds > 1) {
       accept('error', `Duplicate RelationshipKind '${node.name}'`, {
+        node: node,
+        property: 'name'
+      })
+    }
+  }
+}
+
+export const globalStyleChecks = (
+  services: LikeC4Services
+): ValidationCheck<ast.GlobalStyle> => {
+  const index = services.shared.workspace.IndexManager
+  return (node, accept) => {
+    const sameName = index
+      .allElements(ast.GlobalStyle)
+      .filter(s => s.name === node.name)
+      .limit(2)
+      .count()
+    if (sameName > 1) {
+      accept('error', `Duplicate GlobalStyle name '${node.name}'`, {
         node: node,
         property: 'name'
       })


### PR DESCRIPTION
This pull request implements the idea sketched in https://github.com/likec4/likec4/pull/1038#issuecomment-2382135923. If merged, it would render #1038 obsolete.

It fixes two proposals from the discussion: #961 and #962.

The main benefits of the new features:

* Styles can be defined globally (global styles) and defined to each `view {}` by a reference
* Styles defined globally can be grouped (global style groups). Each `view {}` node can apply style groups
* Styles can be defined for a `views {}` block (local styles) and applied to each `view {}` in the block
* Styles (and groups) defined globally can be referenced in a `views {}` block and applied to each `view {}` node in the block
* Include and exclude predicates can be defined in global groups (global predicate groups) and applied to views