### PR TITLE
feat: global element and relation predicates

### DIFF
--- a/apps/docs/src/content/docs/dsl/views.mdx
+++ b/apps/docs/src/content/docs/dsl/views.mdx
@@ -469,6 +469,35 @@ Together with [extend views](#extend-views) you may define a "baseline" view (in
 
 :::
 
+#### Global predicates
+
+Element and relationship predicates can be defined in global groups.
+Each global group can be applied to multiple views.
+When a group is applied to a view, all predicates from the group are applied.
+
+```likec4
+global {
+  predicateGroup new_cloud_service {
+    include cloud.*
+      where kind is microservice
+    exclude *
+      where tag is #deprecated
+  }
+}
+
+views {
+  view of newServices {
+    include *
+    global predicate new_cloud_service
+  }
+
+  view of newBackendServices {
+    include *
+    global predicate new_cloud_service
+  }
+}
+```
+
 ### Groups :badge[v1.15]{variant="success"}
 
 It is possible to group elements, and this is rendered as a boundary around them:

--- a/packages/core/src/builder/Builder.ts
+++ b/packages/core/src/builder/Builder.ts
@@ -10,6 +10,8 @@ import {
   type ElementShape,
   type ElementView,
   type Fqn,
+  type GlobalDynamicElRel,
+  type GlobalElRel,
   type GlobalStyle,
   type IconUrl,
   isScopedElementView,
@@ -220,7 +222,13 @@ function builder<Spec extends BuilderSpecification, T extends AnyTypes>(
   spec: Spec,
   _elements = new Map<string, Element>(),
   _relations = [] as Relation[],
-  _globals = { styles: [] } as {
+  _globals = {
+    predicates: [],
+    dynamicPredicates: [],
+    styles: []
+  } as {
+    predicates: GlobalElRel[]
+    dynamicPredicates: GlobalDynamicElRel[]
     styles: GlobalStyle[]
   },
   _views = new Map<string, LikeC4View>()
@@ -344,6 +352,8 @@ function builder<Spec extends BuilderSpecification, T extends AnyTypes>(
       elements: fromEntries(Array.from(_elements.entries())) as any,
       relations: mapToObj(_relations, r => [r.id, r]),
       globals: {
+        predicates: mapToObj(_globals.predicates, p => [p.id, p]),
+        dynamicPredicates: mapToObj(_globals.dynamicPredicates, p => [p.id, p]),
         styles: mapToObj(_globals.styles, s => [s.id, s])
       },
       views: fromEntries(Array.from(_views.entries())) as any

--- a/packages/core/src/model/__test__/fixture.ts
+++ b/packages/core/src/model/__test__/fixture.ts
@@ -335,6 +335,8 @@ export const fakeComputedModel = {
   elements: fakeElements,
   relations: fakeRelations,
   globals: {
+    predicates: {},
+    dynamicPredicates: {},
     styles: {}
   },
   views: {}

--- a/packages/core/src/types/global.ts
+++ b/packages/core/src/types/global.ts
@@ -1,6 +1,18 @@
 import type { Tagged } from 'type-fest'
 import type { NonEmptyArray } from './_common'
-import type { ViewRuleStyle } from './view'
+import type { DynamicViewIncludeRule, ViewRulePredicate, ViewRuleStyle } from './view'
+
+export type GlobalElRelID = Tagged<string, 'GlobalElRelID'>
+
+export interface GlobalElRel {
+  readonly id: GlobalElRelID
+  readonly predicates: NonEmptyArray<ViewRulePredicate>
+}
+
+export interface GlobalDynamicElRel {
+  readonly id: GlobalElRelID
+  readonly dynamicPredicates: NonEmptyArray<DynamicViewIncludeRule>
+}
 
 export type GlobalStyleID = Tagged<string, 'GlobalStyleID'>
 

--- a/packages/core/src/types/model.ts
+++ b/packages/core/src/types/model.ts
@@ -1,5 +1,5 @@
 import type { ElementKindSpecification, Tag, TypedElement } from './element'
-import type { GlobalStyle, GlobalStyleID } from './global'
+import type { GlobalDynamicElRel, GlobalElRel, GlobalElRelID, GlobalStyle, GlobalStyleID } from './global'
 import type { Relation, RelationID, RelationshipKindSpecification } from './relation'
 import type { ComputedView, DiagramView, LikeC4View, ViewID } from './view'
 
@@ -20,10 +20,14 @@ export interface ParsedLikeC4Model<
   }
   elements: Record<Fqns, TypedElement<Fqns, ElementKinds, Tags>>
   relations: Record<RelationID, Relation>
-  globals: {
-    styles: Record<GlobalStyleID, GlobalStyle>
-  }
+  globals: ParsedGlobals
   views: Record<Views, LikeC4View<Views, Tags>>
+}
+
+export interface ParsedGlobals {
+  predicates: Record<GlobalElRelID, GlobalElRel>
+  dynamicPredicates: Record<GlobalElRelID, GlobalDynamicElRel>
+  styles: Record<GlobalStyleID, GlobalStyle>
 }
 
 /**

--- a/packages/core/src/types/view.ts
+++ b/packages/core/src/types/view.ts
@@ -11,7 +11,7 @@ import {
   type Tag
 } from './element'
 import type { ElementExpression, ElementPredicateExpression, Expression } from './expression'
-import type { GlobalStyleID } from './global'
+import type { GlobalElRelID, GlobalStyleID } from './global'
 import type { RelationID, RelationshipArrowType, RelationshipKind, RelationshipLineType } from './relation'
 import type { Color, ThemeColorValues } from './theme'
 import type { ElementNotation } from './view-notation'
@@ -32,6 +32,13 @@ export function isViewRulePredicate(rule: ViewRule): rule is ViewRulePredicate {
     ('include' in rule && Array.isArray(rule.include))
     || ('exclude' in rule && Array.isArray(rule.exclude))
   )
+}
+
+export interface ViewRuleGlobalPredicateRef {
+  predicateId: GlobalElRelID
+}
+export function isViewRuleGlobalPredicateRef(rule: ViewRule): rule is ViewRuleGlobalPredicateRef {
+  return 'predicateId' in rule
 }
 
 export interface ViewRuleStyle {
@@ -83,7 +90,13 @@ export function isViewRuleGroup(rule: ViewRule): rule is ViewRuleGroup {
   return 'title' in rule && 'groupRules' in rule && Array.isArray(rule.groupRules)
 }
 
-export type ViewRule = ViewRulePredicate | ViewRuleGroup | ViewRuleStyle | ViewRuleGlobalStyle | ViewRuleAutoLayout
+export type ViewRule =
+  | ViewRulePredicate
+  | ViewRuleGlobalPredicateRef
+  | ViewRuleGroup
+  | ViewRuleStyle
+  | ViewRuleGlobalStyle
+  | ViewRuleAutoLayout
 
 export interface BasicView<
   ViewType extends 'element' | 'dynamic',
@@ -178,7 +191,12 @@ export function isDynamicViewIncludeRule(rule: DynamicViewRule): rule is Dynamic
   return 'include' in rule && Array.isArray(rule.include)
 }
 
-export type DynamicViewRule = DynamicViewIncludeRule | ViewRuleStyle | ViewRuleGlobalStyle | ViewRuleAutoLayout
+export type DynamicViewRule =
+  | DynamicViewIncludeRule
+  | ViewRuleGlobalPredicateRef
+  | ViewRuleStyle
+  | ViewRuleGlobalStyle
+  | ViewRuleAutoLayout
 export interface DynamicView<
   ViewIDs extends string = string,
   Tags extends string = string

--- a/packages/language-server/src/ast.ts
+++ b/packages/language-server/src/ast.ts
@@ -94,6 +94,8 @@ export interface ParsedAstRelation {
 }
 
 export interface ParsedAstGlobals {
+  predicates: Record<c4.GlobalElRelID, c4.NonEmptyArray<c4.ViewRulePredicate>>
+  dynamicPredicates: Record<c4.GlobalElRelID, c4.NonEmptyArray<c4.DynamicViewIncludeRule>>
   styles: Record<c4.GlobalStyleID, c4.NonEmptyArray<c4.ViewRuleStyle>>
 }
 
@@ -196,6 +198,8 @@ export function cleanParsedModel(doc: LikeC4LangiumDocument) {
     c4Elements: [],
     c4Relations: [],
     c4Globals: {
+      predicates: {},
+      dynamicPredicates: {},
       styles: {}
     },
     c4Views: []
@@ -235,6 +239,8 @@ function validatableAstNodeGuards<const Predicates extends Guard<AstNode>[]>(
 }
 const isValidatableAstNode = validatableAstNodeGuards([
   ast.isGlobals,
+  ast.isGlobalPredicateGroup,
+  ast.isGlobalDynamicPredicateGroup,
   ast.isGlobalStyle,
   ast.isGlobalStyleGroup,
   ast.isDynamicViewPredicateIterator,

--- a/packages/language-server/src/like-c4.langium
+++ b/packages/language-server/src/like-c4.langium
@@ -267,6 +267,7 @@ ViewLayoutDirection returns string:
 
 ViewRule:
   ViewRulePredicate |
+  ViewRuleGlobalPredicateRef |
   ViewRuleGroup |
   ViewRuleStyleOrGlobalRef |
   ViewRuleAutoLayout
@@ -287,6 +288,7 @@ ViewRuleGroup:
 
 DynamicViewRule:
   DynamicViewIncludePredicate |
+  DynamicViewGlobalPredicateRef |
   ViewRuleStyleOrGlobalRef |
   ViewRuleAutoLayout
 ;
@@ -317,6 +319,9 @@ Predicate:
   RelationPredicate |
   ElementPredicate
 ;
+
+ViewRuleGlobalPredicateRef:
+  'global' 'predicate' predicate=[GlobalPredicateGroup];
 
 ElementPredicate:
   ElementPredicates;
@@ -443,6 +448,9 @@ DynamicViewIncludePredicate:
   'include' predicates=DynamicViewPredicateIterator
 ;
 
+DynamicViewGlobalPredicateRef:
+  'global' 'predicate' predicate=[GlobalDynamicPredicateGroup];
+
 DynamicViewPredicateIterator:
   value=ElementPredicate ({infer DynamicViewPredicateIterator.prev=current} ',' (value=ElementPredicate)?)*
 ;
@@ -506,8 +514,19 @@ RelationNavigateToProperty:
 Globals:
   name='global' '{'
     (
+      predicates+=(GlobalPredicateGroup | GlobalDynamicPredicateGroup)*
       styles+=(GlobalStyle | GlobalStyleGroup)*
     )*
+  '}';
+
+GlobalPredicateGroup:
+  'predicateGroup' name=IdTerminal '{'
+    predicates+=ViewRulePredicate*
+  '}';
+
+GlobalDynamicPredicateGroup:
+  'dynamicPredicateGroup' name=IdTerminal '{'
+    predicates+=DynamicViewIncludePredicate*
   '}';
 
 GlobalStyleId:

--- a/packages/language-server/src/lsp/CompletionProvider.spec.ts
+++ b/packages/language-server/src/lsp/CompletionProvider.spec.ts
@@ -332,9 +332,9 @@ describe.concurrent('LikeC4CompletionProvider', () => {
         'link',
         'include',
         'exclude',
+        'global',
         'group',
         'style',
-        'global',
         'autoLayout'
       ],
       disposeAfterCheck: true
@@ -372,9 +372,9 @@ describe.concurrent('LikeC4CompletionProvider', () => {
         'with',
         'include',
         'exclude',
+        'global',
         'group',
         'style',
-        'global',
         'autoLayout'
       ],
       disposeAfterCheck: true
@@ -529,9 +529,9 @@ describe.concurrent('LikeC4CompletionProvider', () => {
         'with',
         'include',
         'exclude',
+        'global',
         'group',
         'style',
-        'global',
         'autoLayout'
       ],
       disposeAfterCheck: true
@@ -592,9 +592,9 @@ describe.concurrent('LikeC4CompletionProvider', () => {
         'with',
         'include',
         'exclude',
+        'global',
         'group',
         'style',
-        'global',
         'autoLayout'
       ],
       disposeAfterCheck: true

--- a/packages/language-server/src/model/__snapshots__/model-builder.spec.ts.snap
+++ b/packages/language-server/src/model/__snapshots__/model-builder.spec.ts.snap
@@ -53,6 +53,8 @@ exports[`LikeC4ModelBuilder > builds model with description and technology 1`] =
     },
   },
   "globals": {
+    "dynamicPredicates": {},
+    "predicates": {},
     "styles": {},
   },
   "relations": {
@@ -211,6 +213,8 @@ exports[`LikeC4ModelBuilder > builds model with extend 1`] = `
     },
   },
   "globals": {
+    "dynamicPredicates": {},
+    "predicates": {},
     "styles": {},
   },
   "relations": {
@@ -525,6 +529,8 @@ exports[`LikeC4ModelBuilder > builds model with relationship spec and tag 1`] = 
     },
   },
   "globals": {
+    "dynamicPredicates": {},
+    "predicates": {},
     "styles": {},
   },
   "relations": {
@@ -651,6 +657,8 @@ exports[`LikeC4ModelBuilder > builds model with relationship spec with technolog
     },
   },
   "globals": {
+    "dynamicPredicates": {},
+    "predicates": {},
     "styles": {},
   },
   "relations": {
@@ -773,6 +781,8 @@ exports[`LikeC4ModelBuilder > builds model with styled relationship 1`] = `
     },
   },
   "globals": {
+    "dynamicPredicates": {},
+    "predicates": {},
     "styles": {},
   },
   "relations": {

--- a/packages/language-server/src/model/model-builder.spec.ts
+++ b/packages/language-server/src/model/model-builder.spec.ts
@@ -1801,4 +1801,74 @@ describe.concurrent('LikeC4ModelBuilder', () => {
     expect(indexView?.nodes.map(x => x.id)).toStrictEqual(['sys1', 'sys2', 'sys3'])
     expect(indexView?.edges.map(x => [x.id, x.color])).toStrictEqual([['sys1:sys2', 'red'], ['sys2:sys3', 'green']])
   })
+
+  it('global predicate groups are applied', async ({ expect }) => {
+    const { validate, buildModel } = createTestServices()
+    const { diagnostics } = await validate(`
+      specification {
+        element component
+        tag deprecated
+      }
+      model {
+        component sys1
+        component sys2 {
+          #deprecated
+        }
+        sys1 -> sys2
+      }
+      views {
+        view index {
+          include *
+          global predicate global_predicate_group_name
+        }
+      }
+      global {
+        predicateGroup global_predicate_group_name {
+          exclude * where tag is #deprecated
+        }
+      }
+    `)
+    expect(diagnostics.length).toBe(0)
+    const model = await buildModel()
+    const indexView = model?.views['index' as ViewID]!
+    expect(indexView).toBeDefined()
+    expect(indexView.nodes.find(n => n.id === 'sys1')?.color).toBe('primary')
+    expect(indexView.nodes.find(n => n.id === 'sys2')).toBeUndefined()
+  })
+
+  it('global dynamic predicate groups are applied', async ({ expect }) => {
+    const { validate, buildModel } = createTestServices()
+    const { diagnostics } = await validate(`
+      specification {
+        element component
+        tag important
+      }
+      model {
+        component sys1
+        component sys2
+        component sys3 {
+          #important
+        }
+        sys1 -> sys2
+      }
+      views {
+        dynamic view dynamic_view {
+          sys1 -> sys2 'performs an action'
+          global predicate global_predicate_group_name
+        }
+      }
+      global {
+        dynamicPredicateGroup global_predicate_group_name {
+          include sys3
+        }
+      }
+    `)
+    expect(diagnostics.length).toBe(0)
+    const model = await buildModel()
+    const dynamicView = model?.views['dynamic_view' as ViewID]!
+    expect(dynamicView).toBeDefined()
+    expect(dynamicView.nodes.find(n => n.id === 'sys1')).toBeDefined()
+    expect(dynamicView.nodes.find(n => n.id === 'sys2')).toBeDefined()
+    expect(dynamicView.nodes.find(n => n.id === 'sys3')).toBeDefined()
+  })
 })

--- a/packages/language-server/src/references/scope-computation.ts
+++ b/packages/language-server/src/references/scope-computation.ts
@@ -69,6 +69,16 @@ export class LikeC4ScopeComputation extends DefaultScopeComputation {
     if (isNullish(globals) || globals.length === 0) {
       return
     }
+    for (const globalPredicateAst of globals.flatMap(g => g.predicates)) {
+      try {
+        const id = globalPredicateAst
+        if (isTruthy(id.name)) {
+          docExports.push(this.descriptions.createDescription(id, id.name, document))
+        }
+      } catch (e) {
+        logError(e)
+      }
+    }
     for (const globalStyleAst of globals.flatMap(g => g.styles)) {
       try {
         const id = globalStyleAst.id

--- a/packages/language-server/src/validation/index.ts
+++ b/packages/language-server/src/validation/index.ts
@@ -8,6 +8,7 @@ import { iconPropertyRuleChecks, notesPropertyRuleChecks, opacityPropertyRuleChe
 import { relationBodyChecks, relationChecks } from './relation'
 import {
   elementKindChecks,
+  globalPredicateChecks,
   globalsChecks,
   globalStyleIdChecks,
   modelRuleChecks,
@@ -34,6 +35,8 @@ export function registerValidationChecks(services: LikeC4Services) {
     SpecificationRule: specificationRuleChecks(services),
     Model: modelRuleChecks(services),
     Globals: globalsChecks(services),
+    GlobalPredicateGroup: globalPredicateChecks(services),
+    GlobalDynamicPredicateGroup: globalPredicateChecks(services),
     GlobalStyleId: globalStyleIdChecks(services),
     DynamicViewStep: dynamicViewStep(services),
     LikeC4View: viewChecks(services),

--- a/packages/language-server/src/validation/specification.ts
+++ b/packages/language-server/src/validation/specification.ts
@@ -130,6 +130,27 @@ export const relationshipChecks = (
   }
 }
 
+export const globalPredicateChecks = (
+  services: LikeC4Services
+): ValidationCheck<ast.GlobalPredicateGroup | ast.GlobalDynamicPredicateGroup> => {
+  const index = services.shared.workspace.IndexManager
+  return (node, accept) => {
+    const predicateGroups = index.allElements(ast.GlobalPredicateGroup)
+    const dynamicPredicateGroups = index.allElements(ast.GlobalDynamicPredicateGroup)
+    const sameName = predicateGroups
+      .concat(dynamicPredicateGroups)
+      .filter(s => s.name === node.name)
+      .limit(2)
+      .count()
+    if (sameName > 1) {
+      accept('error', `Duplicate GlobalPredicateGroup or GlobalDynamicPredicateGroup name '${node.name}'`, {
+        node: node,
+        property: 'name'
+      })
+    }
+  }
+}
+
 export const globalStyleIdChecks = (
   services: LikeC4Services
 ): ValidationCheck<ast.GlobalStyleId> => {

--- a/packages/language-server/src/view-utils/resolve-global-rules.spec.ts
+++ b/packages/language-server/src/view-utils/resolve-global-rules.spec.ts
@@ -1,121 +1,310 @@
 import * as c4 from '@likec4/core'
+import exp from 'constants'
+import { prepareLangiumParser } from 'langium'
 import { describe, expect, it } from 'vitest'
 import { resolveGlobalRules } from './resolve-global-rules'
 
 describe('resolveGlobalRulesInViews', () => {
+  function generateElementView(): c4.ElementView {
+    return {
+      id: 'viewId' as c4.ViewID,
+      title: 'View Title',
+      description: 'View Description',
+      tags: null,
+      links: null,
+      customColorDefinitions: {},
+      rules: []
+    }
+  }
 
-  function generateGlobalStyles(): Record<c4.GlobalStyleID, c4.GlobalStyle> {
+  function emptyGlobals(): c4.ParsedGlobals {
+    return {
+      predicates: {},
+      dynamicPredicates: {},
+      styles: {}
+    }
+  }
+
+  function generateGlobals(): c4.ParsedGlobals {
+    const globalElRel: Record<c4.GlobalElRelID, c4.GlobalElRel> = {}
+
+    globalElRel['all' as c4.GlobalElRelID] = {
+      id: 'all' as c4.GlobalElRelID,
+      predicates: [{ include: [{ wildcard: true }] }]
+    }
+
+    globalElRel['exclude_deprecated' as c4.GlobalElRelID] = {
+      id: 'exclude_deprecated' as c4.GlobalElRelID,
+      predicates: [{ exclude: [{ elementTag: 'deprecated' as c4.Tag, isEqual: true }] }]
+    }
+
+    globalElRel['multiple' as c4.GlobalElRelID] = {
+      id: 'multiple' as c4.GlobalElRelID,
+      predicates: [
+        { include: [{ elementTag: 'api' as c4.Tag, isEqual: true }] },
+        { include: [{ element: 'backend' as c4.Fqn }] },
+        { exclude: [{ elementTag: 'deprecated' as c4.Tag, isEqual: true }] }
+      ]
+    }
+
+    globalElRel['relation' as c4.GlobalElRelID] = {
+      id: 'relation' as c4.GlobalElRelID,
+      predicates: [{
+        include: [{
+          source: { element: 'source' as c4.Fqn },
+          target: { element: 'target' as c4.Fqn }
+        }]
+      }]
+    }
+
     const globalStyles: Record<c4.GlobalStyleID, c4.GlobalStyle> = {}
 
     globalStyles['empty' as c4.GlobalStyleID] = {
-        id: 'empty' as c4.GlobalStyleID,
-        styles: [{
-            targets: [],
-            style: {},
-        }],
+      id: 'empty' as c4.GlobalStyleID,
+      styles: [{
+        targets: [],
+        style: {}
+      }]
     }
     globalStyles['all' as c4.GlobalStyleID] = {
-        id: 'all' as c4.GlobalStyleID,
-        styles: [{
-            targets: [{wildcard: true}],
-            style: {color: 'amber'},
-        }],
+      id: 'all' as c4.GlobalStyleID,
+      styles: [{
+        targets: [{ wildcard: true }],
+        style: { color: 'amber' }
+      }]
     }
     globalStyles['deprecated' as c4.GlobalStyleID] = {
-        id: 'deprecated' as c4.GlobalStyleID,
-        styles: [{
-            targets: [{elementTag: 'deprecated' as c4.Tag, isEqual: true}],
-            style: {color: 'red'},
-        }],
+      id: 'deprecated' as c4.GlobalStyleID,
+      styles: [{
+        targets: [{ elementTag: 'deprecated' as c4.Tag, isEqual: true }],
+        style: { color: 'red' }
+      }]
     }
     globalStyles['multiple' as c4.GlobalStyleID] = {
-        id: 'multiple' as c4.GlobalStyleID,
-        styles: [{
-            targets: [{elementTag: 'api' as c4.Tag, isEqual: true}],
-            style: {color: 'green'},
-        }, {
-            targets: [{wildcard: true}],
-            style: {color: 'muted'},
-        }],
+      id: 'multiple' as c4.GlobalStyleID,
+      styles: [{
+        targets: [{ elementTag: 'api' as c4.Tag, isEqual: true }],
+        style: { color: 'green' }
+      }, {
+        targets: [{ wildcard: true }],
+        style: { color: 'muted' }
+      }]
     }
 
-    return globalStyles
-  }
-
-  function generateElementView(): c4.ElementView {
     return {
-        id: 'viewId' as c4.ViewID,
-        title: 'View Title',
-        description: 'View Description',
-        tags: null,
-        links: null,
-        customColorDefinitions: {},
-        rules: [],
+      predicates: globalElRel,
+      dynamicPredicates: {},
+      styles: globalStyles
     }
   }
+
+  it('should keep empty rules list if no rules defined', () => {
+    const globals = emptyGlobals()
+    const unresolvedView: c4.ElementView = {
+      ...generateElementView(),
+      rules: []
+    }
+
+    const resolvedView = resolveGlobalRules(unresolvedView, globals)
+
+    expect(resolvedView.rules).toHaveLength(0)
+  })
+
+  it('should preserve element and relation predicates if no global predicates used', () => {
+    const globals = generateGlobals()
+    const unresolvedView: c4.ElementView = {
+      ...generateElementView(),
+      rules: [{
+        include: [{ element: 'elementId' as c4.Fqn }]
+      }]
+    }
+
+    const resolvedView = resolveGlobalRules(unresolvedView, globals)
+
+    expect(resolvedView.rules).toHaveLength(1)
+    expect(resolvedView.rules[0]).toBeDefined()
+    if (resolvedView.rules[0] === undefined) return
+
+    expect(c4.isViewRulePredicate(resolvedView.rules[0])).toBeTruthy()
+    if (!c4.isViewRulePredicate(resolvedView.rules[0])) return
+
+    expect(resolvedView.rules[0].include).toBeDefined()
+    if (resolvedView.rules[0].include === undefined) return
+
+    expect(resolvedView.rules[0].include).toHaveLength(1)
+    expect(resolvedView.rules[0].include[0]).toBeDefined()
+    if (resolvedView.rules[0].include[0] === undefined) return
+
+    expect(resolvedView.rules[0].include[0]).toEqual({ element: 'elementId' as c4.Fqn })
+  })
+
+  it('should replace global predicate id with a predicate', () => {
+    const globals = generateGlobals()
+    const unresolvedView: c4.ElementView = {
+      ...generateElementView(),
+      rules: [{
+        predicateId: 'all' as c4.GlobalElRelID
+      }]
+    }
+
+    const resolvedView = resolveGlobalRules(unresolvedView, globals)
+
+    expect(resolvedView.rules).toEqual(globals.predicates['all' as c4.GlobalElRelID]?.predicates)
+  })
+
+  it('should preserve resolved predicates and replace global predicate', () => {
+    const globals = generateGlobals()
+    const unresolvedView: c4.ElementView = {
+      ...generateElementView(),
+      rules: [{
+        exclude: [{ elementTag: 'obsolete' as c4.Tag, isEqual: true }]
+      }, {
+        predicateId: 'all' as c4.GlobalElRelID
+      }, {
+        include: [{ element: 'new' as c4.Fqn }]
+      }]
+    }
+
+    const resolvedView = resolveGlobalRules(unresolvedView, globals)
+
+    expect(resolvedView.rules).toHaveLength(3)
+
+    expect(resolvedView.rules[0]).toBeDefined()
+    if (resolvedView.rules[0] === undefined) return
+    expect(c4.isViewRulePredicate(resolvedView.rules[0])).toBeTruthy()
+    if (!c4.isViewRulePredicate(resolvedView.rules[0])) return
+    expect(resolvedView.rules[0].exclude).toEqual([{ elementTag: 'obsolete' as c4.Tag, isEqual: true }])
+
+    expect(resolvedView.rules[1]).toBeDefined()
+    if (resolvedView.rules[1] === undefined) return
+    const expectedPredicateList = globals.predicates['all' as c4.GlobalElRelID]
+    expect(expectedPredicateList).toBeDefined()
+    if (expectedPredicateList === undefined) return
+    expect(resolvedView.rules[1]).toEqual(expectedPredicateList.predicates[0])
+
+    expect(resolvedView.rules[2]).toBeDefined()
+    if (resolvedView.rules[2] === undefined) return
+    expect(c4.isViewRulePredicate(resolvedView.rules[2])).toBeTruthy()
+    if (!c4.isViewRulePredicate(resolvedView.rules[2])) return
+    expect(resolvedView.rules[2].include).toEqual([{ element: 'new' as c4.Fqn }])
+  })
+
+  it('should replace global predicate with all elements from the list', () => {
+    const globals = generateGlobals()
+    const unresolvedView: c4.ElementView = {
+      ...generateElementView(),
+      rules: [
+        { exclude: [{ elementTag: 'obsolete' as c4.Tag, isEqual: true }] },
+        { predicateId: 'multiple' as c4.GlobalElRelID },
+        { include: [{ element: 'new' as c4.Fqn }] }
+      ]
+    }
+
+    const resolvedView = resolveGlobalRules(unresolvedView, globals)
+
+    const expectedPredicateList = globals.predicates['multiple' as c4.GlobalElRelID]
+    expect(expectedPredicateList).toBeDefined()
+    if (expectedPredicateList === undefined) return
+
+    expect(resolvedView.rules).toHaveLength(2 + expectedPredicateList.predicates.length)
+
+    expect(resolvedView.rules[0]).toBeDefined()
+    if (resolvedView.rules[0] === undefined) return
+    expect(c4.isViewRulePredicate(resolvedView.rules[0])).toBeTruthy()
+    if (!c4.isViewRulePredicate(resolvedView.rules[0])) return
+    expect(resolvedView.rules[0].exclude).toEqual([{ elementTag: 'obsolete' as c4.Tag, isEqual: true }])
+
+    for (let expI = 0; expI < 3; expI++) {
+      expect(resolvedView.rules[expI + 1]).toBeDefined()
+      if (resolvedView.rules[expI + 1] === undefined) return
+      expect(resolvedView.rules[expI + 1]).toEqual(expectedPredicateList.predicates[expI])
+    }
+
+    expect(resolvedView.rules[4]).toBeDefined()
+    if (resolvedView.rules[4] === undefined) return
+    expect(c4.isViewRulePredicate(resolvedView.rules[4])).toBeTruthy()
+    if (!c4.isViewRulePredicate(resolvedView.rules[4])) return
+    expect(resolvedView.rules[4].include).toEqual([{ element: 'new' as c4.Fqn }])
+  })
+
+  it('should remove global predicate that does not exist', () => {
+    const globals = generateGlobals()
+    const unresolvedView: c4.ElementView = {
+      ...generateElementView(),
+      rules: [
+        { exclude: [{ elementTag: 'obsolete' as c4.Tag, isEqual: true }] },
+        { predicateId: 'missingPredicateId' as c4.GlobalElRelID },
+        { include: [{ element: 'new' as c4.Fqn }] }
+      ]
+    }
+
+    const resolvedView = resolveGlobalRules(unresolvedView, globals)
+
+    expect(resolvedView.rules).toHaveLength(2)
+
+    expect(resolvedView.rules[0]).toBeDefined()
+    if (resolvedView.rules[0] === undefined) return
+    expect(c4.isViewRulePredicate(resolvedView.rules[0])).toBeTruthy()
+    if (!c4.isViewRulePredicate(resolvedView.rules[0])) return
+    expect(resolvedView.rules[0].exclude).toEqual([{ elementTag: 'obsolete' as c4.Tag, isEqual: true }])
+
+    expect(resolvedView.rules[1]).toBeDefined()
+    if (resolvedView.rules[1] === undefined) return
+    expect(c4.isViewRulePredicate(resolvedView.rules[1])).toBeTruthy()
+    if (!c4.isViewRulePredicate(resolvedView.rules[1])) return
+    expect(resolvedView.rules[1].include).toEqual([{ element: 'new' as c4.Fqn }])
+  })
 
   it('should preserve styles if no global styles used', () => {
-    const globalStyles = generateGlobalStyles()
+    const globals = generateGlobals()
     const unresolvedView: c4.ElementView = {
-        ...generateElementView(),
-        rules: [{
-            targets: [{wildcard: true}],
-            style: {color: 'green'},
-        }],
+      ...generateElementView(),
+      rules: [{
+        targets: [{ wildcard: true }],
+        style: { color: 'green' }
+      }]
     }
 
-    const resolvedView = resolveGlobalRules(unresolvedView, globalStyles)
+    const resolvedView = resolveGlobalRules(unresolvedView, globals)
 
     expect(resolvedView.rules).toHaveLength(1)
     expect(resolvedView.rules[0]).toBeDefined()
     if (resolvedView.rules[0] === undefined) return
     expect(c4.isViewRuleStyle(resolvedView.rules[0])).toBeTruthy()
     if (!c4.isViewRuleStyle(resolvedView.rules[0])) return
-    expect(resolvedView.rules[0].style).toEqual({color: 'green'})
-  })
-
-  it('should keep empty rules list if no rules defined', () => {
-    const globalStyles = {}
-    const unresolvedView: c4.ElementView = {
-        ...generateElementView(),
-        rules: [],
-    }
-
-    const resolvedView = resolveGlobalRules(unresolvedView, globalStyles)
-
-    expect(resolvedView.rules).toHaveLength(0)
+    expect(resolvedView.rules[0].style).toEqual({ color: 'green' })
   })
 
   it('should replace global style id with a style', () => {
-    const globalStyles = generateGlobalStyles()
+    const globals = generateGlobals()
     const unresolvedView: c4.ElementView = {
-        ...generateElementView(),
-        rules: [{
-            styleId: 'all' as c4.GlobalStyleID,
-        }],
+      ...generateElementView(),
+      rules: [{
+        styleId: 'all' as c4.GlobalStyleID
+      }]
     }
 
-    const resolvedView = resolveGlobalRules(unresolvedView, globalStyles)
+    const resolvedView = resolveGlobalRules(unresolvedView, globals)
 
-    expect(resolvedView.rules).toEqual(globalStyles['all' as c4.GlobalStyleID]?.styles)
+    expect(resolvedView.rules).toEqual(globals.styles['all' as c4.GlobalStyleID]?.styles)
   })
 
   it('should preserve resolved styles and replace global style', () => {
-    const globalStyles = generateGlobalStyles()
+    const globals = generateGlobals()
     const unresolvedView: c4.ElementView = {
-        ...generateElementView(),
-        rules: [{
-                targets: [{wildcard: true}],
-                style: {color: 'secondary'},
-            }, {
-                styleId: 'all' as c4.GlobalStyleID,
-            }, {
-                targets: [{elementTag: 'new' as c4.Tag, isEqual: true}],
-                style: {color: 'green'},
-            }],
+      ...generateElementView(),
+      rules: [{
+        targets: [{ wildcard: true }],
+        style: { color: 'secondary' }
+      }, {
+        styleId: 'all' as c4.GlobalStyleID
+      }, {
+        targets: [{ elementTag: 'new' as c4.Tag, isEqual: true }],
+        style: { color: 'green' }
+      }]
     }
 
-    const resolvedView = resolveGlobalRules(unresolvedView, globalStyles)
+    const resolvedView = resolveGlobalRules(unresolvedView, globals)
 
     expect(resolvedView.rules).toHaveLength(3)
 
@@ -123,11 +312,11 @@ describe('resolveGlobalRulesInViews', () => {
     if (resolvedView.rules[0] === undefined) return
     expect(c4.isViewRuleStyle(resolvedView.rules[0])).toBeTruthy()
     if (!c4.isViewRuleStyle(resolvedView.rules[0])) return
-    expect(resolvedView.rules[0].style).toEqual({color: 'secondary'})
+    expect(resolvedView.rules[0].style).toEqual({ color: 'secondary' })
 
     expect(resolvedView.rules[1]).toBeDefined()
     if (resolvedView.rules[1] === undefined) return
-    const expectedStyleList = globalStyles['all' as c4.GlobalStyleID]
+    const expectedStyleList = globals.styles['all' as c4.GlobalStyleID]
     expect(expectedStyleList).toBeDefined()
     if (expectedStyleList === undefined) return
     expect(resolvedView.rules[1]).toEqual(expectedStyleList.styles[0])
@@ -136,25 +325,25 @@ describe('resolveGlobalRulesInViews', () => {
     if (resolvedView.rules[2] === undefined) return
     expect(c4.isViewRuleStyle(resolvedView.rules[2])).toBeTruthy()
     if (!c4.isViewRuleStyle(resolvedView.rules[2])) return
-    expect(resolvedView.rules[2].style).toEqual({color: 'green'})
+    expect(resolvedView.rules[2].style).toEqual({ color: 'green' })
   })
 
   it('should replace global style with all elements from the list', () => {
-    const globalStyles = generateGlobalStyles()
+    const globals = generateGlobals()
     const unresolvedView: c4.ElementView = {
-        ...generateElementView(),
-        rules: [{
-                targets: [{wildcard: true}],
-                style: {color: 'secondary'},
-            }, {
-                styleId: 'multiple' as c4.GlobalStyleID,
-            }, {
-                targets: [{elementTag: 'new' as c4.Tag, isEqual: true}],
-                style: {color: 'green'},
-            }],
+      ...generateElementView(),
+      rules: [{
+        targets: [{ wildcard: true }],
+        style: { color: 'secondary' }
+      }, {
+        styleId: 'multiple' as c4.GlobalStyleID
+      }, {
+        targets: [{ elementTag: 'new' as c4.Tag, isEqual: true }],
+        style: { color: 'green' }
+      }]
     }
 
-    const resolvedView = resolveGlobalRules(unresolvedView, globalStyles)
+    const resolvedView = resolveGlobalRules(unresolvedView, globals)
 
     expect(resolvedView.rules).toHaveLength(4)
 
@@ -162,11 +351,11 @@ describe('resolveGlobalRulesInViews', () => {
     if (resolvedView.rules[0] === undefined) return
     expect(c4.isViewRuleStyle(resolvedView.rules[0])).toBeTruthy()
     if (!c4.isViewRuleStyle(resolvedView.rules[0])) return
-    expect(resolvedView.rules[0].style).toEqual({color: 'secondary'})
+    expect(resolvedView.rules[0].style).toEqual({ color: 'secondary' })
 
     expect(resolvedView.rules[1]).toBeDefined()
     if (resolvedView.rules[1] === undefined) return
-    const expectedStyleList = globalStyles['multiple' as c4.GlobalStyleID]
+    const expectedStyleList = globals.styles['multiple' as c4.GlobalStyleID]
     expect(expectedStyleList).toBeDefined()
     if (expectedStyleList === undefined) return
     expect(resolvedView.rules[1]).toEqual(expectedStyleList.styles[0])
@@ -176,25 +365,25 @@ describe('resolveGlobalRulesInViews', () => {
     if (resolvedView.rules[3] === undefined) return
     expect(c4.isViewRuleStyle(resolvedView.rules[3])).toBeTruthy()
     if (!c4.isViewRuleStyle(resolvedView.rules[3])) return
-    expect(resolvedView.rules[3].style).toEqual({color: 'green'})
+    expect(resolvedView.rules[3].style).toEqual({ color: 'green' })
   })
 
   it('should remove global style that does not exist', () => {
-    const globalStyles = generateGlobalStyles()
+    const globals = generateGlobals()
     const unresolvedView: c4.ElementView = {
-        ...generateElementView(),
-        rules: [{
-                targets: [{wildcard: true}],
-                style: {color: 'secondary'},
-            }, {
-                styleId: 'missingStyleId' as c4.GlobalStyleID,
-            }, {
-                targets: [{elementTag: 'new' as c4.Tag, isEqual: true}],
-                style: {color: 'green'},
-            }],
+      ...generateElementView(),
+      rules: [{
+        targets: [{ wildcard: true }],
+        style: { color: 'secondary' }
+      }, {
+        styleId: 'missingStyleId' as c4.GlobalStyleID
+      }, {
+        targets: [{ elementTag: 'new' as c4.Tag, isEqual: true }],
+        style: { color: 'green' }
+      }]
     }
 
-    const resolvedView = resolveGlobalRules(unresolvedView, globalStyles)
+    const resolvedView = resolveGlobalRules(unresolvedView, globals)
 
     expect(resolvedView.rules).toHaveLength(2)
 
@@ -202,42 +391,111 @@ describe('resolveGlobalRulesInViews', () => {
     if (resolvedView.rules[0] === undefined) return
     expect(c4.isViewRuleStyle(resolvedView.rules[0])).toBeTruthy()
     if (!c4.isViewRuleStyle(resolvedView.rules[0])) return
-    expect(resolvedView.rules[0].style).toEqual({color: 'secondary'})
+    expect(resolvedView.rules[0].style).toEqual({ color: 'secondary' })
 
     expect(resolvedView.rules[1]).toBeDefined()
     if (resolvedView.rules[1] === undefined) return
     expect(c4.isViewRuleStyle(resolvedView.rules[1])).toBeTruthy()
     if (!c4.isViewRuleStyle(resolvedView.rules[1])) return
-    expect(resolvedView.rules[1].style).toEqual({color: 'green'})
+    expect(resolvedView.rules[1].style).toEqual({ color: 'green' })
   })
 
-  it('should preserve styles with empty global styles list', () => {
-    const globalStyles = {}
+  it('shold replace element, relation, and style predicates', () => {
+    const globals = generateGlobals()
     const unresolvedView: c4.ElementView = {
-        ...generateElementView(),
-        rules: [{
-                targets: [{wildcard: true}],
-                style: {color: 'secondary'},
-            }, {
-                targets: [{elementTag: 'new' as c4.Tag, isEqual: true}],
-                style: {color: 'green'},
-            }],
+      ...generateElementView(),
+      rules: [
+        { exclude: [{ elementTag: 'obsolete' as c4.Tag, isEqual: true }] },
+        { predicateId: 'all' as c4.GlobalElRelID },
+        { include: [{ element: 'new' as c4.Fqn }] },
+        { styleId: 'all' as c4.GlobalStyleID },
+        { predicateId: 'relation' as c4.GlobalElRelID }
+      ]
     }
 
-    const resolvedView = resolveGlobalRules(unresolvedView, globalStyles)
+    const resolvedView = resolveGlobalRules(unresolvedView, globals)
 
-    expect(resolvedView.rules).toHaveLength(2)
+    const expectedPredicateList = globals.predicates
+
+    expect(resolvedView.rules).toHaveLength(5)
+
+    expect(resolvedView.rules[0]).toBeDefined()
+    if (resolvedView.rules[0] === undefined) return
+    expect(c4.isViewRulePredicate(resolvedView.rules[0])).toBeTruthy()
+    if (!c4.isViewRulePredicate(resolvedView.rules[0])) return
+    expect(resolvedView.rules[0].exclude).toEqual([{ elementTag: 'obsolete' as c4.Tag, isEqual: true }])
+
+    expect(resolvedView.rules[1]).toBeDefined()
+    if (resolvedView.rules[1] === undefined) return
+    const expectedPredicate = expectedPredicateList['all' as c4.GlobalElRelID]
+    expect(expectedPredicate).toBeDefined()
+    if (expectedPredicate === undefined) return
+    expect(resolvedView.rules[1]).toEqual(expectedPredicate.predicates[0])
+
+    expect(resolvedView.rules[2]).toBeDefined()
+    if (resolvedView.rules[2] === undefined) return
+    expect(c4.isViewRulePredicate(resolvedView.rules[2])).toBeTruthy()
+    if (!c4.isViewRulePredicate(resolvedView.rules[2])) return
+    expect(resolvedView.rules[2].include).toEqual([{ element: 'new' as c4.Fqn }])
+
+    expect(resolvedView.rules[3]).toBeDefined()
+    if (resolvedView.rules[3] === undefined) return
+    const expectedStyleList = globals.styles['all' as c4.GlobalStyleID]
+    expect(expectedStyleList).toBeDefined()
+    if (expectedStyleList === undefined) return
+    expect(resolvedView.rules[3]).toEqual(expectedStyleList.styles[0])
+
+    expect(resolvedView.rules[4]).toBeDefined()
+    if (resolvedView.rules[4] === undefined) return
+    const expectedRelationPredicate = expectedPredicateList['relation' as c4.GlobalElRelID]
+    expect(expectedRelationPredicate).toBeDefined()
+    if (expectedRelationPredicate === undefined) return
+    expect(resolvedView.rules[4]).toEqual(expectedRelationPredicate.predicates[0])
+  })
+
+  it('should preserve rules if global rules list is empty', () => {
+    const globals = emptyGlobals()
+    const unresolvedView: c4.ElementView = {
+      ...generateElementView(),
+      rules: [{
+        targets: [{ wildcard: true }],
+        style: { color: 'secondary' }
+      }, {
+        targets: [{ elementTag: 'new' as c4.Tag, isEqual: true }],
+        style: { color: 'green' }
+      }, {
+        include: [{ element: 'new' as c4.Fqn }]
+      }, {
+        exclude: [{ elementTag: 'obsolete' as c4.Tag, isEqual: true }]
+      }]
+    }
+
+    const resolvedView = resolveGlobalRules(unresolvedView, globals)
+
+    expect(resolvedView.rules).toHaveLength(4)
 
     expect(resolvedView.rules[0]).toBeDefined()
     if (resolvedView.rules[0] === undefined) return
     expect(c4.isViewRuleStyle(resolvedView.rules[0])).toBeTruthy()
     if (!c4.isViewRuleStyle(resolvedView.rules[0])) return
-    expect(resolvedView.rules[0].style).toEqual({color: 'secondary'})
+    expect(resolvedView.rules[0].style).toEqual({ color: 'secondary' })
 
     expect(resolvedView.rules[1]).toBeDefined()
     if (resolvedView.rules[1] === undefined) return
     expect(c4.isViewRuleStyle(resolvedView.rules[1])).toBeTruthy()
     if (!c4.isViewRuleStyle(resolvedView.rules[1])) return
-    expect(resolvedView.rules[1].style).toEqual({color: 'green'})
+    expect(resolvedView.rules[1].style).toEqual({ color: 'green' })
+
+    expect(resolvedView.rules[2]).toBeDefined()
+    if (resolvedView.rules[2] === undefined) return
+    expect(c4.isViewRulePredicate(resolvedView.rules[2])).toBeTruthy()
+    if (!c4.isViewRulePredicate(resolvedView.rules[2])) return
+    expect(resolvedView.rules[2].include).toEqual([{ element: 'new' as c4.Fqn }])
+
+    expect(resolvedView.rules[3]).toBeDefined()
+    if (resolvedView.rules[3] === undefined) return
+    expect(c4.isViewRulePredicate(resolvedView.rules[3])).toBeTruthy()
+    if (!c4.isViewRulePredicate(resolvedView.rules[3])) return
+    expect(resolvedView.rules[3].exclude).toEqual([{ elementTag: 'obsolete' as c4.Tag, isEqual: true }])
   })
 })

--- a/packages/vscode-preview/src/state.ts
+++ b/packages/vscode-preview/src/state.ts
@@ -105,6 +105,8 @@ const EMPTY: ComputedLikeC4Model = {
   elements: {},
   relations: {},
   globals: {
+    predicates: {},
+    dynamicPredicates: {},
     styles: {}
   },
   views: {}


### PR DESCRIPTION
This feature is intended for reusable include / exclude sequences

Architecture documentation can contain multiple views sharing the same set of repeated include and exclude sequences. Instead of repeating this set, the maintenance gets easier when the set is defined once and applied to all relevant views.

This feature allows for defining "global predicate groups" that can contain a list of include and exclude predicates. Each group can be explicitly applied to any view.

This is the 5th and final PR in the series replacing #1058 