### PR TITLE
Implemented alignment tools

### DIFF
--- a/packages/diagram/package.json
+++ b/packages/diagram/package.json
@@ -31,7 +31,6 @@
   },
   "dependencies": {
     "@likec4/core": "workspace:*",
-    "@lume/kiwi": "^0.4.4",
     "@mantine/vanilla-extract": "7.13.2",
     "@react-hookz/web": "^24.0.4",
     "@tabler/icons-react": "3.17.0",

--- a/packages/diagram/src/state/diagram-to-xyflow.ts
+++ b/packages/diagram/src/state/diagram-to-xyflow.ts
@@ -73,7 +73,7 @@ export function diagramViewToXYFlowData(
     // const inEdges = node.inEdges.map(e => view.edges.find(edge => edge.id === e)).filter(Boolean)
 
     const id = ns + node.id
-    const draggable = opts.draggable && (!parent || parent.children.length > 1)
+    const draggable = opts.draggable
     xynodes.push({
       id,
       type: isCompound ? 'compound' : 'element',

--- a/packages/diagram/src/state/diagramStore.ts
+++ b/packages/diagram/src/state/diagramStore.ts
@@ -81,6 +81,8 @@ export type DiagramInitialState = {
   getContainer: () => HTMLDivElement | null
 } & RequiredOrNull<LikeC4DiagramEventHandlers>
 
+type AlignmentMode = 'Left' | 'Center' | 'Right' | 'Top' | 'Middle' | 'Bottom'
+
 const StringSet = Set<string>
 
 export type DiagramState = Simplify<
@@ -172,7 +174,7 @@ export type DiagramState = Simplify<
     highlightByElementNotation: (notation: ElementNotation, onlyOfKind?: ElementKind) => void
 
     resetEdgeControlPoints: () => void
-    align: (mode: 'Left' | 'Right' | 'Top' | 'Bottom') => void
+    align: (mode: AlignmentMode) => void
   }
 >
 
@@ -1028,7 +1030,7 @@ export function createDiagramStore(props: DiagramInitialState) {
               return vector(v).mul(scale).add(nodeCenter)
             }
           },
-          align: (mode: 'Left' | 'Right' | 'Top' | 'Bottom') => {
+          align: (mode: AlignmentMode) => {
             const { scheduleSaveManualLayout, xystore } = get()
             const { nodeLookup, parentLookup } = xystore.getState()
 
@@ -1052,14 +1054,28 @@ export function createDiagramStore(props: DiagramInitialState) {
                 getPosition = (alignTo, _) => Math.floor(alignTo)
                 break
               case 'Right':
-                getEdgePosition = nodes => Math.max(...nodes.map(n => n.internals.positionAbsolute.x + n.width!))
+                getEdgePosition = nodes =>
+                  Math.max(...nodes.map(n => n.internals.positionAbsolute.x + getNodeDimensions(n).width))
                 propertyToEdit = 'x'
                 getPosition = (alignTo, node) => Math.floor(alignTo - node.width!)
                 break
               case 'Bottom':
-                getEdgePosition = nodes => Math.max(...nodes.map(n => n.internals.positionAbsolute.y + n.height!))
+                getEdgePosition = nodes =>
+                  Math.max(...nodes.map(n => n.internals.positionAbsolute.y + getNodeDimensions(n).height))
                 propertyToEdit = 'y'
                 getPosition = (alignTo, node) => Math.floor(alignTo - node.height!)
+                break
+              case 'Center':
+                getEdgePosition = nodes =>
+                  Math.max(...nodes.map(n => n.internals.positionAbsolute.x + getNodeDimensions(n).width / 2))
+                propertyToEdit = 'x'
+                getPosition = (alignTo, node) => Math.floor(alignTo - getNodeDimensions(node).width / 2)
+                break
+              case 'Middle':
+                getEdgePosition = nodes =>
+                  Math.max(...nodes.map(n => n.internals.positionAbsolute.y + getNodeDimensions(n).height / 2))
+                propertyToEdit = 'y'
+                getPosition = (alignTo, node) => Math.floor(alignTo - getNodeDimensions(node).height / 2)
                 break
             }
 

--- a/packages/diagram/src/ui/top-left/ManualLayoutToolsButton.tsx
+++ b/packages/diagram/src/ui/top-left/ManualLayoutToolsButton.tsx
@@ -1,0 +1,127 @@
+import {
+  ActionIconGroup,
+  Group,
+  Popover,
+  PopoverDropdown,
+  type PopoverProps,
+  PopoverTarget,
+  type TooltipProps
+} from '@mantine/core'
+import {
+  IconLayoutAlignBottom,
+  IconLayoutAlignCenter,
+  IconLayoutAlignLeft,
+  IconLayoutAlignMiddle,
+  IconLayoutAlignRight,
+  IconLayoutAlignTop,
+  IconLayoutCollage,
+  IconRouteOff
+} from '@tabler/icons-react'
+import { useMantinePortalProps } from '../../hooks'
+import { useDiagramStoreApi } from '../../hooks/useDiagramState'
+import { ActionIcon, Tooltip } from './_shared'
+
+export const ManualLAyoutToolsButton = (props: PopoverProps) => {
+  const store = useDiagramStoreApi()
+
+  const portalProps = useMantinePortalProps()
+
+  return (
+    <Popover
+      position="right-start"
+      clickOutsideEvents={[
+        'pointerdown'
+      ]}
+      radius="xs"
+      shadow="lg"
+      offset={{
+        mainAxis: 10
+      }}
+      {...props}>
+      <PopoverTarget>
+        <Tooltip label="Manual layouting tools">
+          <ActionIcon>
+            <IconLayoutCollage />
+          </ActionIcon>
+        </Tooltip>
+      </PopoverTarget>
+      <PopoverDropdown p={0}>
+        <Group>
+          <ActionIconGroup pos={'relative'}>
+            <Tooltip label="Align left" {...portalProps}>
+              <ActionIcon
+                onClick={e => {
+                  e.stopPropagation()
+                  store.getState().align('Left')
+                }}>
+                <IconLayoutAlignLeft />
+              </ActionIcon>
+            </Tooltip>
+            <Tooltip label="Align center" {...portalProps}>
+              <ActionIcon
+                onClick={e => {
+                  e.stopPropagation()
+                  store.getState().align('Center')
+                }}>
+                <IconLayoutAlignCenter />
+              </ActionIcon>
+            </Tooltip>
+            <Tooltip label="Align right" {...portalProps}>
+              <ActionIcon
+                onClick={e => {
+                  e.stopPropagation()
+                  store.getState().align('Right')
+                }}>
+                <IconLayoutAlignRight />
+              </ActionIcon>
+            </Tooltip>
+            <Tooltip label="Align top" {...portalProps}>
+              <ActionIcon
+                onClick={e => {
+                  e.stopPropagation()
+                  store.getState().align('Top')
+                }}>
+                <IconLayoutAlignTop />
+              </ActionIcon>
+            </Tooltip>
+            <Tooltip label="Align middle" {...portalProps}>
+              <ActionIcon
+                onClick={e => {
+                  e.stopPropagation()
+                  store.getState().align('Middle')
+                }}>
+                <IconLayoutAlignMiddle />
+              </ActionIcon>
+            </Tooltip>
+            <Tooltip label="Align bottom" {...portalProps}>
+              <ActionIcon
+                onClick={e => {
+                  e.stopPropagation()
+                  store.getState().align('Bottom')
+                }}>
+                <IconLayoutAlignBottom />
+              </ActionIcon>
+            </Tooltip>
+          </ActionIconGroup>
+          <ResetControlPointsButton {...portalProps} />
+        </Group>
+      </PopoverDropdown>
+    </Popover>
+  )
+}
+
+const ResetControlPointsButton = (props: Omit<TooltipProps, 'label' | 'children'>) => {
+  const store = useDiagramStoreApi()
+
+  return (
+    <Tooltip label="Reset all control points" {...props}>
+      <ActionIcon
+        onClick={e => {
+          e.stopPropagation()
+          store.getState().resetEdgeControlPoints()
+        }}>
+        <IconRouteOff />
+      </ActionIcon>
+    </Tooltip>
+  )
+}

--- a/packages/diagram/src/ui/top-left/TopLeftPanel.tsx
+++ b/packages/diagram/src/ui/top-left/TopLeftPanel.tsx
@@ -10,21 +10,15 @@ import {
   type PopoverProps,
   Stack,
   Text,
-  TooltipGroup,
-  type TooltipProps
+  TooltipGroup
 } from '@mantine/core'
 import {
   IconAlertTriangle,
-  IconBoxAlignBottom,
-  IconBoxAlignLeft,
-  IconBoxAlignRight,
-  IconBoxAlignTop,
   IconChevronLeft,
   IconChevronRight,
   IconFileSymlink,
   IconFocusCentered,
   IconMenu2,
-  IconRouteOff
 } from '@tabler/icons-react'
 import clsx from 'clsx'
 import { AnimatePresence, LayoutGroup, m } from 'framer-motion'
@@ -34,6 +28,7 @@ import { useMantinePortalProps } from '../../hooks/useMantinePortalProps'
 import { mantine } from '../../theme-vars'
 import { ActionIcon, Tooltip } from './_shared'
 import { ChangeAutoLayoutButton } from './ChangeAutoLayoutButton'
+import { ManualLAyoutToolsButton } from './ManualLayoutToolsButton'
 import * as css from './styles.css'
 
 const historySelector = (s: DiagramState) => ({
@@ -139,22 +134,6 @@ const LayoutDriftNotification = (props: PopoverProps) => (
   </HoverCard>
 )
 
-const ResetControlPointsButton = (props: Omit<TooltipProps, 'label' | 'children'>) => {
-  const store = useDiagramStoreApi()
-
-  return (
-    <Tooltip label="Reset all control points" {...props}>
-      <ActionIcon
-        onClick={e => {
-          e.stopPropagation()
-          store.getState().resetEdgeControlPoints()
-        }}>
-        <IconRouteOff />
-      </ActionIcon>
-    </Tooltip>
-  )
-}
-
 export const TopLeftPanel = () => {
   const store = useDiagramStoreApi()
   const {
@@ -164,7 +143,7 @@ export const TopLeftPanel = () => {
     showChangeAutoLayout,
     showGoToSource,
     viewportChanged,
-    showResetControlPoints
+    showManualLayoutTools
   } = useDiagramState(s => {
     const isNotWalkthrough = isNullish(s.activeWalkthrough)
     const isNotFocused = isNullish(s.focusedNodeId)
@@ -176,7 +155,7 @@ export const TopLeftPanel = () => {
       showChangeAutoLayout: s.isEditable() && isNotActive,
       showGoToSource: !!s.onOpenSourceView && isNotWalkthrough,
       viewportChanged: s.viewportChanged,
-      showResetControlPoints: s.readonly !== true && s.experimentalEdgeEditing === true
+      showManualLayoutTools: s.readonly !== true && s.experimentalEdgeEditing === true
     })
   })
   const portalProps = useMantinePortalProps()
@@ -207,7 +186,7 @@ export const TopLeftPanel = () => {
           )}
           {showChangeAutoLayout && <ChangeAutoLayoutButton {...portalProps} />}
           {showLayoutDriftWarning && <LayoutDriftNotification {...portalProps} />}
-          {showResetControlPoints && <ResetControlPointsButton {...portalProps} />}
+          {showManualLayoutTools && <ManualLAyoutToolsButton {...portalProps} />}
           {showFitDiagram && (
             <Tooltip label={viewportChanged ? 'Center camera' : 'Camera is centered'} {...portalProps}>
               <ActionIcon
@@ -220,42 +199,6 @@ export const TopLeftPanel = () => {
             </Tooltip>
           )}
         </ActionIconGroup>
-        <Tooltip label="Align top" {...portalProps}>
-          <ActionIcon
-            onClick={e => {
-              e.stopPropagation()
-              store.getState().align('Top')
-            }}>
-            <IconBoxAlignTop />
-          </ActionIcon>
-        </Tooltip>
-        <Tooltip label="Align left" {...portalProps}>
-          <ActionIcon
-            onClick={e => {
-              e.stopPropagation()
-              store.getState().align('Left')
-            }}>
-            <IconBoxAlignLeft />
-          </ActionIcon>
-        </Tooltip>
-        <Tooltip label="Align bottom" {...portalProps}>
-          <ActionIcon
-            onClick={e => {
-              e.stopPropagation()
-              store.getState().align('Bottom')
-            }}>
-            <IconBoxAlignBottom />
-          </ActionIcon>
-        </Tooltip>
-        <Tooltip label="Align right" {...portalProps}>
-          <ActionIcon
-            onClick={e => {
-              e.stopPropagation()
-              store.getState().align('Right')
-            }}>
-            <IconBoxAlignRight />
-          </ActionIcon>
-        </Tooltip>
       </Stack>
     </TooltipGroup>
   )

--- a/packages/diagram/src/ui/top-left/TopLeftPanel.tsx
+++ b/packages/diagram/src/ui/top-left/TopLeftPanel.tsx
@@ -15,6 +15,10 @@ import {
 } from '@mantine/core'
 import {
   IconAlertTriangle,
+  IconBoxAlignBottom,
+  IconBoxAlignLeft,
+  IconBoxAlignRight,
+  IconBoxAlignTop,
   IconChevronLeft,
   IconChevronRight,
   IconFileSymlink,
@@ -216,6 +220,42 @@ export const TopLeftPanel = () => {
             </Tooltip>
           )}
         </ActionIconGroup>
+        <Tooltip label="Align top" {...portalProps}>
+          <ActionIcon
+            onClick={e => {
+              e.stopPropagation()
+              store.getState().align('Top')
+            }}>
+            <IconBoxAlignTop />
+          </ActionIcon>
+        </Tooltip>
+        <Tooltip label="Align left" {...portalProps}>
+          <ActionIcon
+            onClick={e => {
+              e.stopPropagation()
+              store.getState().align('Left')
+            }}>
+            <IconBoxAlignLeft />
+          </ActionIcon>
+        </Tooltip>
+        <Tooltip label="Align bottom" {...portalProps}>
+          <ActionIcon
+            onClick={e => {
+              e.stopPropagation()
+              store.getState().align('Bottom')
+            }}>
+            <IconBoxAlignBottom />
+          </ActionIcon>
+        </Tooltip>
+        <Tooltip label="Align right" {...portalProps}>
+          <ActionIcon
+            onClick={e => {
+              e.stopPropagation()
+              store.getState().align('Right')
+            }}>
+            <IconBoxAlignRight />
+          </ActionIcon>
+        </Tooltip>
       </Stack>
     </TooltipGroup>
   )

--- a/packages/diagram/src/xyflow/useLayoutConstraints.ts
+++ b/packages/diagram/src/xyflow/useLayoutConstraints.ts
@@ -107,8 +107,6 @@ export function createLayoutConstraints(
   const traverse = new Array<{ xynode: InternalNode<XYFlowNode>; parent: Compound | null }>()
 
   for (const [, xynode] of nodeLookup) {
-    console.log(xynode.id, xynode.parentId)
-
     if (isNullish(xynode.parentId)) {
       traverse.push({
         xynode,
@@ -142,7 +140,6 @@ export function createLayoutConstraints(
   applyConstraints(rectsToUpdate)
 
   function applyConstraints(targets: Rect[]) {
-    console.log('applyConstraints', targets)
     targets
       .filter(x => x instanceof Compound)
       .forEach((r) => {
@@ -160,14 +157,11 @@ export function createLayoutConstraints(
           maxY: -Infinity
         })
 
-        console.log('applyConstraints', r.id, childrenBB)
 
         r.minX = childrenBB.minX - Rect.LeftPadding
         r.minY = childrenBB.minY - Rect.TopPadding
         r.maxX = childrenBB.maxX + Rect.RightPadding
         r.maxY = childrenBB.maxY + Rect.BottomPadding
-
-        console.log('applyConstraints', r.id, r.minX, r.minY, r.maxX, r.maxY)
       })
   }
 
@@ -175,11 +169,6 @@ export function createLayoutConstraints(
     applyConstraints(rectsToUpdate)
     xyflowApi.getState().triggerNodeChanges(
       rectsToUpdate.reduce((acc, r) => {
-        console.log(
-          `updating ${r.id} to ${JSON.stringify(r.positionAbsolute)} (${JSON.stringify(r.position)}) from ${
-            JSON.stringify(nodeLookup.get(r.id)!.internals.positionAbsolute)
-          } (${JSON.stringify(nodeLookup.get(r.id)!.position)})`
-        )
         acc.push({
           id: r.id,
           type: 'position',

--- a/packages/diagram/src/xyflow/useLayoutConstraints.ts
+++ b/packages/diagram/src/xyflow/useLayoutConstraints.ts
@@ -1,5 +1,4 @@
 import { invariant, isAncestor, nonNullable } from '@likec4/core'
-import { Expression, Expression as Expr, Operator, Solver, Strength, Variable } from '@lume/kiwi'
 import type { InternalNode, NodeChange, ReactFlowProps, XYPosition } from '@xyflow/react'
 import { getNodeDimensions } from '@xyflow/system'
 import { useMemo, useRef } from 'react'
@@ -9,31 +8,36 @@ import { type XYStoreApi } from '../hooks/useXYFlow'
 import type { XYFlowNode } from './types'
 
 abstract class Rect {
+  static readonly LeftPadding = 40
+  static readonly RightPadding = 40
+  static readonly TopPadding = 55
+  static readonly BottomPadding = 40
+
   id!: string
-  minX = new Variable()
-  minY = new Variable()
-  maxX: Expression | Variable = new Variable()
-  maxY: Expression | Variable = new Variable()
-
-  get x() {
-    return this.minX
-  }
-
-  get y() {
-    return this.minY
-  }
+  minX: number = Infinity
+  minY: number = Infinity
+  maxX: number = -Infinity
+  maxY: number = -Infinity
 
   get positionAbsolute(): XYPosition {
     return {
-      x: this.x.value(),
-      y: this.y.value()
+      x: this.minX,
+      y: this.minY
     }
+  }
+
+  set positionAbsolute(pos: XYPosition) {
+    this.maxX += pos.x - this.minX
+    this.maxY += pos.y - this.minY
+
+    this.minX = pos.x
+    this.minY = pos.y
   }
 
   get dimensions() {
     return {
-      width: this.maxX.value() - this.minX.value(),
-      height: this.maxY.value() - this.minY.value()
+      width: this.maxX - this.minX,
+      height: this.maxY - this.minY
     }
   }
 
@@ -53,126 +57,58 @@ abstract class Rect {
 }
 
 class Compound extends Rect {
-  protected readonly children = [] as Rect[]
+  public readonly children = [] as Rect[]
 
   constructor(
-    protected solver: Solver,
     xynode: InternalNode<XYFlowNode>,
     protected readonly parent: Compound | null = null
   ) {
     super()
     this.id = xynode.id
 
-    solver.createConstraint(this.maxX, Operator.Ge, this.minX)
-    solver.createConstraint(this.maxY, Operator.Ge, this.minY)
-
     if (parent) {
-      parent.addChild(this)
+      parent.children.push(this)
     }
-  }
-
-  addChild<R extends Rect>(rect: R) {
-    this.children.push(rect)
-
-    const leftPadding = new Expr(
-      rect.minX,
-      [-1, this.minX]
-    )
-    const { weak } = Strength
-    this.solver.createConstraint(leftPadding, Operator.Ge, 40)
-    this.solver.createConstraint(leftPadding, Operator.Eq, 41, weak)
-
-    const topPadding = new Expr(
-      rect.minY,
-      [-1, this.minY]
-    )
-    this.solver.createConstraint(topPadding, Operator.Ge, 54)
-    this.solver.createConstraint(topPadding, Operator.Eq, 55, weak)
-
-    const rightPadding = new Expr(
-      this.maxX,
-      [-1, rect.maxX]
-    )
-    this.solver.createConstraint(rightPadding, Operator.Ge, 40)
-    this.solver.createConstraint(rightPadding, Operator.Eq, 41, weak)
-
-    const bottomPadding = new Expr(
-      this.maxY,
-      [-1, rect.maxY]
-    )
-    this.solver.createConstraint(bottomPadding, Operator.Ge, 40)
-    this.solver.createConstraint(bottomPadding, Operator.Eq, 41, weak)
   }
 }
 
 class Leaf extends Rect {
   constructor(
-    solver: Solver,
     xynode: InternalNode<XYFlowNode>,
-    public readonly parent: Compound | null = null,
-    public readonly isEditing: boolean = false
+    public readonly parent: Compound | null = null
   ) {
     super()
     this.id = xynode.id
 
-    // const isEditing: boolean = xynode.dragging ?? false
-    const x = Math.ceil(xynode.internals.positionAbsolute.x)
-    const y = Math.ceil(xynode.internals.positionAbsolute.y)
+    this.positionAbsolute = xynode.internals.positionAbsolute
 
     const { width, height } = getNodeDimensions(xynode)
 
-    this.maxX = new Expression(this.minX, Math.ceil(width))
-    this.maxY = new Expression(this.minY, Math.ceil(height))
-
-    // solver.createConstraint(this.width, Operator.Eq, width, Strength.required)
-    // solver.createConstraint(this.height, Operator.Eq, height, Strength.required)
-
-    if (isEditing) {
-      const superStrong = Strength.create(100, 0, 0)
-      solver.addEditVariable(this.minX, superStrong)
-      solver.addEditVariable(this.minY, superStrong)
-      solver.suggestValue(this.minX, x)
-      solver.suggestValue(this.minY, y)
-    } else {
-      const halfMedium = Strength.create(0.0, 1.0, 0.0, 0.5)
-      solver.createConstraint(this.minX, Operator.Eq, x, halfMedium)
-      solver.createConstraint(this.minY, Operator.Eq, y, halfMedium)
-      // const weaker = Strength.create(0.0, 0.0, 1.0, 0.5)
-      // const weak = Strength.create(0.0, 0.0, 1.0)
-      // const x = new Expr(
-      //   this.minX,
-      //   [-1, pos.x]
-      // )
-      // solver.createConstraint(x, Operator.Eq, 0, weaker)
-      // solver.createConstraint(x, Operator.Ge, -30, weak)
-      // solver.createConstraint(x, Operator.Le, 30, weak)
-
-      // const y = new Expr(
-      //   this.minY,
-      //   [-1, pos.y]
-      // )
-      // solver.createConstraint(y, Operator.Eq, 0, weaker)
-      // solver.createConstraint(y, Operator.Ge, -30, weak)
-      // solver.createConstraint(y, Operator.Le, 30, weak)
-    }
+    this.maxX = this.minX + Math.ceil(width)
+    this.maxY = this.minY + Math.ceil(height)
 
     if (parent) {
-      parent.addChild(this)
+      parent.children.push(this)
     }
   }
 }
 
-function createLayoutConstraints(
+type NodePositionUpdater = (
+  nodes: Array<{ rect: Rect | Compound; node: InternalNode<XYFlowNode> }>
+) => void
+
+export function createLayoutConstraints(
   xyflowApi: XYStoreApi,
-  draggingNodeId: string
+  editingNodeIds: Set<string>
 ) {
   const { parentLookup, nodeLookup } = xyflowApi.getState()
-  const solver = new Solver()
   const rects = new Map<string, Leaf | Compound>()
 
   const traverse = new Array<{ xynode: InternalNode<XYFlowNode>; parent: Compound | null }>()
 
   for (const [, xynode] of nodeLookup) {
+    console.log(xynode.id, xynode.parentId)
+
     if (isNullish(xynode.parentId)) {
       traverse.push({
         xynode,
@@ -181,21 +117,15 @@ function createLayoutConstraints(
     }
   }
 
-  const draggingNodes = new Set(
-    nodeLookup.values()
-      .filter(x => x.dragging === true || x.id === draggingNodeId || x.selected)
-      .map(x => x.id)
-  )
-
   while (traverse.length > 0) {
     const { xynode, parent } = traverse.shift()!
-    const isDragging = draggingNodes.has(xynode.id)
+    const isEditing = editingNodeIds.has(xynode.id)
 
     // Traverse children if the node is a compound, not dragging, and is an ancestor of the dragging node
-    const shouldTraverse = !isDragging && xynode.type === 'compound'
-      && draggingNodes.values().some(x => isAncestor(xynode.id, x))
+    const shouldTraverse = !isEditing && xynode.type === 'compound'
+      && editingNodeIds.values().some(x => isAncestor(xynode.id, x))
 
-    const rect = shouldTraverse ? new Compound(solver, xynode, parent) : new Leaf(solver, xynode, parent, isDragging)
+    const rect = shouldTraverse ? new Compound(xynode, parent) : new Leaf(xynode, parent)
     rects.set(xynode.id, rect)
 
     if (shouldTraverse) {
@@ -208,14 +138,48 @@ function createLayoutConstraints(
     }
   }
 
-  solver.updateVariables()
-  solver.maxIterations = 1000
-  const rectsToUpdate = [...rects.values()].filter(r => !draggingNodes.has(r.id))
+  const rectsToUpdate = [...rects.values()]
+  applyConstraints(rectsToUpdate)
+
+  function applyConstraints(targets: Rect[]) {
+    console.log('applyConstraints', targets)
+    targets
+      .filter(x => x instanceof Compound)
+      .forEach((r) => {
+        applyConstraints(r.children)
+
+        const childrenBB = r.children.reduce((acc, r) => ({
+          minX: Math.min(acc.minX, r.minX),
+          minY: Math.min(acc.minY, r.minY),
+          maxX: Math.max(acc.maxX, r.maxX),
+          maxY: Math.max(acc.maxY, r.maxY)
+        }), {
+          minX: Infinity,
+          minY: Infinity,
+          maxX: -Infinity,
+          maxY: -Infinity
+        })
+
+        console.log('applyConstraints', r.id, childrenBB)
+
+        r.minX = childrenBB.minX - Rect.LeftPadding
+        r.minY = childrenBB.minY - Rect.TopPadding
+        r.maxX = childrenBB.maxX + Rect.RightPadding
+        r.maxY = childrenBB.maxY + Rect.BottomPadding
+
+        console.log('applyConstraints', r.id, r.minX, r.minY, r.maxX, r.maxY)
+      })
+  }
 
   function updateXYFlowNodes() {
-    solver.updateVariables()
+    applyConstraints(rectsToUpdate)
     xyflowApi.getState().triggerNodeChanges(
       rectsToUpdate.reduce((acc, r) => {
+        console.log(
+          `updating ${r.id} to ${JSON.stringify(r.positionAbsolute)} (${JSON.stringify(r.position)}) from ${
+            JSON.stringify(nodeLookup.get(r.id)!.internals.positionAbsolute)
+          } (${JSON.stringify(nodeLookup.get(r.id)!.position)})`
+        )
         acc.push({
           id: r.id,
           type: 'position',
@@ -238,26 +202,28 @@ function createLayoutConstraints(
 
   let animationFrameId: number | null = null
 
-  /**
-   * Move the editing node to the given position.
-   */
-  function onNodeDrag(xynode: XYFlowNode) {
+  function onMove(
+    updater: NodePositionUpdater
+  ) {
     if (rectsToUpdate.length === 0) {
       return
     }
     animationFrameId ??= requestAnimationFrame(() => {
       animationFrameId = null
-      const pos = nodeLookup.get(xynode.id)!.internals.positionAbsolute
-      const rect = nonNullable(rects.get(xynode.id))
-      solver.suggestValue(rect.minX, Math.floor(pos.x))
-      solver.suggestValue(rect.minY, Math.floor(pos.y))
+      updater(
+        [
+          ...editingNodeIds.values()
+            .filter(id => rects.has(id) && nodeLookup.has(id))
+            .map(id => ({ rect: nonNullable(rects.get(id)), node: nodeLookup.get(id)! }))
+        ]
+      )
       updateXYFlowNodes()
     })
   }
 
   return {
-    onNodeDrag,
-    updateXYFlowNodes
+    updateXYFlowNodes,
+    onMove
   }
 }
 
@@ -271,14 +237,26 @@ export function useLayoutConstraints(): LayoutConstraints {
   return useMemo((): LayoutConstraints => ({
     onNodeDragStart: (_event, xynode) => {
       const { cancelSaveManualLayout, xystore } = diagramApi.getState()
+      const { nodeLookup } = xystore.getState()
       cancelSaveManualLayout()
-      solverRef.current = createLayoutConstraints(xystore, xynode.id)
+
+      const draggingNodes = new Set(
+        nodeLookup.values()
+          .filter(x => x.dragging === true || x.id === xynode.id || x.selected)
+          .filter(x => x.draggable === true)
+          .map(x => x.id)
+      )
+      solverRef.current = createLayoutConstraints(xystore, draggingNodes)
     },
-    onNodeDrag: (_event, xynode) => {
+    onNodeDrag: () => {
       invariant(solverRef.current, 'solverRef.current should be defined')
-      solverRef.current?.onNodeDrag(xynode)
+      solverRef.current.onMove((nodes) => {
+        nodes.forEach(({ rect, node }) => {
+          rect.positionAbsolute = node.internals.positionAbsolute
+        })
+      })
     },
-    onNodeDragStop: (_event, _xynode) => {
+    onNodeDragStop: () => {
       solverRef.current?.updateXYFlowNodes()
       diagramApi.getState().scheduleSaveManualLayout()
       solverRef.current = undefined

--- a/yarn.lock
+++ b/yarn.lock
@@ -2075,7 +2075,6 @@ __metadata:
   dependencies:
     "@likec4/core": "workspace:*"
     "@likec4/tsconfig": "workspace:*"
-    "@lume/kiwi": "npm:^0.4.4"
     "@mantine/core": "npm:7.13.2"
     "@mantine/hooks": "npm:7.13.2"
     "@mantine/vanilla-extract": "npm:7.13.2"
@@ -2360,13 +2359,6 @@ __metadata:
     vscode-messenger-webview: "npm:^0.4.5"
   languageName: unknown
   linkType: soft
-
-"@lume/kiwi@npm:^0.4.4":
-  version: 0.4.4
-  resolution: "@lume/kiwi@npm:0.4.4"
-  checksum: 10c0/780d41ae5133ce08dc71bcbdd4aa16e77322fc0e2ee6c04823adaf32f19259f35980b5db46520df73c965fbe78b4a060fd145ee8fc0480d8760ce736ee1b495a
-  languageName: node
-  linkType: hard
 
 "@mantine/colors-generator@npm:^7.13.2":
   version: 7.13.2


### PR DESCRIPTION
Implemented alignment tools for manual layouting. Alignment applied to leaf nodes only.
![alignment-tools](https://github.com/user-attachments/assets/9d6e5b1b-e2af-4cce-bac5-b0a3a1dfc73b)


Also replaced @lume/kiwi solver with simple implementation. kiwi solver does not work properly for compound nodes on 2+ level with a single child. I guess that was the reason why dragging was disabled for nodes which are the only child. This workaround is acceptable for drag scenario but does not fit to align scenario: it is still required to align a node with others, even it is the only child.
Although implementation with solver is more flexible than bounding box implementation, this flexibility is not used.