### PR TITLE
'Smart Layout' commands

### DIFF
--- a/packages/diagram/package.json
+++ b/packages/diagram/package.json
@@ -27,7 +27,8 @@
   "scripts": {
     "typecheck": "tsc --noEmit",
     "lint": "run -T eslint src/ --fix",
-    "clean": "rm -r -f -g 'dist/*' .tsbuildinfo"
+    "clean": "rm -r -f -g 'dist/*' .tsbuildinfo",
+    "test": "vitest run --no-isolate"
   },
   "dependencies": {
     "@dagrejs/dagre": "^1.1.4",
@@ -68,6 +69,7 @@
     "execa": "^9.3.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "typescript": "^5.6.3"
+    "typescript": "^5.6.3",
+    "vitest": "^2.1.4"
   }
 }

--- a/packages/diagram/src/state/aligners.spec.ts
+++ b/packages/diagram/src/state/aligners.spec.ts
@@ -119,5 +119,27 @@ describe('aligners', () => {
       expect(aligner.applyPosition(nodeRects[7]!)).toEqual({ x: 120, y: 40 })
       expect(aligner.applyPosition(nodeRects[8]!)).toEqual({ x: 155, y: 40 })
     })
+
+    it('spreads rows evenly', () => {
+      const nodeRects = [
+        n('a', 0, 0),
+        n('b', 0, 40),
+        n('c', 0, 80),
+        n('d', 0, 120),
+        n('e', 40, 120),
+        n('f', 0, 160)
+      ]
+
+      const aligner = new GridAligner('Row')
+
+      aligner.computeLayout(nodeRects)
+
+      expect(aligner.applyPosition(nodeRects[0]!).y).toEqual(0)
+      expect(aligner.applyPosition(nodeRects[1]!).y).toEqual(40)
+      expect(aligner.applyPosition(nodeRects[2]!).y).toEqual(80)
+      expect(aligner.applyPosition(nodeRects[3]!).y).toEqual(120)
+      expect(aligner.applyPosition(nodeRects[4]!).y).toEqual(120)
+      expect(aligner.applyPosition(nodeRects[5]!).y).toEqual(160)
+    })
   })
 })

--- a/packages/diagram/src/state/aligners.spec.ts
+++ b/packages/diagram/src/state/aligners.spec.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest'
+import { GridAligner, type NodeRect } from './aligners'
+
+const placementError = 5
+
+function n(id: string, x: number, y: number, width = 20, height = 20): NodeRect {
+  return {
+    id,
+    x,
+    y,
+    width,
+    height
+  }
+}
+
+describe('aligners', () => {
+  describe('GridAligner', () => {
+    it('centers node if there is only one node in a row', () => {
+      const nodeRects = [
+        n('a', 0, 0),
+        n('b', 80, 40)
+      ]
+
+      const aligner = new GridAligner('Row')
+
+      aligner.computeLayout(nodeRects)
+
+      expect(aligner.applyPosition(nodeRects[0]!)).toEqual({ x: 40, y: 0 })
+      expect(aligner.applyPosition(nodeRects[1]!)).toEqual({ x: 40, y: 40 })
+    })
+
+    it('groups overlapping nodes in a row and aligns top', () => {
+      const nodeRects = [
+        n('a', 0, 10),
+        n('b', 40, 20),
+        n('c', 80, 30)
+      ]
+
+      const aligner = new GridAligner('Row')
+
+      aligner.computeLayout(nodeRects)
+
+      expect(aligner.applyPosition(nodeRects[0]!).y).toEqual(10)
+      expect(aligner.applyPosition(nodeRects[1]!).y).toEqual(10)
+      expect(aligner.applyPosition(nodeRects[2]!).y).toEqual(10)
+    })
+
+    it('spreads nodes in a row with equal space if this fits best to original layout', () => {
+      const nodeRects = [
+        n('a', 0, 0),
+        n('b', 20, 0),
+        n('c', 80, 0)
+      ]
+
+      const aligner = new GridAligner('Row')
+
+      aligner.computeLayout(nodeRects)
+
+      expect(aligner.applyPosition(nodeRects[0]!)).toEqual({ x: 0, y: 0 })
+      expect(aligner.applyPosition(nodeRects[1]!)).toEqual({ x: 40, y: 0 })
+      expect(aligner.applyPosition(nodeRects[2]!)).toEqual({ x: 80, y: 0 })
+    })
+
+    it('aligns with nodes in previous row if this fits best to original layout', () => {
+      const nodeRects = [
+        n('a', 0, 0),
+        n('b', 40, 0),
+        n('c', 80, 0),
+        n('d', 120, 0),
+        n('e', 40 + placementError, 40),
+        n('f', 80 - placementError, 40)
+      ]
+
+      const aligner = new GridAligner('Row')
+
+      aligner.computeLayout(nodeRects)
+
+      expect(aligner.applyPosition(nodeRects[4]!)).toEqual({ x: 40, y: 40 })
+      expect(aligner.applyPosition(nodeRects[5]!)).toEqual({ x: 80, y: 40 })
+    })
+
+    it('aligns with gaps in previous row if this fits best to original layout', () => {
+      const nodeRects = [
+        n('a', 0, 0),
+        n('b', 40, 0),
+        n('c', 80, 0),
+        n('d', 120, 0),
+        n('e', 20 + placementError, 40),
+        n('f', 60 - placementError, 40)
+      ]
+
+      const aligner = new GridAligner('Row')
+
+      aligner.computeLayout(nodeRects)
+
+      expect(aligner.applyPosition(nodeRects[4]!)).toEqual({ x: 20, y: 40 })
+      expect(aligner.applyPosition(nodeRects[5]!)).toEqual({ x: 60, y: 40 })
+    })
+
+    it('skips cell if previous layer has more cells than nodes in the current layer and it fits better', () => {
+      const nodeRects = [
+        n('a', 0, 0),
+        n('b', 40, 0),
+        n('c', 80, 0),
+        n('d', 120, 0),
+        n('e', 160, 0),
+        n('f', 40 - placementError, 40),
+        n('g', 80 - placementError, 40),
+        n('h', 120 - placementError, 40),
+        n('i', 160 - placementError, 40),
+      ]
+
+      const aligner = new GridAligner('Row')
+
+      aligner.computeLayout(nodeRects)
+
+      expect(aligner.applyPosition(nodeRects[5]!)).toEqual({ x: 40, y: 40 })
+      expect(aligner.applyPosition(nodeRects[6]!)).toEqual({ x: 80, y: 40 })
+      expect(aligner.applyPosition(nodeRects[7]!)).toEqual({ x: 120, y: 40 })
+      expect(aligner.applyPosition(nodeRects[8]!)).toEqual({ x: 155, y: 40 })
+    })
+  })
+})

--- a/packages/diagram/src/state/aligners.spec.ts
+++ b/packages/diagram/src/state/aligners.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { GridAligner, type NodeRect } from './aligners'
+import { getLinearAligner, GridAligner, type NodeRect } from './aligners'
 
 const placementError = 5
 
@@ -107,7 +107,7 @@ describe('aligners', () => {
         n('f', 40 - placementError, 40),
         n('g', 80 - placementError, 40),
         n('h', 120 - placementError, 40),
-        n('i', 160 - placementError, 40),
+        n('i', 160 - placementError, 40)
       ]
 
       const aligner = new GridAligner('Row')
@@ -117,7 +117,30 @@ describe('aligners', () => {
       expect(aligner.applyPosition(nodeRects[5]!)).toEqual({ x: 40, y: 40 })
       expect(aligner.applyPosition(nodeRects[6]!)).toEqual({ x: 80, y: 40 })
       expect(aligner.applyPosition(nodeRects[7]!)).toEqual({ x: 120, y: 40 })
-      expect(aligner.applyPosition(nodeRects[8]!)).toEqual({ x: 155, y: 40 })
+      expect(aligner.applyPosition(nodeRects[8]!)).toEqual({ x: 160, y: 40 })
+    })
+
+    it('uses secondary axis to order rows in a row', () => {
+      const nodeRects = [
+        n('e', 160, 0),
+        n('b', 40, 0),
+        n('a', 0, 0),
+        n('d', 120, 0),
+        n('c', 80, 0),
+        n('f', 40 - placementError, 40),
+        n('g', 80 - placementError, 40),
+        n('h', 120 - placementError, 40),
+        n('i', 160 - placementError, 40)
+      ]
+
+      const aligner = new GridAligner('Row')
+
+      aligner.computeLayout(nodeRects)
+
+      expect(aligner.applyPosition(nodeRects[5]!)).toEqual({ x: 40, y: 40 })
+      expect(aligner.applyPosition(nodeRects[6]!)).toEqual({ x: 80, y: 40 })
+      expect(aligner.applyPosition(nodeRects[7]!)).toEqual({ x: 120, y: 40 })
+      expect(aligner.applyPosition(nodeRects[8]!)).toEqual({ x: 160, y: 40 })
     })
 
     it('spreads rows evenly', () => {
@@ -140,6 +163,104 @@ describe('aligners', () => {
       expect(aligner.applyPosition(nodeRects[3]!).y).toEqual(120)
       expect(aligner.applyPosition(nodeRects[4]!).y).toEqual(120)
       expect(aligner.applyPosition(nodeRects[5]!).y).toEqual(160)
+    })
+  })
+
+  describe('LinearAligner', () => {
+    it('aligns to leftmost edge', () => {
+      const nodeRects = [
+        n('a', 20, 10),
+        n('b', 10, 20),
+        n('c', 40, 30)
+      ]
+
+      const aligner = getLinearAligner('Left')
+
+      aligner.computeLayout(nodeRects)
+
+      expect(aligner.applyPosition(nodeRects[0]!)).toEqual({ x: 10 })
+      expect(aligner.applyPosition(nodeRects[1]!)).toEqual({ x: 10 })
+      expect(aligner.applyPosition(nodeRects[2]!)).toEqual({ x: 10 })
+    })
+    
+    it('aligns rightmost edge', () => {
+      const nodeRects = [
+        n('a', 20, 10, 5),
+        n('b', 10, 20, 6),
+        n('c', 40, 30, 7)
+      ]
+
+      const aligner = getLinearAligner('Right')
+
+      aligner.computeLayout(nodeRects)
+
+      expect(aligner.applyPosition(nodeRects[0]!)).toEqual({ x: 42 })
+      expect(aligner.applyPosition(nodeRects[1]!)).toEqual({ x: 41 })
+      expect(aligner.applyPosition(nodeRects[2]!)).toEqual({ x: 40 })
+    })
+
+    it('aligns topmost edge', () => {
+      const nodeRects = [
+        n('a', 10, 20),
+        n('b', 20, 10),
+        n('c', 30, 40)
+      ]
+
+      const aligner = getLinearAligner('Top')
+
+      aligner.computeLayout(nodeRects)
+
+      expect(aligner.applyPosition(nodeRects[0]!)).toEqual({ y: 10 })
+      expect(aligner.applyPosition(nodeRects[1]!)).toEqual({ y: 10 })
+      expect(aligner.applyPosition(nodeRects[2]!)).toEqual({ y: 10 })
+    })
+    
+    it('aligns bottommost edge', () => {
+      const nodeRects = [
+        n('a', 10, 20, 10, 5),
+        n('b', 20, 10, 10, 6),
+        n('c', 30, 40, 10, 7)
+      ]
+
+      const aligner = getLinearAligner('Bottom')
+
+      aligner.computeLayout(nodeRects)
+
+      expect(aligner.applyPosition(nodeRects[0]!)).toEqual({ y: 42 })
+      expect(aligner.applyPosition(nodeRects[1]!)).toEqual({ y: 41 })
+      expect(aligner.applyPosition(nodeRects[2]!)).toEqual({ y: 40 })
+    })
+
+    it('aligns to leftmost node center', () => {
+      const nodeRects = [
+        n('a', 20, 10, 4),  // 22
+        n('b', 10, 20, 8),  // 14
+        n('c', 40, 30, 12)  // 46
+      ]
+
+      const aligner = getLinearAligner('Center')
+
+      aligner.computeLayout(nodeRects)
+
+      expect(aligner.applyPosition(nodeRects[0]!)).toEqual({ x: 12 })
+      expect(aligner.applyPosition(nodeRects[1]!)).toEqual({ x: 10 })
+      expect(aligner.applyPosition(nodeRects[2]!)).toEqual({ x: 8 })
+    })
+
+    it('aligns to topmost node middle', () => {
+      const nodeRects = [
+        n('a', 10, 20, 10, 4),  // 22
+        n('b', 20, 10, 10, 8),  // 14
+        n('c', 30, 40, 10, 12)  // 46
+      ]
+
+      const aligner = getLinearAligner('Middle')
+
+      aligner.computeLayout(nodeRects)
+
+      expect(aligner.applyPosition(nodeRects[0]!)).toEqual({ y: 12 })
+      expect(aligner.applyPosition(nodeRects[1]!)).toEqual({ y: 10 })
+      expect(aligner.applyPosition(nodeRects[2]!)).toEqual({ y: 8 })
     })
   })
 })

--- a/packages/diagram/src/state/aligners.ts
+++ b/packages/diagram/src/state/aligners.ts
@@ -1,0 +1,341 @@
+import { invariant, type NonEmptyArray } from '@likec4/core'
+import type { Rect, XYPosition } from '@xyflow/react'
+import { map, pick, pipe, reduce, sortBy } from 'remeda'
+
+export type GridAlignmentMode = 'Column' | 'Row'
+
+export abstract class Aligner {
+  abstract computeLayout(nodes: NodeRect[]): void
+  abstract applyPosition(node: NodeRect): Partial<XYPosition>
+}
+
+export class LinearAligner extends Aligner {
+  private alignTo: number | undefined
+  constructor(
+    private getEdgePosition: (nodes: NodeRect[]) => number,
+    private computePosition: (alignTo: number, node: NodeRect) => number,
+    private propertyToEdit: keyof XYPosition
+  ) {
+    super()
+  }
+
+  override computeLayout(nodes: NodeRect[]) {
+    this.alignTo = this.getEdgePosition(nodes)
+  }
+
+  override applyPosition(node: NodeRect): Partial<XYPosition> {
+    return {
+      [this.propertyToEdit]: this.computePosition(this.alignTo!, node)
+    }
+  }
+}
+
+export type NodeRect = Rect & { id: string }
+type Layer = {
+  primaryAxisSize: number
+  nodes: NodeRect[]
+  occupiedSpace: number
+  cells: NonEmptyArray<LayoutCell> | null
+}
+type LayoutCell = { offset: number; size: number }
+
+export class GridAligner extends Aligner {
+  private layout: Map<string, XYPosition> = new Map()
+  private axisPreset: {
+    primaryAxisDimension: 'height' | 'width'
+    secondaryAxisDimension: 'height' | 'width'
+    primaryAxisCoord: 'x' | 'y'
+    secondaryAxisCoord: 'x' | 'y'
+  }
+
+  constructor(alignmentMode: GridAlignmentMode) {
+    super()
+
+    this.axisPreset = alignmentMode === 'Column'
+      ? {
+        primaryAxisDimension: 'width',
+        secondaryAxisDimension: 'height',
+        primaryAxisCoord: 'x',
+        secondaryAxisCoord: 'y'
+      }
+      : {
+        primaryAxisDimension: 'height',
+        secondaryAxisDimension: 'width',
+        primaryAxisCoord: 'y',
+        secondaryAxisCoord: 'x'
+      }
+  }
+
+  override applyPosition(node: NodeRect): Partial<XYPosition> {
+    return this.layout?.get(node.id) ?? {}
+  }
+
+  override computeLayout(nodes: NodeRect[]) {
+    // Sort by primary axis
+    const sortedNodeRects = pipe(
+      nodes,
+      sortBy(r => r[this.axisPreset.primaryAxisCoord])
+    )
+
+    const layoutRect = this.getLayoutRect(sortedNodeRects)
+
+    const layers = this.getLayers(sortedNodeRects)
+
+    this.layout = this.buildLayout(layers, layoutRect, sortedNodeRects)
+  }
+
+  private getLayoutRect(nodeRects: NodeRect[]): Rect {
+    const x = Math.min(...nodeRects.map(n => n.x))
+    const y = Math.min(...nodeRects.map(n => n.y))
+    const right = Math.max(...nodeRects.map(n => n.x + n.width))
+    const bottom = Math.max(...nodeRects.map(n => n.y + n.height))
+
+    return {
+      x,
+      y,
+      width: right - x,
+      height: bottom - y
+    }
+  }
+
+  private getLayers(sortedNodeRects: NodeRect[]): Layer[] {
+    const layers: Layer[] = []
+    let layerEnd = 0
+    let layer = null
+
+    for (let node of sortedNodeRects) {
+      if (!!layer && node[this.axisPreset.primaryAxisCoord] < layerEnd) {
+        layer.nodes.push(node)
+        layer.primaryAxisSize = Math.max(layer.primaryAxisSize, node[this.axisPreset.primaryAxisDimension])
+        layer.occupiedSpace += node[this.axisPreset.secondaryAxisDimension]
+        layerEnd = Math.max(
+          node[this.axisPreset.primaryAxisCoord] + node[this.axisPreset.primaryAxisDimension],
+          layerEnd
+        )
+      } else {
+        layer = {
+          primaryAxisSize: node[this.axisPreset.primaryAxisDimension],
+          nodes: [node],
+          occupiedSpace: node[this.axisPreset.secondaryAxisDimension],
+          cells: null
+        }
+        layers.push(layer)
+        layerEnd = node[this.axisPreset.primaryAxisCoord] + node[this.axisPreset.primaryAxisDimension]
+        continue
+      }
+    }
+
+    return layers
+  }
+
+  private buildLayout(layers: Layer[], layoutRect: Rect, nodeRects: NodeRect[]): Map<string, XYPosition> {
+    const nodeMap = new Map(nodeRects.map(n => [n.id, n]))
+    const layout: [string, XYPosition][] = []
+    const occupiedSpace = layers.reduce((a, b) => a + b.primaryAxisSize, 0)
+    const rowMargin = layers.length > 1
+      ? (layoutRect[this.axisPreset.primaryAxisDimension] - occupiedSpace) / (layers.length - 1)
+      : 0
+
+    let placeNextLayerAt = layoutRect[this.axisPreset.primaryAxisCoord]
+    let previousLayerCells = null
+    for (let layer of layers) {
+      let bestLayerLayout = this.scoreLayout(
+        this.spaceAround(layer, layoutRect, placeNextLayerAt),
+        nodeMap
+      )
+
+      if (layer.nodes.length != 1) {
+        const currentlayerLayout = this.scoreLayout(
+          this.spaceBetween(layer, layoutRect, placeNextLayerAt),
+          nodeMap
+        )
+        bestLayerLayout = currentlayerLayout[0] < bestLayerLayout[0] ? currentlayerLayout : bestLayerLayout
+      }
+
+      if (previousLayerCells && previousLayerCells.length - 1 >= layer.nodes.length) {
+        const currentlayerLayout = this.scoreLayout(
+          this.placeInGaps(layer, placeNextLayerAt, previousLayerCells),
+          nodeMap
+        )
+        bestLayerLayout = currentlayerLayout[0] < bestLayerLayout[0] ? currentlayerLayout : bestLayerLayout
+      }
+
+      if (previousLayerCells && previousLayerCells.length >= layer.nodes.length) {
+        const currentlayerLayout = this.scoreLayout(
+          this.placeInCells(layer, placeNextLayerAt, previousLayerCells),
+          nodeMap
+        )
+        bestLayerLayout = currentlayerLayout[0] < bestLayerLayout[0] ? currentlayerLayout : bestLayerLayout
+      }
+
+      layout.push(...bestLayerLayout[2])
+      previousLayerCells = bestLayerLayout[1]
+      placeNextLayerAt += layer.primaryAxisSize + rowMargin
+    }
+
+    return new Map(layout)
+  }
+
+  private spaceBetween(
+    layer: Layer,
+    layoutRect: Rect,
+    placeNextLayerAt: number
+  ): [NonEmptyArray<LayoutCell>, Map<string, XYPosition>] {
+    const freeSpace = layoutRect[this.axisPreset.secondaryAxisDimension] - layer.occupiedSpace
+    const margin = freeSpace / (layer.nodes.length - 1)
+
+    let placeNextNodeAt = layoutRect[this.axisPreset.secondaryAxisCoord]
+    const result = new Map<string, XYPosition>()
+    const cells = []
+
+    let i = 0
+    for (let node of sortBy(layer.nodes, n => n[this.axisPreset.secondaryAxisCoord])) {
+      const isFirst = i === 0
+      const isLast = i === layer.nodes.length - 1
+
+      cells.push({
+        offset: placeNextNodeAt - (isFirst ? 0 : margin / 2),
+        size: node[this.axisPreset.secondaryAxisDimension] + (isFirst || isLast ? margin / 2 : margin)
+      })
+      result.set(node.id, {
+        [this.axisPreset.secondaryAxisCoord]: placeNextNodeAt,
+        [this.axisPreset.primaryAxisCoord]: placeNextLayerAt
+      } as XYPosition)
+      placeNextNodeAt += node[this.axisPreset.secondaryAxisDimension] + margin
+      i++
+    }
+
+    return [cells as NonEmptyArray<LayoutCell>, result]
+  }
+
+  private spaceAround(
+    layer: Layer,
+    layoutRect: Rect,
+    placeNextLayerAt: number
+  ): [NonEmptyArray<LayoutCell>, Map<string, XYPosition>] {
+    const freeSpace = layoutRect[this.axisPreset.secondaryAxisDimension] - layer.occupiedSpace
+    const margin = freeSpace / (layer.nodes.length + 1)
+
+    let placeNextNodeAt = layoutRect[this.axisPreset.secondaryAxisCoord] + margin
+    const result = new Map<string, XYPosition>()
+    const cells = []
+
+    for (let node of sortBy(layer.nodes, n => n[this.axisPreset.secondaryAxisCoord])) {
+      cells.push({
+        offset: placeNextNodeAt - margin / 2,
+        size: node[this.axisPreset.secondaryAxisDimension] + margin
+      })
+      result.set(node.id, {
+        [this.axisPreset.secondaryAxisCoord]: placeNextNodeAt,
+        [this.axisPreset.primaryAxisCoord]: placeNextLayerAt
+      } as XYPosition)
+      placeNextNodeAt += node[this.axisPreset.secondaryAxisDimension] + margin
+    }
+
+    return [cells as NonEmptyArray<LayoutCell>, result]
+  }
+
+  private placeInGaps(
+    layer: Layer,
+    placeNextLayerAt: number,
+    previousLayerCells: NonEmptyArray<LayoutCell>
+  ): [NonEmptyArray<LayoutCell>, Map<string, XYPosition>] {
+    invariant(previousLayerCells, 'Layout of the previous layer was not computed')
+    const result = new Map<string, XYPosition>()
+
+    const sortedNodes = sortBy(layer.nodes, n => n[this.axisPreset.secondaryAxisCoord])
+    const placementOptions = previousLayerCells
+      .map(cell => cell.offset + cell.size)
+      .slice(0, -1)
+
+    let optionIndex = 0
+    for (let i = 0, node = sortedNodes[i]!; i < sortedNodes.length; i++, node = sortedNodes[i]!) {
+      const nodeCenter = node[this.axisPreset.secondaryAxisCoord] + node[this.axisPreset.secondaryAxisDimension] / 2
+
+      let bestOffset = Infinity
+      while (optionIndex - i <= placementOptions.length - sortedNodes.length) {
+        let position = placementOptions[optionIndex]!
+        const offset = position - nodeCenter
+
+        if (Math.abs(offset) < Math.abs(bestOffset)) {
+          bestOffset = offset
+
+          optionIndex++
+        }
+        else {
+          break;
+        }
+      }
+
+      result.set(node.id, {
+        [this.axisPreset.secondaryAxisCoord]: node[this.axisPreset.secondaryAxisCoord] + bestOffset,
+        [this.axisPreset.primaryAxisCoord]: placeNextLayerAt
+      } as XYPosition)
+    }
+
+    return [previousLayerCells, result]
+  }
+
+  private placeInCells(
+    layer: Layer,
+    placeNextLayerAt: number,
+    previousLayerCells: NonEmptyArray<LayoutCell>,
+  ): [NonEmptyArray<LayoutCell>, Map<string, XYPosition>] {
+    invariant(previousLayerCells, 'Layout of the previous layer was not computed')
+    const result = new Map<string, XYPosition>()
+
+    const sortedNodes = sortBy(layer.nodes, n => n[this.axisPreset.secondaryAxisCoord])
+    const placementOptions = previousLayerCells
+      .map(cell => cell.offset + cell.size / 2)
+
+    let optionIndex = 0
+    for (let i = 0, node = sortedNodes[i]!; i < sortedNodes.length; i++, node = sortedNodes[i]!) {
+      const nodeCenter = node[this.axisPreset.secondaryAxisCoord] + node[this.axisPreset.secondaryAxisDimension] / 2
+
+      let bestOffset = Infinity
+
+      while (optionIndex - i <= placementOptions.length - sortedNodes.length) {
+        let position = placementOptions[optionIndex]!
+        const offset = position - nodeCenter
+
+        if (Math.abs(offset) < Math.abs(bestOffset)) {
+          bestOffset = offset
+
+          optionIndex++
+        }
+        else{
+          break
+        }
+      }
+
+      result.set(node.id, {
+        [this.axisPreset.secondaryAxisCoord]: node[this.axisPreset.secondaryAxisCoord] + bestOffset,
+        [this.axisPreset.primaryAxisCoord]: placeNextLayerAt
+      } as XYPosition)
+    }
+
+    return [previousLayerCells, result]
+  }
+
+  private scoreLayout(
+    [cells, layout]: [NonEmptyArray<LayoutCell>, Map<string, XYPosition>],
+    originalRects: Map<string, NodeRect>
+  ): [number, NonEmptyArray<LayoutCell>, Map<string, XYPosition>] {
+    return [
+      pipe(
+        layout.entries().toArray(),
+        map(([id, position]) => {
+          const originalRect = originalRects.get(id)
+          invariant(originalRect, `Could not find original rect for node ${id}`)
+          return [pick(originalRect, ['x', 'y']), position]
+        }),
+        map(([original, suggested]) =>
+          Math.abs(original![this.axisPreset.secondaryAxisCoord] - suggested![this.axisPreset.secondaryAxisCoord])
+        ),
+        reduce((a, b) => a + b, 0)
+      ),
+      cells,
+      layout
+    ]
+  }
+}

--- a/packages/diagram/src/state/diagramStore.layout.ts
+++ b/packages/diagram/src/state/diagramStore.layout.ts
@@ -1,0 +1,267 @@
+import { nonexhaustive } from '@likec4/core'
+import type { InternalNode, Rect, XYPosition } from '@xyflow/react'
+import { getNodeDimensions } from '@xyflow/system'
+import { hasAtLeast, map, pipe, sortBy } from 'remeda'
+import type { DiagramState } from '../hooks'
+import type { XYFlowNode } from '../xyflow/types'
+import { createLayoutConstraints } from '../xyflow/useLayoutConstraints'
+
+type LinearAlignmentMode = 'Left' | 'Center' | 'Right' | 'Top' | 'Middle' | 'Bottom'
+type GridAlignmentMode = 'Column' | 'Row'
+export type AlignmentMode = LinearAlignmentMode | GridAlignmentMode
+
+abstract class Aligner {
+  abstract computeLayout(nodes: InternalNode<XYFlowNode>[]): void
+  abstract applyPosition(node: InternalNode<XYFlowNode>): Partial<XYPosition>
+}
+
+class LinearAligner extends Aligner {
+  private alignTo: number | undefined
+  constructor(
+    private getEdgePosition: (nodes: InternalNode<XYFlowNode>[]) => number,
+    private getPosition: (alignTo: number, node: InternalNode<XYFlowNode>) => number,
+    private propertyToEdit: keyof XYPosition
+  ) {
+    super()
+  }
+
+  override computeLayout(nodes: InternalNode<XYFlowNode>[]) {
+    this.alignTo = this.getEdgePosition(nodes)
+  }
+
+  override applyPosition(node: InternalNode<XYFlowNode>): Partial<XYPosition> {
+    return {
+      [this.propertyToEdit]: this.getPosition(this.alignTo!, node)
+    }
+  }
+}
+
+type NodeRect = Rect & { id: string }
+
+class GridAligner extends Aligner {
+  private layout: Map<string, XYPosition> = new Map()
+  private axisPreset: {
+    primaryAxisDimension: 'height' | 'width'
+    secondaryAxisDimension: 'height' | 'width'
+    primaryAxisCoord: 'x' | 'y'
+    secondaryAxisCoord: 'x' | 'y'
+  }
+
+  constructor(alignmentMode: GridAlignmentMode) {
+    super()
+
+    this.axisPreset = alignmentMode === 'Column'
+      ? {
+        primaryAxisDimension: 'width',
+        secondaryAxisDimension: 'height',
+        primaryAxisCoord: 'x',
+        secondaryAxisCoord: 'y'
+      }
+      : {
+        primaryAxisDimension: 'height',
+        secondaryAxisDimension: 'width',
+        primaryAxisCoord: 'y',
+        secondaryAxisCoord: 'x'
+      }
+  }
+
+  override applyPosition(node: InternalNode<XYFlowNode>): Partial<XYPosition> {
+    return this.layout?.get(node.id) ?? {}
+  }
+
+  override computeLayout(nodes: InternalNode<XYFlowNode>[]) {
+    // Sort by position
+    const sortedNodeRects = pipe(
+      nodes,
+      map(n =>
+        ({
+          ...n.internals.positionAbsolute,
+          id: n.id,
+          width: getNodeDimensions(n).width,
+          height: getNodeDimensions(n).height
+        }) as NodeRect
+      ),
+      sortBy(r => r[this.axisPreset.primaryAxisCoord])
+    )
+    const x = Math.min(...sortedNodeRects.map(n => n.x))
+    const y = Math.min(...sortedNodeRects.map(n => n.y))
+    const right = Math.max(...sortedNodeRects.map(n => n.x + n.width))
+    const bottom = Math.max(...sortedNodeRects.map(n => n.y + n.height))
+
+    const layoutRect: Rect = {
+      x,
+      y,
+      width: right - x,
+      height: bottom - y
+    }
+
+    // Group by rows
+    const layers: { primaryAxisSize: number; nodes: NodeRect[] }[] = []
+    let layerStart = 0
+    let layerEnd = 0
+    let layer = null
+
+    for (let node of sortedNodeRects) {
+      if (!!layer && node[this.axisPreset.primaryAxisCoord] < layerEnd) {
+        layer.nodes.push(node)
+        layer.primaryAxisSize = Math.max(layer.primaryAxisSize, node[this.axisPreset.primaryAxisDimension])
+        layerEnd = Math.max(
+          node[this.axisPreset.primaryAxisCoord] + node[this.axisPreset.primaryAxisDimension],
+          layerEnd
+        )
+      } else {
+        layer = { primaryAxisSize: node[this.axisPreset.primaryAxisDimension], nodes: [node] }
+        layers.push(layer)
+        layerStart = node[this.axisPreset.primaryAxisCoord]
+        layerEnd = node[this.axisPreset.primaryAxisCoord] + node[this.axisPreset.primaryAxisDimension]
+        continue
+      }
+    }
+
+    // Find position in a row
+    const occupiedSpace = layers.reduce((a, b) => a + b.primaryAxisSize, 0)
+    const rowMargin = layers.length > 1
+      ? (layoutRect[this.axisPreset.primaryAxisDimension] - occupiedSpace) / (layers.length - 1)
+      : 0
+    let placeNextRowAt = layoutRect[this.axisPreset.primaryAxisCoord]
+    for (let layer of layers) {
+      if (layer.nodes.length == 1) {
+        this.centerInRow(layer, layoutRect, placeNextRowAt)
+      }
+      else {
+        this.fillRow(layer, layoutRect, placeNextRowAt)
+      }
+
+      placeNextRowAt += layer.primaryAxisSize + rowMargin
+    }
+  }
+
+  private fillRow(
+    layer: { primaryAxisSize: number; nodes: NodeRect[] },
+    layoutRect: Rect,
+    placeNextLayerAt: number
+  ) {
+    const occupiedSpace = layer.nodes.map(n => n[this.axisPreset.secondaryAxisDimension]).reduce((a, b) => a + b, 0)
+    const freeSpace = layoutRect[this.axisPreset.secondaryAxisDimension] - occupiedSpace
+
+    const margin = freeSpace / (layer.nodes.length - 1)
+
+    let placeNextNodeAt = layoutRect[this.axisPreset.secondaryAxisCoord]
+    for (let node of sortBy(layer.nodes, n => n[this.axisPreset.secondaryAxisCoord])) {
+      this.layout.set(node.id, {
+        [this.axisPreset.secondaryAxisCoord]: placeNextNodeAt,
+        [this.axisPreset.primaryAxisCoord]: placeNextLayerAt
+      } as XYPosition)
+      placeNextNodeAt += node[this.axisPreset.secondaryAxisDimension] + margin
+    }
+  }
+
+  private centerInRow(
+    layer: { primaryAxisSize: number; nodes: NodeRect[] },
+    layoutRect: Rect,
+    placeNextLayerAt: number
+  ) {
+    const occupiedSpace = layer.nodes.map(n => n[this.axisPreset.secondaryAxisDimension]).reduce((a, b) => a + b, 0)
+    const freeSpace = layoutRect[this.axisPreset.secondaryAxisDimension] - occupiedSpace
+
+    const margin = freeSpace / (layer.nodes.length + 1)
+
+    let placeNextNodeAt = layoutRect[this.axisPreset.secondaryAxisCoord] + margin
+    for (let node of sortBy(layer.nodes, n => n[this.axisPreset.secondaryAxisCoord])) {
+      this.layout.set(node.id, {
+        [this.axisPreset.secondaryAxisCoord]: placeNextNodeAt,
+        [this.axisPreset.primaryAxisCoord]: placeNextLayerAt
+      } as XYPosition)
+      placeNextNodeAt += node[this.axisPreset.secondaryAxisDimension] + margin
+    }
+  }
+}
+
+export function align(get: () => DiagramState) {
+  return (mode: AlignmentMode) => {
+    const { scheduleSaveManualLayout, xystore } = get()
+    const { nodeLookup, parentLookup } = xystore.getState()
+
+    const selectedNodes = new Set(nodeLookup.values().filter(n => n.selected).map(n => n.id))
+    const nodesToAlign = [...selectedNodes.difference(new Set(parentLookup.keys()))]
+
+    if (!hasAtLeast(nodesToAlign, 2)) {
+      console.warn('At least 2 nodes must be selected to align')
+      return
+    }
+    const constraints = createLayoutConstraints(xystore, nodesToAlign)
+
+    const aligner = getAligner(mode)
+
+    constraints.onMove((nodes) => {
+      aligner.computeLayout(nodes.map(({ node }) => node))
+
+      nodes.forEach(({ rect, node }) => {
+        rect.positionAbsolute = {
+          ...rect.positionAbsolute,
+          ...aligner.applyPosition(node)
+        }
+      })
+    })
+
+    scheduleSaveManualLayout()
+  }
+}
+
+function getAligner(mode: AlignmentMode): Aligner {
+  switch (mode) {
+    case 'Left':
+    case 'Right':
+    case 'Top':
+    case 'Bottom':
+    case 'Center':
+    case 'Middle':
+      return getLinearAligner(mode)
+    case 'Column':
+    case 'Row':
+      return new GridAligner(mode)
+    default:
+      nonexhaustive(mode)
+  }
+}
+
+function getLinearAligner(mode: LinearAlignmentMode): Aligner {
+  switch (mode) {
+    case 'Left':
+      return new LinearAligner(
+        nodes => Math.min(...nodes.map(n => n.internals.positionAbsolute.x)),
+        (alignTo, _) => Math.floor(alignTo),
+        'x'
+      )
+    case 'Top':
+      return new LinearAligner(
+        nodes => Math.min(...nodes.map(n => n.internals.positionAbsolute.y)),
+        (alignTo, _) => Math.floor(alignTo),
+        'y'
+      )
+    case 'Right':
+      return new LinearAligner(
+        nodes => Math.max(...nodes.map(n => n.internals.positionAbsolute.x + getNodeDimensions(n).width)),
+        (alignTo, node) => Math.floor(alignTo - node.width!),
+        'x'
+      )
+    case 'Bottom':
+      return new LinearAligner(
+        nodes => Math.max(...nodes.map(n => n.internals.positionAbsolute.y + getNodeDimensions(n).height)),
+        (alignTo, node) => Math.floor(alignTo - node.height!),
+        'y'
+      )
+    case 'Center':
+      return new LinearAligner(
+        nodes => Math.max(...nodes.map(n => n.internals.positionAbsolute.x + getNodeDimensions(n).width / 2)),
+        (alignTo, node) => Math.floor(alignTo - getNodeDimensions(node).width / 2),
+        'x'
+      )
+    case 'Middle':
+      return new LinearAligner(
+        nodes => Math.max(...nodes.map(n => n.internals.positionAbsolute.y + getNodeDimensions(n).height / 2)),
+        (alignTo, node) => Math.floor(alignTo - getNodeDimensions(node).height / 2),
+        'y'
+      )
+  }
+}

--- a/packages/diagram/src/state/diagramStore.layout.ts
+++ b/packages/diagram/src/state/diagramStore.layout.ts
@@ -1,214 +1,15 @@
 import { nonexhaustive } from '@likec4/core'
-import type { InternalNode, Rect, XYPosition } from '@xyflow/react'
+import type { InternalNode } from '@xyflow/react'
 import { getNodeDimensions } from '@xyflow/system'
-import { hasAtLeast, map, pipe, sortBy } from 'remeda'
+import { hasAtLeast } from 'remeda'
 import type { DiagramState } from '../hooks'
 import type { XYFlowNode } from '../xyflow/types'
 import { createLayoutConstraints } from '../xyflow/useLayoutConstraints'
+import { type Aligner, GridAligner, LinearAligner, type NodeRect } from './aligners'
 
 type LinearAlignmentMode = 'Left' | 'Center' | 'Right' | 'Top' | 'Middle' | 'Bottom'
 type GridAlignmentMode = 'Column' | 'Row'
 export type AlignmentMode = LinearAlignmentMode | GridAlignmentMode
-
-abstract class Aligner {
-  abstract computeLayout(nodes: InternalNode<XYFlowNode>[]): void
-  abstract applyPosition(node: InternalNode<XYFlowNode>): Partial<XYPosition>
-}
-
-class LinearAligner extends Aligner {
-  private alignTo: number | undefined
-  constructor(
-    private getEdgePosition: (nodes: InternalNode<XYFlowNode>[]) => number,
-    private getPosition: (alignTo: number, node: InternalNode<XYFlowNode>) => number,
-    private propertyToEdit: keyof XYPosition
-  ) {
-    super()
-  }
-
-  override computeLayout(nodes: InternalNode<XYFlowNode>[]) {
-    this.alignTo = this.getEdgePosition(nodes)
-  }
-
-  override applyPosition(node: InternalNode<XYFlowNode>): Partial<XYPosition> {
-    return {
-      [this.propertyToEdit]: this.getPosition(this.alignTo!, node)
-    }
-  }
-}
-
-type NodeRect = Rect & { id: string }
-type Layer = {
-  primaryAxisSize: number
-  nodes: NodeRect[]
-  occupiedSpace: number
-  layoutOptions: Map<string, XYPosition>[]
-}
-
-class GridAligner extends Aligner {
-  private layout: Map<string, XYPosition> = new Map()
-  private axisPreset: {
-    primaryAxisDimension: 'height' | 'width'
-    secondaryAxisDimension: 'height' | 'width'
-    primaryAxisCoord: 'x' | 'y'
-    secondaryAxisCoord: 'x' | 'y'
-  }
-
-  constructor(alignmentMode: GridAlignmentMode) {
-    super()
-
-    this.axisPreset = alignmentMode === 'Column'
-      ? {
-        primaryAxisDimension: 'width',
-        secondaryAxisDimension: 'height',
-        primaryAxisCoord: 'x',
-        secondaryAxisCoord: 'y'
-      }
-      : {
-        primaryAxisDimension: 'height',
-        secondaryAxisDimension: 'width',
-        primaryAxisCoord: 'y',
-        secondaryAxisCoord: 'x'
-      }
-  }
-
-  override applyPosition(node: InternalNode<XYFlowNode>): Partial<XYPosition> {
-    return this.layout?.get(node.id) ?? {}
-  }
-
-  override computeLayout(nodes: InternalNode<XYFlowNode>[]) {
-    // Sort by primary axis
-    const sortedNodeRects = pipe(
-      nodes,
-      map(n =>
-        ({
-          ...n.internals.positionAbsolute,
-          id: n.id,
-          width: getNodeDimensions(n).width,
-          height: getNodeDimensions(n).height
-        }) as NodeRect
-      ),
-      sortBy(r => r[this.axisPreset.primaryAxisCoord])
-    )
-
-    const layoutRect = this.getLayoutRect(sortedNodeRects)
-
-    const layers = this.getLayers(sortedNodeRects)
-
-    this.layout = this.buildLayout(layers, layoutRect)
-  }
-
-  private getLayoutRect(nodeRects: NodeRect[]): Rect {
-    const x = Math.min(...nodeRects.map(n => n.x))
-    const y = Math.min(...nodeRects.map(n => n.y))
-    const right = Math.max(...nodeRects.map(n => n.x + n.width))
-    const bottom = Math.max(...nodeRects.map(n => n.y + n.height))
-
-    return {
-      x,
-      y,
-      width: right - x,
-      height: bottom - y
-    }
-  }
-
-  private getLayers(sortedNodeRects: NodeRect[]): Layer[] {
-    const layers: Layer[] = []
-    let layerStart = 0
-    let layerEnd = 0
-    let layer = null
-
-    for (let node of sortedNodeRects) {
-      if (!!layer && node[this.axisPreset.primaryAxisCoord] < layerEnd) {
-        layer.nodes.push(node)
-        layer.primaryAxisSize = Math.max(layer.primaryAxisSize, node[this.axisPreset.primaryAxisDimension])
-        layer.occupiedSpace += node[this.axisPreset.secondaryAxisDimension]
-        layerEnd = Math.max(
-          node[this.axisPreset.primaryAxisCoord] + node[this.axisPreset.primaryAxisDimension],
-          layerEnd
-        )
-      } else {
-        layer = {
-          primaryAxisSize: node[this.axisPreset.primaryAxisDimension],
-          nodes: [node],
-          occupiedSpace: node[this.axisPreset.secondaryAxisDimension],
-          layoutOptions: []
-        }
-        layers.push(layer)
-        layerStart = node[this.axisPreset.primaryAxisCoord]
-        layerEnd = node[this.axisPreset.primaryAxisCoord] + node[this.axisPreset.primaryAxisDimension]
-        continue
-      }
-    }
-
-    return layers
-  }
-
-  private buildLayout(layers: Layer[], layoutRect: Rect): Map<string, XYPosition> {
-    const layout: [string, XYPosition][] = []
-    const occupiedSpace = layers.reduce((a, b) => a + b.primaryAxisSize, 0)
-    const rowMargin = layers.length > 1
-      ? (layoutRect[this.axisPreset.primaryAxisDimension] - occupiedSpace) / (layers.length - 1)
-      : 0
-    let placeNextLayerAt = layoutRect[this.axisPreset.primaryAxisCoord]
-    for (let layer of layers) {
-      if (layer.nodes.length != 1) {
-        layout.push(...this.spaceBetween(layer, layoutRect, placeNextLayerAt))
-      } else {
-        layout.push(...this.spaceAround(layer, layoutRect, placeNextLayerAt))
-      }
-
-      placeNextLayerAt += layer.primaryAxisSize + rowMargin
-    }
-
-    return new Map(layout)
-  }
-
-  private spaceBetween(
-    layer: Layer,
-    layoutRect: Rect,
-    placeNextLayerAt: number
-  ): Map<string, XYPosition> {
-    const freeSpace = layoutRect[this.axisPreset.secondaryAxisDimension] - layer.occupiedSpace
-
-    const margin = freeSpace / (layer.nodes.length - 1)
-
-    let placeNextNodeAt = layoutRect[this.axisPreset.secondaryAxisCoord]
-    const result = new Map<string, XYPosition>()
-
-    for (let node of sortBy(layer.nodes, n => n[this.axisPreset.secondaryAxisCoord])) {
-      result.set(node.id, {
-        [this.axisPreset.secondaryAxisCoord]: placeNextNodeAt,
-        [this.axisPreset.primaryAxisCoord]: placeNextLayerAt
-      } as XYPosition)
-      placeNextNodeAt += node[this.axisPreset.secondaryAxisDimension] + margin
-    }
-
-    return result
-  }
-
-  private spaceAround(
-    layer: Layer,
-    layoutRect: Rect,
-    placeNextLayerAt: number
-  ) {
-    const freeSpace = layoutRect[this.axisPreset.secondaryAxisDimension] - layer.occupiedSpace
-
-    const margin = freeSpace / (layer.nodes.length + 1)
-
-    let placeNextNodeAt = layoutRect[this.axisPreset.secondaryAxisCoord] + margin
-    const result = new Map<string, XYPosition>()
-
-    for (let node of sortBy(layer.nodes, n => n[this.axisPreset.secondaryAxisCoord])) {
-      result.set(node.id, {
-        [this.axisPreset.secondaryAxisCoord]: placeNextNodeAt,
-        [this.axisPreset.primaryAxisCoord]: placeNextLayerAt
-      } as XYPosition)
-      placeNextNodeAt += node[this.axisPreset.secondaryAxisDimension] + margin
-    }
-
-    return result
-  }
-}
 
 export function align(get: () => DiagramState) {
   return (mode: AlignmentMode) => {
@@ -226,18 +27,27 @@ export function align(get: () => DiagramState) {
 
     const aligner = getAligner(mode)
 
-    constraints.onMove((nodes) => {
-      aligner.computeLayout(nodes.map(({ node }) => node))
+    constraints.onMove(nodes => {
+      aligner.computeLayout(nodes.map(({ node }) => toNodeRect(node)))
 
       nodes.forEach(({ rect, node }) => {
         rect.positionAbsolute = {
           ...rect.positionAbsolute,
-          ...aligner.applyPosition(node)
+          ...aligner.applyPosition(toNodeRect(node))
         }
       })
     })
 
     scheduleSaveManualLayout()
+  }
+}
+
+function toNodeRect(node: InternalNode<XYFlowNode>): NodeRect {
+  return {
+    ...node.internals.positionAbsolute,
+    id: node.id,
+    width: getNodeDimensions(node).width,
+    height: getNodeDimensions(node).height
   }
 }
 
@@ -262,38 +72,38 @@ function getLinearAligner(mode: LinearAlignmentMode): Aligner {
   switch (mode) {
     case 'Left':
       return new LinearAligner(
-        nodes => Math.min(...nodes.map(n => n.internals.positionAbsolute.x)),
+        nodes => Math.min(...nodes.map(n => n.x)),
         (alignTo, _) => Math.floor(alignTo),
         'x'
       )
     case 'Top':
       return new LinearAligner(
-        nodes => Math.min(...nodes.map(n => n.internals.positionAbsolute.y)),
+        nodes => Math.min(...nodes.map(n => n.y)),
         (alignTo, _) => Math.floor(alignTo),
         'y'
       )
     case 'Right':
       return new LinearAligner(
-        nodes => Math.max(...nodes.map(n => n.internals.positionAbsolute.x + getNodeDimensions(n).width)),
+        nodes => Math.max(...nodes.map(n => n.x + n.width)),
         (alignTo, node) => Math.floor(alignTo - node.width!),
         'x'
       )
     case 'Bottom':
       return new LinearAligner(
-        nodes => Math.max(...nodes.map(n => n.internals.positionAbsolute.y + getNodeDimensions(n).height)),
+        nodes => Math.max(...nodes.map(n => n.y + n.height)),
         (alignTo, node) => Math.floor(alignTo - node.height!),
         'y'
       )
     case 'Center':
       return new LinearAligner(
-        nodes => Math.max(...nodes.map(n => n.internals.positionAbsolute.x + getNodeDimensions(n).width / 2)),
-        (alignTo, node) => Math.floor(alignTo - getNodeDimensions(node).width / 2),
+        nodes => Math.max(...nodes.map(n => n.x + n.width / 2)),
+        (alignTo, node) => Math.floor(alignTo - node.width / 2),
         'x'
       )
     case 'Middle':
       return new LinearAligner(
-        nodes => Math.max(...nodes.map(n => n.internals.positionAbsolute.y + getNodeDimensions(n).height / 2)),
-        (alignTo, node) => Math.floor(alignTo - getNodeDimensions(node).height / 2),
+        nodes => Math.max(...nodes.map(n => n.y + n.height / 2)),
+        (alignTo, node) => Math.floor(alignTo - node.height / 2),
         'y'
       )
   }

--- a/packages/diagram/src/state/diagramStore.layout.ts
+++ b/packages/diagram/src/state/diagramStore.layout.ts
@@ -5,10 +5,8 @@ import { hasAtLeast } from 'remeda'
 import type { DiagramState } from '../hooks'
 import type { XYFlowNode } from '../xyflow/types'
 import { createLayoutConstraints } from '../xyflow/useLayoutConstraints'
-import { type Aligner, GridAligner, LinearAligner, type NodeRect } from './aligners'
+import { type Aligner, getLinearAligner, GridAligner, type GridAlignmentMode, type LinearAlignmentMode, type NodeRect } from './aligners'
 
-type LinearAlignmentMode = 'Left' | 'Center' | 'Right' | 'Top' | 'Middle' | 'Bottom'
-type GridAlignmentMode = 'Column' | 'Row'
 export type AlignmentMode = LinearAlignmentMode | GridAlignmentMode
 
 export function align(get: () => DiagramState) {
@@ -65,46 +63,5 @@ function getAligner(mode: AlignmentMode): Aligner {
       return new GridAligner(mode)
     default:
       nonexhaustive(mode)
-  }
-}
-
-function getLinearAligner(mode: LinearAlignmentMode): Aligner {
-  switch (mode) {
-    case 'Left':
-      return new LinearAligner(
-        nodes => Math.min(...nodes.map(n => n.x)),
-        (alignTo, _) => Math.floor(alignTo),
-        'x'
-      )
-    case 'Top':
-      return new LinearAligner(
-        nodes => Math.min(...nodes.map(n => n.y)),
-        (alignTo, _) => Math.floor(alignTo),
-        'y'
-      )
-    case 'Right':
-      return new LinearAligner(
-        nodes => Math.max(...nodes.map(n => n.x + n.width)),
-        (alignTo, node) => Math.floor(alignTo - node.width!),
-        'x'
-      )
-    case 'Bottom':
-      return new LinearAligner(
-        nodes => Math.max(...nodes.map(n => n.y + n.height)),
-        (alignTo, node) => Math.floor(alignTo - node.height!),
-        'y'
-      )
-    case 'Center':
-      return new LinearAligner(
-        nodes => Math.max(...nodes.map(n => n.x + n.width / 2)),
-        (alignTo, node) => Math.floor(alignTo - node.width / 2),
-        'x'
-      )
-    case 'Middle':
-      return new LinearAligner(
-        nodes => Math.max(...nodes.map(n => n.y + n.height / 2)),
-        (alignTo, node) => Math.floor(alignTo - node.height / 2),
-        'y'
-      )
   }
 }

--- a/packages/diagram/src/ui/top-left/ManualLayoutToolsButton.tsx
+++ b/packages/diagram/src/ui/top-left/ManualLayoutToolsButton.tsx
@@ -6,6 +6,7 @@ import {
   IconLayoutAlignMiddle,
   IconLayoutAlignRight,
   IconLayoutAlignTop,
+  IconLayoutBoardSplit,
   IconLayoutCollage,
   IconRouteOff
 } from '@tabler/icons-react'
@@ -54,6 +55,13 @@ export const ManualLayoutToolsButton = (props: PopoverProps) => {
         <Group gap={'xs'}>
           <ActionIconGroup pos={'relative'}>
             <Action
+              label="Align in columns"
+              icon={<IconLayoutBoardSplit />}
+              onClick={e => {
+                e.stopPropagation()
+                store.getState().align('Column')
+              }} />
+            <Action
               label="Align left"
               icon={<IconLayoutAlignLeft />}
               onClick={e => {
@@ -73,6 +81,13 @@ export const ManualLayoutToolsButton = (props: PopoverProps) => {
               onClick={e => {
                 e.stopPropagation()
                 store.getState().align('Right')
+              }} />
+            <Action
+              label="Align in rows"
+              icon={<IconLayoutBoardSplit style={{ transform: 'rotate(90deg)' }} />}
+              onClick={e => {
+                e.stopPropagation()
+                store.getState().align('Row')
               }} />
             <Action
               label="Align top"


### PR DESCRIPTION
'Smart Layout' commands simplifies manual layouting. It tries to fit selected nodes into layers and arrange those nodes inside the layer with minimal adjustments. It is useful when you know what is the 'best' layout, but you don't want to manually align nodes to each other.

![smart-layout](https://github.com/user-attachments/assets/c96d36f7-5900-49ef-b8fa-a6b6e93ef351)
