### PR TITLE
feat: traverse symlinks in the workspace

### DIFF
--- a/packages/language-server/src/index.ts
+++ b/packages/language-server/src/index.ts
@@ -1,5 +1,6 @@
+import { URI, UriUtils } from 'langium'
 import { startLanguageServer as startLanguim } from 'langium/lsp'
-import { NodeFileSystem } from 'langium/node'
+import { NodeFileSystemProvider } from 'langium/node'
 import { createConnection, ProposedFeatures } from 'vscode-languageserver/node'
 import { createLanguageServices } from './module'
 
@@ -8,12 +9,16 @@ export type * from './model'
 export type * from './module'
 export { createCustomLanguageServices, createLanguageServices, LikeC4Module } from './module'
 
+import type { FileSystemNode } from 'langium'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+
 export function startLanguageServer() {
   /* browser specific setup code */
   const connection = createConnection(ProposedFeatures.all)
 
   // Inject the shared services and language-specific services
-  const services = createLanguageServices({ connection, ...NodeFileSystem })
+  const services = createLanguageServices({ connection, ...LikeC4FileSystem })
 
   // Start the language server with the shared services
   startLanguim(services.shared)
@@ -21,5 +26,32 @@ export function startLanguageServer() {
   return {
     ...services,
     connection
+  }
+}
+
+export const LikeC4FileSystem = {
+  fileSystemProvider: () => new SymLinkTraversingFileSystemProvider()
+}
+
+class SymLinkTraversingFileSystemProvider extends NodeFileSystemProvider {
+  override async readDirectory(folderPath: URI): Promise<FileSystemNode[]> {
+    const dirents = await fs.promises.readdir(folderPath.fsPath, { withFileTypes: true })
+    return dirents.map(dirent => (this.followUri(UriUtils.joinPath(folderPath, dirent.name))))
+  }
+
+  followUri(uri: URI): FileSystemNode {
+    const directoryPath = path.dirname(uri.fsPath)
+    const stat = fs.lstatSync(uri.fsPath)
+    if (stat.isSymbolicLink()) {
+      const resolved_link = fs.readlinkSync(uri.fsPath)
+      const linked_path = path.resolve(directoryPath, resolved_link)
+      return this.followUri(URI.file(linked_path))
+    } else {
+      return {
+        isFile: stat.isFile(),
+        isDirectory: stat.isDirectory(),
+        uri
+      }
+    }
   }
 }

--- a/packages/likec4/src/language/module.ts
+++ b/packages/likec4/src/language/module.ts
@@ -1,10 +1,15 @@
-import { createCustomLanguageServices, type LikeC4Services, lspLogger, setLogLevel } from '@likec4/language-server'
+import {
+  createCustomLanguageServices,
+  LikeC4FileSystem,
+  type LikeC4Services,
+  lspLogger,
+  setLogLevel
+} from '@likec4/language-server'
 import { GraphvizLayouter, GraphvizWasmAdapter } from '@likec4/layouts'
 import { GraphvizBinaryAdapter } from '@likec4/layouts/graphviz/binary'
 import { consola, LogLevels } from '@likec4/log'
 import defu from 'defu'
 import type { DeepPartial, Module } from 'langium'
-import { NodeFileSystem } from 'langium/node'
 import { isError } from 'remeda'
 import k from 'tinyrainbow'
 import type { Constructor } from 'type-fest'
@@ -139,5 +144,5 @@ export function createLanguageServices(opts?: CreateLanguageServiceOptions): Cli
     }])
   }
 
-  return createCustomLanguageServices(options.useFileSystem ? NodeFileSystem : {}, CliModule, module).likec4
+  return createCustomLanguageServices(options.useFileSystem ? LikeC4FileSystem : {}, CliModule, module).likec4
 }


### PR DESCRIPTION
A likeC4 workspace can contain symbolic links to documents shared between multiple workspaces. The WorspaceManager is enhanced to traverse through symbolic links to correctly include documents linked by symbolic links.