### PR TITLE
#1259 Predicate to include all descendants `.**`

### DIFF
--- a/packages/core/src/builder/Builder.spec.ts
+++ b/packages/core/src/builder/Builder.spec.ts
@@ -234,7 +234,7 @@ describe('Builder', () => {
               "include": [
                 {
                   "element": "2",
-                  "isDescedants": true,
+                  "isChildren": true,
                 },
               ],
             },
@@ -309,7 +309,7 @@ describe('Builder', () => {
                 {
                   "inout": {
                     "element": "2.3",
-                    "isDescedants": true,
+                    "isChildren": true,
                   },
                 },
               ],
@@ -322,7 +322,7 @@ describe('Builder', () => {
                   },
                   "target": {
                     "element": "2.3",
-                    "isDescedants": true,
+                    "isChildren": true,
                   },
                 },
               ],

--- a/packages/core/src/builder/Builder.view.ts
+++ b/packages/core/src/builder/Builder.view.ts
@@ -311,12 +311,12 @@ function $expr<Types extends AnyTypes>(expr: ViewPredicate.Expression<Types> | C
   if (expr.endsWith('.*')) {
     return {
       element: expr.replace('.*', '') as Fqn,
-      isDescedants: true
+      isChildren: true
     } as TypedC4Expression<Types>
   }
   return {
     element: expr as any as Fqn,
-    isDescedants: false
+    isChildren: false
   } as TypedC4Expression<Types>
 }
 

--- a/packages/core/src/builder/Builder.view.ts
+++ b/packages/core/src/builder/Builder.view.ts
@@ -314,9 +314,15 @@ function $expr<Types extends AnyTypes>(expr: ViewPredicate.Expression<Types> | C
       isChildren: true
     } as TypedC4Expression<Types>
   }
+  if (expr.endsWith('.**')) {
+    return {
+      element: expr.replace('.**', '') as Fqn,
+      isDescendants: true
+    } as TypedC4Expression<Types>
+  }
   return {
     element: expr as any as Fqn,
-    isChildren: false
+    isChildren: false // TODO: why do we set this to false? Shouldn't undefined work too?
   } as TypedC4Expression<Types>
 }
 

--- a/packages/core/src/types/expression.ts
+++ b/packages/core/src/types/expression.ts
@@ -13,7 +13,7 @@ interface BaseExpr {
   elementKind?: never
   elementTag?: never
   isEqual?: never
-  isDescedants?: never
+  isChildren?: never
   wildcard?: never
   source?: never
   target?: never
@@ -23,9 +23,9 @@ interface BaseExpr {
   customRelation?: never
 }
 
-export interface ElementRefExpr extends Omit<BaseExpr, 'element' | 'isDescedants'> {
+export interface ElementRefExpr extends Omit<BaseExpr, 'element' | 'isChildren'> {
   element: Fqn
-  isDescedants?: boolean
+  isChildren?: boolean
 }
 export function isElementRef(expr: Expression): expr is ElementRefExpr {
   return 'element' in expr

--- a/packages/core/src/types/expression.ts
+++ b/packages/core/src/types/expression.ts
@@ -14,6 +14,8 @@ interface BaseExpr {
   elementTag?: never
   isEqual?: never
   isChildren?: never
+  isDescendants?: never
+  isLeafs?: never
   wildcard?: never
   source?: never
   target?: never
@@ -23,9 +25,10 @@ interface BaseExpr {
   customRelation?: never
 }
 
-export interface ElementRefExpr extends Omit<BaseExpr, 'element' | 'isChildren'> {
+export interface ElementRefExpr extends Omit<BaseExpr, 'element' | 'isChildren' | 'isDescendants'> {
   element: Fqn
   isChildren?: boolean
+  isDescendants?: boolean
 }
 export function isElementRef(expr: Expression): expr is ElementRefExpr {
   return 'element' in expr

--- a/packages/generators/src/__mocks__/data.ts
+++ b/packages/generators/src/__mocks__/data.ts
@@ -439,11 +439,11 @@ export const fakeComputedView3Levels: ComputedView = {
         },
         {
           element: 'cloud.frontend',
-          isDescedants: true
+          isChildren: true
         },
         {
           element: 'cloud.backend',
-          isDescedants: true
+          isChildren: true
         }
       ],
       isInclude: true
@@ -452,7 +452,7 @@ export const fakeComputedView3Levels: ComputedView = {
       exprs: [
         {
           element: 'cloud.frontend',
-          isDescedants: false
+          isChildren: false
         }
       ],
       isInclude: false

--- a/packages/language-server/src/like-c4.langium
+++ b/packages/language-server/src/like-c4.langium
@@ -372,7 +372,7 @@ ElementSelectorExpression infers ElementExpression:
 ElementDescedantsExpression infers ElementExpression:
   ElementRef (
     {infer ExpandElementExpression.expand=current} DotUnderscore |
-    {infer ElementDescedantsExpression.parent=current} DotWildcard
+    {infer ElementDescedantsExpression.parent=current} suffix=DotWildcard
   )?
 ;
 
@@ -675,7 +675,7 @@ terminal URI_WITH_SCHEMA: /\w+:\/\/\S+/;
 terminal URI_RELATIVE: /\.{0,2}\/[^\/]\S+/;
 
 terminal DotUnderscore: /\b\._/;
-terminal DotWildcard: /\b\.\*/;
+terminal DotWildcard: /\b\.\*{1,2}/;
 terminal Hash: '#';
 
 // No space allowed before dot

--- a/packages/language-server/src/model-graph/LikeC4ModelGraph.ts
+++ b/packages/language-server/src/model-graph/LikeC4ModelGraph.ts
@@ -100,10 +100,15 @@ export class LikeC4ModelGraph {
     return this._childrenOf(id).slice()
   }
 
-  // Get children or element itself if no children
-  public childrenOrElement(id: Fqn) {
-    const children = this.children(id)
-    return children.length > 0 ? children : [this.element(id)]
+  public descendants(id: Fqn) {
+    const result: Element[] = [];
+    this.descendantsDfs(id, result);
+    return result;
+  }
+
+  private descendantsDfs(id: Fqn, result: Element[]) {
+    result.push(this.element(id));
+    this.children(id).forEach(c => this.descendantsDfs(c.id, result));
   }
 
   // Get all sibling (i.e. same parent)

--- a/packages/language-server/src/model-graph/compute-view/__test__/fixture.ts
+++ b/packages/language-server/src/model-graph/compute-view/__test__/fixture.ts
@@ -519,12 +519,12 @@ export function $expr(expr: Expression | C4Expression): C4Expression {
   if (expr.endsWith('.*')) {
     return {
       element: expr.replace('.*', '') as Fqn,
-      isDescedants: true
+      isChildren: true
     }
   }
   return {
     element: expr as Fqn,
-    isDescedants: false
+    isChildren: false
   }
 }
 

--- a/packages/language-server/src/model-graph/compute-view/__test__/fixture.ts
+++ b/packages/language-server/src/model-graph/compute-view/__test__/fixture.ts
@@ -522,9 +522,14 @@ export function $expr(expr: Expression | C4Expression): C4Expression {
       isChildren: true
     }
   }
+  if (expr.endsWith('.**')) {
+    return {
+      element: expr.replace('.*', '') as Fqn,
+      isDescendants: true
+    }
+  }
   return {
-    element: expr as Fqn,
-    isChildren: false
+    element: expr as Fqn
   }
 }
 

--- a/packages/language-server/src/model-graph/compute-view/__test__/legacy.spec.ts
+++ b/packages/language-server/src/model-graph/compute-view/__test__/legacy.spec.ts
@@ -335,7 +335,7 @@ describe('compute-element-view', () => {
       // cloud.*
       // shape: browser
       {
-        targets: [{ element: 'cloud' as Fqn, isDescedants: true }],
+        targets: [{ element: 'cloud' as Fqn, isChildren: true }],
         style: {
           shape: 'browser'
         }

--- a/packages/language-server/src/model-graph/compute-view/predicates.ts
+++ b/packages/language-server/src/model-graph/compute-view/predicates.ts
@@ -23,7 +23,7 @@ export function includeElementRef(this: ComputeCtx, expr: Expr.ElementRefExpr, w
   const filter = filterBy(where)
 
   const elements = filter(
-    expr.isDescedants === true
+    expr.isChildren === true
       ? this.graph.childrenOrElement(expr.element)
       : [this.graph.element(expr.element)]
   )
@@ -266,11 +266,11 @@ function resolveElements(this: ComputeCtx, expr: Expr.ElementExpression): Elemen
     return nonexhaustive(expr)
   }
 
-  if (this.root === expr.element && expr.isDescedants !== true) {
+  if (this.root === expr.element && expr.isChildren !== true) {
     return [...this.graph.children(this.root), this.graph.element(this.root)]
   }
 
-  if (expr.isDescedants) {
+  if (expr.isChildren) {
     return this.graph.childrenOrElement(expr.element)
   } else {
     return [this.graph.element(expr.element)]
@@ -296,10 +296,10 @@ function edgesIncomingExpr(this: ComputeCtx, expr: Expr.ElementExpression) {
   let sources = [...this.resolvedElements]
   if (Expr.isElementRef(expr) || Expr.isExpandedElementExpr(expr)) {
     const exprElement = expr.element ?? expr.expanded
-    const isDescedants = expr.isDescedants ?? false
+    const isChildren = expr.isChildren ?? false
     sources = sources.filter(el =>
       // allow elements, that are not nested or are direct children
-      !isAncestor(exprElement, el.id) || (isDescedants && parentFqn(el.id) === exprElement)
+      !isAncestor(exprElement, el.id) || (isChildren && parentFqn(el.id) === exprElement)
     )
   }
   if (sources.length === 0) {
@@ -361,10 +361,10 @@ function edgesOutgoingExpr(this: ComputeCtx, expr: Expr.ElementExpression) {
   let targets = [...this.resolvedElements]
   if (Expr.isElementRef(expr) || Expr.isExpandedElementExpr(expr)) {
     const sourceElement = expr.element ?? expr.expanded
-    const isDescedants = expr.isDescedants ?? false
+    const isChildren = expr.isChildren ?? false
     targets = targets.filter(el =>
       // allow elements, that are not nested or are direct children
-      !isAncestor(sourceElement, el.id) || (isDescedants && parentFqn(el.id) === sourceElement)
+      !isAncestor(sourceElement, el.id) || (isChildren && parentFqn(el.id) === sourceElement)
     )
   }
   if (targets.length === 0) {
@@ -419,10 +419,10 @@ function edgesInOutExpr(this: ComputeCtx, { inout }: Expr.InOutExpr, where?: Rel
 
   if (Expr.isElementRef(inout) || Expr.isExpandedElementExpr(inout)) {
     const exprElement = inout.element ?? inout.expanded
-    const isDescedants = inout.isDescedants ?? false
+    const isChildren = inout.isChildren ?? false
     currentElements = currentElements.filter(el =>
       // allow elements, that are not nested or are direct children
-      !isAncestor(exprElement, el.id) || (isDescedants && parentFqn(el.id) === exprElement)
+      !isAncestor(exprElement, el.id) || (isChildren && parentFqn(el.id) === exprElement)
     )
   }
   if (currentElements.length === 0) {
@@ -463,7 +463,7 @@ export function excludeInOutExpr(this: ComputeCtx, expr: Expr.InOutExpr, where?:
  *   }
  */
 function resolveRelationExprElements(this: ComputeCtx, expr: Expr.ElementExpression) {
-  if (Expr.isElementRef(expr) && this.root === expr.element && expr.isDescedants !== true) {
+  if (Expr.isElementRef(expr) && this.root === expr.element && expr.isChildren !== true) {
     return [...this.graph.children(expr.element), this.graph.element(expr.element)]
   }
   if (Expr.isExpandedElementExpr(expr) && this.root === expr.expanded) {

--- a/packages/language-server/src/model-graph/utils/elementExpressionToPredicate.ts
+++ b/packages/language-server/src/model-graph/utils/elementExpressionToPredicate.ts
@@ -27,8 +27,8 @@ export function elementExprToPredicate<T extends Pick<Element, 'id' | 'kind' | '
     return n => n.id === target.expanded || parentFqn(n.id) === target.expanded
   }
   if (Expr.isElementRef(target)) {
-    const { element, isDescedants } = target
-    return isDescedants
+    const { element, isChildren } = target
+    return isChildren
       ? n => n.id.startsWith(element + '.')
       : n => (n.id as string) === element
   }

--- a/packages/language-server/src/model-graph/utils/elementExpressionToPredicate.ts
+++ b/packages/language-server/src/model-graph/utils/elementExpressionToPredicate.ts
@@ -27,8 +27,8 @@ export function elementExprToPredicate<T extends Pick<Element, 'id' | 'kind' | '
     return n => n.id === target.expanded || parentFqn(n.id) === target.expanded
   }
   if (Expr.isElementRef(target)) {
-    const { element, isChildren } = target
-    return isChildren
+    const { element, isChildren, isDescendants } = target
+    return isChildren || isDescendants
       ? n => n.id.startsWith(element + '.')
       : n => (n.id as string) === element
   }

--- a/packages/language-server/src/model/model-parser.ts
+++ b/packages/language-server/src/model/model-parser.ts
@@ -501,7 +501,7 @@ export class LikeC4ModelParser {
       const element = this.resolveFqn(elementNode)
       return {
         element,
-        isDescedants: true
+        isChildren: true
       }
     }
     if (ast.isElementRef(astNode)) {

--- a/packages/language-server/src/model/model-parser.ts
+++ b/packages/language-server/src/model/model-parser.ts
@@ -501,7 +501,8 @@ export class LikeC4ModelParser {
       const element = this.resolveFqn(elementNode)
       return {
         element,
-        isChildren: true
+        isChildren: astNode.suffix === '.*',
+        isDescendants: astNode.suffix === '.**'
       }
     }
     if (ast.isElementRef(astNode)) {

--- a/packages/language-server/src/view-utils/resolve-extended-views.spec.ts
+++ b/packages/language-server/src/view-utils/resolve-extended-views.spec.ts
@@ -20,7 +20,7 @@ describe('resolveRulesExtendedViews', () => {
     exclude: [
       {
         element: 'cloud' as Fqn,
-        isDescedants: true
+        isChildren: true
       }
     ]
   }

--- a/packages/layouts/src/graphviz/__fixtures__/model.ts
+++ b/packages/layouts/src/graphviz/__fixtures__/model.ts
@@ -270,15 +270,15 @@ export const cloud3levels = {
         // include *
         { wildcard: true },
         // include cloud.frontend.*
-        { element: fakeElements['cloud.frontend'].id, isDescedants: true },
+        { element: fakeElements['cloud.frontend'].id, isChildren: true },
         // include cloud.backend.*
-        { element: fakeElements['cloud.backend'].id, isDescedants: true }
+        { element: fakeElements['cloud.backend'].id, isChildren: true }
       ]
     },
     {
       exclude: [
         // exclude cloud.frontend
-        { element: 'cloud.frontend' as Fqn, isDescedants: false }
+        { element: 'cloud.frontend' as Fqn, isChildren: false }
       ]
     }
   ]
@@ -299,11 +299,11 @@ export const amazonView = {
         // include *
         { wildcard: true },
         // include cloud
-        { element: 'cloud' as Fqn, isDescedants: false },
+        { element: 'cloud' as Fqn, isChildren: false },
         // include cloud.* -> amazon
         {
-          source: { element: 'cloud' as Fqn, isDescedants: true },
-          target: { element: 'amazon' as Fqn, isDescedants: false }
+          source: { element: 'cloud' as Fqn, isChildren: true },
+          target: { element: 'amazon' as Fqn, isChildren: false }
         }
       ]
     }


### PR DESCRIPTION
Add a new predicate `.**` to include all of an element's descendants into a view. 

Example:
```
views {
  view index {
    include.saas.**
  }
}
```

@davydkov, where do you want me to update the documentation? After the current documentation for `.*` might be a good place.