### PR TITLE
feat: local styles

### DIFF
--- a/apps/docs/src/content/docs/dsl/views.mdx
+++ b/apps/docs/src/content/docs/dsl/views.mdx
@@ -532,6 +532,28 @@ view apiApp of internetBankingSystem.apiApplication {
 
 Please note, that [overrides](#with-overrides) have higher priority.
 
+#### Local style predicates
+
+Style predicates can be defined for a `views` group.
+
+```likec4
+views {
+  // apply to all elements in all views in this views block
+  style * {
+    color muted
+    opacity 10%
+  }
+
+  view apiApp of internetBankingSystem.apiApplication {
+    include *
+  }
+
+  view mobileApp of internetBankingSystem.mobileApplication {
+    include *
+  }
+}
+```
+
 ### Extend views
 
 Views can be extended to avoid duplication, to create a "baseline" or, for example, "slides" for a presentation:

--- a/packages/language-server/src/like-c4.langium
+++ b/packages/language-server/src/like-c4.langium
@@ -194,8 +194,10 @@ MetadataAttribute:
 // Views -------------------------------------
 
 ModelViews:
-  name='views' '{'
-    views+=LikeC4ViewRule*
+  name='views' '{' (
+      views+=LikeC4ViewRule |
+      styles+=ViewRuleStyle
+    )*
   '}';
 
 type LikeC4View = ElementView | DynamicView;


### PR DESCRIPTION
Allow defining styles local to the `views {}` blocks applicable to all views in a block.

This is the first PR of a series aiming to replace #1058