### PR TITLE
Fix 'control points are not draggable under the edge label' (#1104)

### DIFF
--- a/packages/diagram/src/xyflow/edges/RelationshipEdge.tsx
+++ b/packages/diagram/src/xyflow/edges/RelationshipEdge.tsx
@@ -438,11 +438,10 @@ export const RelationshipEdge = memo<EdgeProps<XYFlowEdge>>(function Relationshi
   const MarkerStart = markerStartName ? EdgeMarkers[markerStartName] : null
   const MarkerEnd = markerEndName ? EdgeMarkers[markerEndName] : null
 
-  let labelZIndex = 1 + (isHovered ? ZIndexes.Element : (edgeLookup.get(id)!.zIndex ?? ZIndexes.Edge))
-  if (isEdgePathEditable && selected) {
+  let labelZIndex = isEdgePathEditable
     // Move label below ControlPoints, otherwise they don't capture events
-    labelZIndex = (edgeLookup.get(id)!.zIndex ?? ZIndexes.Edge) - 1
-  }
+    ? (edgeLookup.get(id)!.zIndex ?? ZIndexes.Edge) - 1
+    : 1 + (isHovered ? ZIndexes.Element : (edgeLookup.get(id)!.zIndex ?? ZIndexes.Edge))
 
   return (
     <g

--- a/packages/diagram/src/xyflow/edges/RelationshipEdge.tsx
+++ b/packages/diagram/src/xyflow/edges/RelationshipEdge.tsx
@@ -137,7 +137,6 @@ const curve = d3line<XYPosition>()
 export const RelationshipEdge = memo<EdgeProps<XYFlowEdge>>(function RelationshipEdgeR({
   id,
   data,
-  selected,
   sourceX,
   sourceY,
   targetX,

--- a/packages/diagram/src/xyflow/edges/RelationshipEdge.tsx
+++ b/packages/diagram/src/xyflow/edges/RelationshipEdge.tsx
@@ -437,10 +437,18 @@ export const RelationshipEdge = memo<EdgeProps<XYFlowEdge>>(function Relationshi
   const MarkerStart = markerStartName ? EdgeMarkers[markerStartName] : null
   const MarkerEnd = markerEndName ? EdgeMarkers[markerEndName] : null
 
-  let labelZIndex = isEdgePathEditable
+  const edgeZIndex = edgeLookup.get(id)!.zIndex ?? ZIndexes.Edge
+  let labelZIndex
+  if (isEdgePathEditable) {
     // Move label below ControlPoints, otherwise they don't capture events
-    ? (edgeLookup.get(id)!.zIndex ?? ZIndexes.Edge) - 1
-    : 1 + (isHovered ? ZIndexes.Element : (edgeLookup.get(id)!.zIndex ?? ZIndexes.Edge))
+    labelZIndex = edgeZIndex - 1
+  }
+  else if (isHovered) {
+    // Move above the elements
+    labelZIndex = ZIndexes.Element + 1
+  } else {
+    labelZIndex = edgeZIndex + 1
+  }
 
   return (
     <g


### PR DESCRIPTION
Reordered layers in editing mode to allow dragging edge control points without selecting the edge. Tried to keep hover behavior as close as possible to the current implementation.
Before:
![before](https://github.com/user-attachments/assets/9e1797fa-69a1-495d-9a48-32645cff0a99)

After:
![after](https://github.com/user-attachments/assets/60555b15-dfa0-4c38-a68c-8e4e85d97ddd)
