### PR TITLE
feat: accept global styles as local styles

### DIFF
--- a/apps/docs/src/content/docs/dsl/views.mdx
+++ b/apps/docs/src/content/docs/dsl/views.mdx
@@ -721,6 +721,35 @@ views {
 }
 ```
 
+##### Shared global styles as shared local styles
+
+Global styles can be used as local styles:
+
+```likec4
+global {
+  // apply only to elements with a specific tag
+  style deprecated element.tag = #deprecated {
+    color muted
+  }
+
+  // apply to all elements
+  style all_elements * {
+    color muted
+    opacity 10%
+  }
+}
+
+views {
+  global style deprecated
+
+  view apiApp of internetBankingSystem.apiApplication {
+    include *
+
+    global style all_elements
+  }
+}
+```
+
 #### Shared style groups :badge[v1.15]{variant="success"}
 
 Global styles can be grouped and applied together:
@@ -763,6 +792,45 @@ views {
     }
     style element.tag != #deprecated {
       opacity 20%
+    }
+  }
+}
+```
+
+##### Shared style groups as local styles
+
+Global style groups can be used as local styles:
+
+```likec4
+global {
+  styleGroup common_styles {
+    style all_elements * {
+      color amber
+    }
+
+    style element.tag = #deprecated {
+      color muted
+    }
+
+    style element.tag != #undefined {
+      opacity 50%
+    }
+  }
+}
+
+views {
+  global style common_styles
+
+  view mobileApp of internetBankingSystem.mobileApplication {
+    include *
+  }
+
+  view apiApp of internetBankingSystem.apiApplication {
+    include *
+
+    // view-specific style predicates
+    style apiApplication.* {
+      color primary
     }
   }
 }

--- a/packages/core/src/types/view.ts
+++ b/packages/core/src/types/view.ts
@@ -54,6 +54,8 @@ export function isViewRuleGlobalStyle(rule: ViewRule): rule is ViewRuleGlobalSty
   return 'styleId' in rule
 }
 
+export type ViewRuleStyleOrGlobalRef = ViewRuleStyle | ViewRuleGlobalStyle
+
 export type AutoLayoutDirection = 'TB' | 'BT' | 'LR' | 'RL'
 export function isAutoLayoutDirection(autoLayout: unknown): autoLayout is AutoLayoutDirection {
   return autoLayout === 'TB' || autoLayout === 'BT' || autoLayout === 'LR' || autoLayout === 'RL'

--- a/packages/language-server/src/like-c4.langium
+++ b/packages/language-server/src/like-c4.langium
@@ -197,7 +197,7 @@ MetadataAttribute:
 ModelViews:
   name='views' '{' (
       views+=LikeC4ViewRule |
-      styles+=ViewRuleStyle
+      styles+=ViewRuleStyleOrGlobalRef
     )*
   '}';
 
@@ -268,8 +268,7 @@ ViewLayoutDirection returns string:
 ViewRule:
   ViewRulePredicate |
   ViewRuleGroup |
-  ViewRuleStyle |
-  ViewRuleGlobalStyle |
+  ViewRuleStyleOrGlobalRef |
   ViewRuleAutoLayout
 ;
 
@@ -288,8 +287,7 @@ ViewRuleGroup:
 
 DynamicViewRule:
   DynamicViewIncludePredicate |
-  ViewRuleStyle |
-  ViewRuleGlobalStyle |
+  ViewRuleStyleOrGlobalRef |
   ViewRuleAutoLayout
 ;
 
@@ -459,6 +457,9 @@ ViewRuleStyle:
 
 ViewRuleGlobalStyle:
   'global' 'style' style=[GlobalStyleId];
+
+ViewRuleStyleOrGlobalRef:
+  ViewRuleStyle | ViewRuleGlobalStyle;
 
 ViewRuleAutoLayout:
   'autoLayout' direction=ViewLayoutDirection (

--- a/packages/language-server/src/model/model-builder.spec.ts
+++ b/packages/language-server/src/model/model-builder.spec.ts
@@ -1684,4 +1684,140 @@ describe.concurrent('LikeC4ModelBuilder', () => {
     if (indexView === null) return
     expect(indexView.nodes.find(n => n.id === 'sys1')?.color).toBe('green')
   })
+
+  it('local styles can apply global styles', async ({ expect }) => {
+    const { validate, services } = createTestServices()
+    const { diagnostics } = await validate(`
+      specification {
+        element component
+      }
+      model {
+        component sys1
+        component sys2
+        sys1 -> sys2
+      }
+      views {
+        view index {
+          include sys1
+        }
+
+        view sys2 {
+          include sys2
+        }
+
+        global style global_style_name
+      }
+      global {
+        style global_style_name * {
+          color amber
+        }
+      }
+    `)
+    expect(diagnostics.length).toBe(0)
+    // Compute view, because global styles are appied at this stage
+    const indexView = await services.likec4.ModelBuilder.computeView('index' as ViewID)
+    expect(indexView).toBeDefined()
+    expect(indexView).not.toBeNull()
+    if (indexView === null) return
+    expect(indexView.nodes.find(n => n.id === 'sys1')?.color).toBe('amber')
+
+    const sys2View = await services.likec4.ModelBuilder.computeView('sys2' as ViewID)
+    expect(sys2View).toBeDefined()
+    expect(sys2View).not.toBeNull()
+    if (sys2View === null) return
+    expect(sys2View.nodes.find(n => n.id === 'sys2')?.color).toBe('amber')
+  })
+
+  it('local styles can apply global style groups', async ({ expect }) => {
+    const { validate, services } = createTestServices()
+    const { diagnostics } = await validate(`
+      specification {
+        element component
+      }
+      model {
+        component sys1
+        component sys2
+        sys1 -> sys2
+      }
+      views {
+        view index {
+          include sys1
+        }
+
+        view sys2 {
+          include sys2
+        }
+
+        global style global_style_group_name
+      }
+      global {
+        styleGroup global_style_group_name {
+          style * {
+            color amber
+          }
+        }
+      }
+    `)
+    expect(diagnostics.length).toBe(0)
+    // Compute view, because global styles are appied at this stage
+    const indexView = await services.likec4.ModelBuilder.computeView('index' as ViewID)
+    expect(indexView).toBeDefined()
+    expect(indexView).not.toBeNull()
+    if (indexView === null) return
+    expect(indexView.nodes.find(n => n.id === 'sys1')?.color).toBe('amber')
+
+    const sys2View = await services.likec4.ModelBuilder.computeView('sys2' as ViewID)
+    expect(sys2View).toBeDefined()
+    expect(sys2View).not.toBeNull()
+    if (sys2View === null) return
+    expect(sys2View.nodes.find(n => n.id === 'sys2')?.color).toBe('amber')
+  })
+
+  it('local styles are applied in order', async ({ expect }) => {
+    const { validate, services } = createTestServices()
+    const { diagnostics } = await validate(`
+      specification {
+        element component
+      }
+      model {
+        component sys1
+        component sys2
+        sys1 -> sys2
+      }
+      views {
+        view index {
+          include sys1
+        }
+
+        view sys2 {
+          include sys2
+        }
+
+        global style global_style_red
+        global style global_style_green
+      }
+      global {
+        style global_style_green * {
+          color green
+        }
+
+        style global_style_red * {
+          color red
+        }
+      }
+    `)
+    expect(diagnostics.length).toBe(0)
+    // Compute view, because global styles are appied at this stage
+    const indexView = await services.likec4.ModelBuilder.computeView('index' as ViewID)
+    expect(indexView).toBeDefined()
+    expect(indexView).not.toBeNull()
+    if (indexView === null) return
+    expect(indexView.nodes.find(n => n.id === 'sys1')?.color).toBe('green')
+
+    const sys2View = await services.likec4.ModelBuilder.computeView('sys2' as ViewID)
+    expect(sys2View).toBeDefined()
+    expect(sys2View).not.toBeNull()
+    if (sys2View === null) return
+    expect(sys2View.nodes.find(n => n.id === 'sys2')?.color).toBe('green')
+  })
 })

--- a/packages/language-server/src/model/model-parser.ts
+++ b/packages/language-server/src/model/model-parser.ts
@@ -334,7 +334,7 @@ export class LikeC4ModelParser {
     const viewBlocks = doc.parseResult.value.views.filter(v => isValid(v))
     for (const viewBlock of viewBlocks) {
       const localStyles = viewBlock.styles
-        .flatMap(s => this.parseViewRuleStyle(s, isValid))
+        .flatMap(s => this.parseViewRuleStyleOrGlobalRef(s, isValid))
       const stylesToApply = localStyles
 
       for (const view of viewBlock.views) {
@@ -653,17 +653,24 @@ export class LikeC4ModelParser {
     if (ast.isViewRulePredicate(astRule)) {
       return this.parseViewRulePredicate(astRule, isValid)
     }
-    if (ast.isViewRuleStyle(astRule)) {
-      return this.parseViewRuleStyle(astRule, isValid)
+    if (ast.isViewRuleStyleOrGlobalRef(astRule)) {
+      return this.parseViewRuleStyleOrGlobalRef(astRule, isValid)
     }
     if (ast.isViewRuleAutoLayout(astRule)) {
       return toAutoLayout(astRule)
     }
-    if (ast.isViewRuleGlobalStyle(astRule)) {
-      return this.parseViewRuleGlobalStyle(astRule, isValid)
-    }
     if (ast.isViewRuleGroup(astRule)) {
       return this.parseViewRuleGroup(astRule, isValid)
+    }
+    nonexhaustive(astRule)
+  }
+
+  private parseViewRuleStyleOrGlobalRef(astRule: ast.ViewRuleStyleOrGlobalRef, isValid: IsValidFn): c4.ViewRuleStyleOrGlobalRef {
+    if (ast.isViewRuleStyle(astRule)) {
+      return this.parseViewRuleStyle(astRule, isValid)
+    }
+    if (ast.isViewRuleGlobalStyle(astRule)) {
+      return this.parseViewRuleGlobalStyle(astRule, isValid)
     }
     nonexhaustive(astRule)
   }
@@ -824,7 +831,7 @@ export class LikeC4ModelParser {
 
   private parseElementView(
     astNode: ast.ElementView,
-    additionalStyles: c4.ViewRuleStyle[],
+    additionalStyles: c4.ViewRuleStyleOrGlobalRef[],
     isValid: IsValidFn
   ): ParsedAstElementView {
     const body = astNode.body
@@ -896,7 +903,7 @@ export class LikeC4ModelParser {
 
   private parseDynamicElementView(
     astNode: ast.DynamicView,
-    additionalStyles: c4.ViewRuleStyle[],
+    additionalStyles: c4.ViewRuleStyleOrGlobalRef[],
     isValid: IsValidFn
   ): ParsedAstDynamicView {
     const body = astNode.body
@@ -964,14 +971,11 @@ export class LikeC4ModelParser {
     if (ast.isDynamicViewIncludePredicate(astRule)) {
       return this.parseDynamicViewIncludePredicate(astRule, isValid)
     }
-    if (ast.isViewRuleStyle(astRule)) {
-      return this.parseViewRuleStyle(astRule, isValid)
+    if (ast.isViewRuleStyleOrGlobalRef(astRule)) {
+      return this.parseViewRuleStyleOrGlobalRef(astRule, isValid)
     }
     if (ast.isViewRuleAutoLayout(astRule)) {
       return toAutoLayout(astRule)
-    }
-    if (ast.isViewRuleGlobalStyle(astRule)) {
-      return this.parseViewRuleGlobalStyle(astRule, isValid)
     }
     nonexhaustive(astRule)
   }


### PR DESCRIPTION
Allow referencing global styles and groups as the local styles in the views {} blocks applicable to all views in a block.

This is the 4th PR of a series aiming to replace #1058