### PR TITLE
feat: global style groups

### DIFF
--- a/apps/docs/src/content/docs/dsl/views.mdx
+++ b/apps/docs/src/content/docs/dsl/views.mdx
@@ -617,6 +617,58 @@ views {
 }
 ```
 
+#### Global style groups
+
+Global style predicates can be grouped.
+When a group is applied to a view, all predicates from the group are applied.
+A group can be applied to multiple views
+
+```likec4
+global {
+  styleGroup common_styles {
+    // apply to all elements
+    style all_elements * {
+      color muted
+      opacity 10%
+    }
+
+    // apply only to these elements
+    style singlePageApplication, mobileApp {
+      color secondary
+    }
+
+    // apply only to elements with specific tag
+    style element.tag = #deprecated {
+      color muted
+    }
+  }
+}
+
+views {
+  view mobileApp of internetBankingSystem.mobileApplication {
+    include *
+
+    global style common_styles
+  }
+
+  view apiApp of internetBankingSystem.apiApplication {
+
+    include *
+
+    global style common_styles
+
+    // view-specific style predicates
+    style apiApplication.* {
+      color primary
+    }
+
+    style element.tag != #deprecated {
+      opacity 20%
+    }
+  }
+}
+```
+
 ### Extend views
 
 Views can be extended to avoid duplication, to create a "baseline" or, for example, "slides" for a presentation:

--- a/packages/language-server/src/ast.ts
+++ b/packages/language-server/src/ast.ts
@@ -236,6 +236,7 @@ function validatableAstNodeGuards<const Predicates extends Guard<AstNode>[]>(
 const isValidatableAstNode = validatableAstNodeGuards([
   ast.isGlobals,
   ast.isGlobalStyle,
+  ast.isGlobalStyleGroup,
   ast.isDynamicViewPredicateIterator,
   ast.isElementPredicateWith,
   ast.isRelationPredicateWith,

--- a/packages/language-server/src/like-c4.langium
+++ b/packages/language-server/src/like-c4.langium
@@ -444,7 +444,7 @@ ViewRuleStyle:
   '}';
 
 ViewRuleGlobalStyle:
-  'global' 'style' style=[GlobalStyle];
+  'global' 'style' style=[GlobalStyleId];
 
 ViewRuleAutoLayout:
   'autoLayout' direction=ViewLayoutDirection (
@@ -491,16 +491,24 @@ RelationNavigateToProperty:
 Globals:
   name='global' '{'
     (
-      styles+=GlobalStyle*
+      styles+=(GlobalStyle | GlobalStyleGroup)*
     )*
   '}';
 
+GlobalStyleId:
+  name=IdTerminal;
+
 GlobalStyle:
-  'style' name=IdTerminal target=ElementExpressionsIterator '{'
+  'style' id=GlobalStyleId target=ElementExpressionsIterator '{'
     props+=(
       StyleProperty |
       NotationProperty
     )*
+  '}';
+
+GlobalStyleGroup:
+  'styleGroup' id=GlobalStyleId '{'
+    styles+=ViewRuleStyle*
   '}';
 
 // Common properties -------------------------------------

--- a/packages/language-server/src/model/model-builder.spec.ts
+++ b/packages/language-server/src/model/model-builder.spec.ts
@@ -1226,7 +1226,7 @@ describe.concurrent('LikeC4ModelBuilder', () => {
     const indexView = await services.likec4.ModelBuilder.computeView('index' as ViewID)
     expect(indexView).toBeDefined()
     expect(indexView).not.toBeNull()
-    if (indexView === null) return;
+    if (indexView === null) return
     expect(indexView.nodes.find(n => n.id === 'sys1')?.color).toBe('green')
   })
 
@@ -1260,7 +1260,8 @@ describe.concurrent('LikeC4ModelBuilder', () => {
     // Compute view, because global styles are appied at this stage
     const indexView = await services.likec4.ModelBuilder.computeView('index' as ViewID)
     expect(indexView).toBeDefined()
-    if (indexView === null) return;
+    expect(indexView).not.toBeNull()
+    if (indexView === null) return
     expect(indexView.nodes.find(n => n.id === 'sys1')?.color).toBe('red')
   })
 
@@ -1294,7 +1295,8 @@ describe.concurrent('LikeC4ModelBuilder', () => {
     // Compute view, because global styles are appied at this stage
     const indexView = await services.likec4.ModelBuilder.computeView('index' as ViewID)
     expect(indexView).toBeDefined()
-    if (indexView === null) return;
+    expect(indexView).not.toBeNull()
+    if (indexView === null) return
     expect(indexView.nodes.find(n => n.id === 'sys1')?.color).toBe('green')
   })
 
@@ -1328,7 +1330,8 @@ describe.concurrent('LikeC4ModelBuilder', () => {
     // Compute view, because global styles are appied at this stage
     const indexView = await services.likec4.ModelBuilder.computeView('index' as ViewID)
     expect(indexView).toBeDefined()
-    if (indexView === null) return;
+    expect(indexView).not.toBeNull()
+    if (indexView === null) return
     expect(indexView.nodes.find(n => n.id === 'sys1')?.color).toBe('primary')
   })
 
@@ -1365,7 +1368,320 @@ describe.concurrent('LikeC4ModelBuilder', () => {
     // Compute view, because global styles are appied at this stage
     const indexView = await services.likec4.ModelBuilder.computeView('index' as ViewID)
     expect(indexView).toBeDefined()
-    if (indexView === null) return;
+    expect(indexView).not.toBeNull()
+    if (indexView === null) return
+    expect(indexView.nodes.find(n => n.id === 'sys1')?.color).toBe('green')
+  })
+
+  it('global style group is applied to a view', async ({ expect }) => {
+    const { validate, services } = createTestServices()
+    const { diagnostics } = await validate(`
+      specification {
+        element component
+      }
+      model {
+        component sys1
+        component sys2
+        sys1 -> sys2
+      }
+      views {
+        view index {
+          include sys1
+          global style style_group_name
+        }
+      }
+      global {
+        styleGroup style_group_name {
+          style * {
+            color green
+          }
+        }
+      }
+    `)
+    expect(diagnostics).toHaveLength(0)
+    // Compute view, because global styles are appied at this stage
+    const indexView = await services.likec4.ModelBuilder.computeView('index' as ViewID)
+    expect(indexView).toBeDefined()
+    expect(indexView).not.toBeNull()
+    if (indexView === null) return
+    expect(indexView.nodes.find(n => n.id === 'sys1')?.color).toBe('green')
+  })
+
+  it('global style group can be filtered on tags', async ({ expect }) => {
+    const { validate, services } = createTestServices()
+    const { diagnostics } = await validate(`
+      specification {
+        element component
+        tag deprecated
+      }
+      model {
+        component sys1
+        component sys2 {
+          #deprecated
+        }
+        sys1 -> sys2
+      }
+      views {
+        view index {
+          include *
+          global style style_group_name
+        }
+      }
+      global {
+        styleGroup style_group_name {
+          style * {
+            color green
+          }
+          style element.tag = #deprecated {
+            color muted
+          }
+        }
+      }
+    `)
+    expect(diagnostics).toHaveLength(0)
+    // Compute view, because global styles are appied at this stage
+    const indexView = await services.likec4.ModelBuilder.computeView('index' as ViewID)
+    expect(indexView).toBeDefined()
+    expect(indexView).not.toBeNull()
+    if (indexView === null) return
+    expect(indexView.nodes.find(n => n.id === 'sys1')?.color).toBe('green')
+    expect(indexView.nodes.find(n => n.id === 'sys2')?.color).toBe('muted')
+  })
+
+  it('global style group entreis are applied in order', async ({ expect }) => {
+    const { validate, services } = createTestServices()
+    const { diagnostics } = await validate(`
+      specification {
+        element component
+        tag deprecated
+      }
+      model {
+        component sys1
+        component sys2 {
+          #deprecated
+        }
+        sys1 -> sys2
+      }
+      views {
+        view index {
+          include *
+          global style style_group_name
+        }
+      }
+      global {
+        styleGroup style_group_name {
+          style element.tag = #deprecated {
+            color muted
+          }
+          style * {
+            color green
+          }
+        }
+      }
+    `)
+    expect(diagnostics).toHaveLength(0)
+    // Compute view, because global styles are appied at this stage
+    const indexView = await services.likec4.ModelBuilder.computeView('index' as ViewID)
+    expect(indexView).toBeDefined()
+    expect(indexView).not.toBeNull()
+    if (indexView === null) return
+    expect(indexView.nodes.find(n => n.id === 'sys1')?.color).toBe('green')
+    expect(indexView.nodes.find(n => n.id === 'sys2')?.color).toBe('green')
+  })
+
+  it('global style group is overwritten by further styles', async ({ expect }) => {
+    const { validate, services } = createTestServices()
+    const { diagnostics } = await validate(`
+      specification {
+        element component
+      }
+      model {
+        component sys1
+        component sys2
+        sys1 -> sys2
+      }
+      views {
+        view index {
+          include sys1
+          global style style_group_name
+          style * {
+            color secondary
+          }
+        }
+      }
+      global {
+        styleGroup style_group_name {
+          style * {
+            color green
+            opacity 10%
+          }
+        }
+      }
+    `)
+    expect(diagnostics).toHaveLength(0)
+    // Compute view, because global styles are appied at this stage
+    const indexView = await services.likec4.ModelBuilder.computeView('index' as ViewID)
+    expect(indexView).toBeDefined()
+    expect(indexView).not.toBeNull()
+    if (indexView === null) return
+    expect(indexView.nodes.find(n => n.id === 'sys1')?.color).toBe('secondary')
+    expect(indexView.nodes.find(n => n.id === 'sys1')?.style.opacity).toBe(10)
+  })
+
+  it('global style group overwrites previous styles', async ({ expect }) => {
+    const { validate, services } = createTestServices()
+    const { diagnostics } = await validate(`
+      specification {
+        element component
+      }
+      model {
+        component sys1
+        component sys2
+        sys1 -> sys2
+      }
+      views {
+        view index {
+          include sys1
+
+          style * {
+            color secondary
+            opacity 50%
+          }
+          global style style_group_name
+        }
+      }
+      global {
+        styleGroup style_group_name {
+          style * {
+            color green
+          }
+        }
+      }
+    `)
+    expect(diagnostics).toHaveLength(0)
+    // Compute view, because global styles are appied at this stage
+    const indexView = await services.likec4.ModelBuilder.computeView('index' as ViewID)
+    expect(indexView).toBeDefined()
+    expect(indexView).not.toBeNull()
+    if (indexView === null) return
+    expect(indexView.nodes.find(n => n.id === 'sys1')?.color).toBe('green')
+    expect(indexView.nodes.find(n => n.id === 'sys1')?.style.opacity).toBe(50)
+  })
+
+  it('global style group is not applied if missing', async ({ expect }) => {
+    const { validate, services } = createTestServices()
+    const { diagnostics } = await validate(`
+      specification {
+        element component
+      }
+      model {
+        component sys1
+        component sys2
+        sys1 -> sys2
+      }
+      views {
+        view index {
+          include sys1
+
+          style * {
+            color secondary
+          }
+          global style missing_style_group_name
+        }
+      }
+      global {
+        styleGroup style_group_name {
+          style * {
+            color green
+          }
+        }
+      }
+    `)
+    expect(diagnostics.length).toBeGreaterThan(0)
+    // Compute view, because global styles are appied at this stage
+    const indexView = await services.likec4.ModelBuilder.computeView('index' as ViewID)
+    expect(indexView).toBeDefined()
+    expect(indexView).not.toBeNull()
+    if (indexView === null) return
+    expect(indexView.nodes.find(n => n.id === 'sys1')?.color).toBe('secondary')
+  })
+
+  it('global style group can be applied with a global style', async ({ expect }) => {
+    const { validate, services } = createTestServices()
+    const { diagnostics } = await validate(`
+      specification {
+        element component
+      }
+      model {
+        component sys1
+        component sys2
+        sys1 -> sys2
+      }
+      views {
+        view index {
+          include sys1
+
+          global style style_group_name
+          global style style_name
+        }
+      }
+      global {
+        styleGroup style_group_name {
+          style * {
+            color green
+            opacity 70%
+          }
+        }
+        style style_name * {
+          color red
+        }
+      }
+    `)
+    expect(diagnostics.length).toBe(0)
+    // Compute view, because global styles are appied at this stage
+    const indexView = await services.likec4.ModelBuilder.computeView('index' as ViewID)
+    expect(indexView).toBeDefined()
+    expect(indexView).not.toBeNull()
+    if (indexView === null) return
+    expect(indexView.nodes.find(n => n.id === 'sys1')?.color).toBe('red')
+    expect(indexView.nodes.find(n => n.id === 'sys1')?.style.opacity).toBe(70)
+  })
+
+  it('global style group should not share a name with a global style', async ({ expect }) => {
+    const { validate, services } = createTestServices()
+    const { diagnostics } = await validate(`
+      specification {
+        element component
+      }
+      model {
+        component sys1
+        component sys2
+        sys1 -> sys2
+      }
+      views {
+        view index {
+          include sys1
+
+          global style repeated_style_name
+        }
+      }
+      global {
+        styleGroup repeated_style_name {
+          style * {
+            color green
+          }
+        }
+        style repeated_style_name * {
+          color red
+        }
+      }
+    `)
+    expect(diagnostics.length).toBeGreaterThan(0)
+    // Compute view, because global styles are appied at this stage
+    const indexView = await services.likec4.ModelBuilder.computeView('index' as ViewID)
+    expect(indexView).toBeDefined()
+    expect(indexView).not.toBeNull()
+    if (indexView === null) return
     expect(indexView.nodes.find(n => n.id === 'sys1')?.color).toBe('green')
   })
 })

--- a/packages/language-server/src/model/model-parser.ts
+++ b/packages/language-server/src/model/model-parser.ts
@@ -30,7 +30,7 @@ import {
   ViewOps
 } from '../ast'
 import { elementRef, getFqnElementRef } from '../elementRef'
-import { type NotationProperty } from '../generated/ast'
+import { isGlobalStyle, isGlobalStyleGroup, type NotationProperty } from '../generated/ast'
 import { logError, logger, logWarnError } from '../logger'
 import type { LikeC4Services } from '../module'
 import { stringHash } from '../utils'
@@ -291,7 +291,7 @@ export class LikeC4ModelParser {
     const styles = globals.flatMap(r => r.styles.filter(isValid))
     for (const style of styles) {
       try {
-        const globalStyleId = style.name as c4.GlobalStyleID
+        const globalStyleId = style.id.name as c4.GlobalStyleID
         if (!isTruthy(globalStyleId)) {
           continue
         }
@@ -299,13 +299,28 @@ export class LikeC4ModelParser {
           logger.warn(`Global style named "${globalStyleId}" is already defined`)
           continue
         }
-        c4Globals.styles[globalStyleId] = [
-          this.parseGlobalStyle(style, isValid)
-        ]
+
+        const styles = this.parseGlobalStyleOrGroup(style, isValid)
+        if (styles.length > 0) {
+          c4Globals.styles[globalStyleId] = styles as c4.NonEmptyArray<c4.ViewRuleStyle>
+        }
       } catch (e) {
         logWarnError(e)
       }
     }
+  }
+
+  private parseGlobalStyleOrGroup(
+    astRule: ast.GlobalStyle | ast.GlobalStyleGroup,
+    isValid: IsValidFn
+  ): c4.ViewRuleStyle[] {
+    if (ast.isGlobalStyle(astRule)) {
+      return [this.parseGlobalStyle(astRule, isValid)]
+    }
+    if (ast.isGlobalStyleGroup(astRule)) {
+      return astRule.styles.map(s => this.parseViewRuleStyle(s, isValid))
+    }
+    nonexhaustive(astRule)
   }
 
   private parseGlobalStyle(astRule: ast.GlobalStyle, isValid: IsValidFn): c4.ViewRuleStyle {
@@ -673,7 +688,7 @@ export class LikeC4ModelParser {
     }
   }
 
-  private parseViewRuleGlobalStyle(astRule: ast.ViewRuleGlobalStyle, isValid: IsValidFn): c4.ViewRuleGlobalStyle {
+  private parseViewRuleGlobalStyle(astRule: ast.ViewRuleGlobalStyle, _isValid: IsValidFn): c4.ViewRuleGlobalStyle {
     return {
       styleId: astRule.style.$refText as c4.GlobalStyleID
     }

--- a/packages/language-server/src/references/scope-computation.ts
+++ b/packages/language-server/src/references/scope-computation.ts
@@ -71,8 +71,9 @@ export class LikeC4ScopeComputation extends DefaultScopeComputation {
     }
     for (const globalStyleAst of globals.flatMap(g => g.styles)) {
       try {
-        if (isTruthy(globalStyleAst.name)) {
-          docExports.push(this.descriptions.createDescription(globalStyleAst, globalStyleAst.name, document))
+        const id = globalStyleAst.id
+        if (isTruthy(id.name)) {
+          docExports.push(this.descriptions.createDescription(id, id.name, document))
         }
       } catch (e) {
         logError(e)

--- a/packages/language-server/src/validation/index.ts
+++ b/packages/language-server/src/validation/index.ts
@@ -9,7 +9,7 @@ import { relationBodyChecks, relationChecks } from './relation'
 import {
   elementKindChecks,
   globalsChecks,
-  globalStyleChecks,
+  globalStyleIdChecks,
   modelRuleChecks,
   relationshipChecks,
   specificationRuleChecks,
@@ -34,7 +34,7 @@ export function registerValidationChecks(services: LikeC4Services) {
     SpecificationRule: specificationRuleChecks(services),
     Model: modelRuleChecks(services),
     Globals: globalsChecks(services),
-    GlobalStyle: globalStyleChecks(services),
+    GlobalStyleId: globalStyleIdChecks(services),
     DynamicViewStep: dynamicViewStep(services),
     LikeC4View: viewChecks(services),
     Element: elementChecks(services),

--- a/packages/language-server/src/validation/specification.ts
+++ b/packages/language-server/src/validation/specification.ts
@@ -130,18 +130,18 @@ export const relationshipChecks = (
   }
 }
 
-export const globalStyleChecks = (
+export const globalStyleIdChecks = (
   services: LikeC4Services
-): ValidationCheck<ast.GlobalStyle> => {
+): ValidationCheck<ast.GlobalStyleId> => {
   const index = services.shared.workspace.IndexManager
   return (node, accept) => {
     const sameName = index
-      .allElements(ast.GlobalStyle)
+      .allElements(ast.GlobalStyleId)
       .filter(s => s.name === node.name)
       .limit(2)
       .count()
     if (sameName > 1) {
-      accept('error', `Duplicate GlobalStyle name '${node.name}'`, {
+      accept('error', `Duplicate GlobalStyleId name '${node.name}'`, {
         node: node,
         property: 'name'
       })


### PR DESCRIPTION
Allow defining style groups with a set of style rules that can be applied to multiple views.

This is the 3rd PR of a series aiming to replace #1058