### PR TITLE
refactor: overlay deduplication

### DIFF
--- a/packages/core/src/builder/Builder.model.ts
+++ b/packages/core/src/builder/Builder.model.ts
@@ -1,16 +1,16 @@
-import type { Element, Fqn, Relation } from '../types'
+import type { Element, Fqn, ModelRelation } from '../types'
 import type { AnyTypes, AnyTypesNested, Invalid, Types } from './_types'
 import type { Builder } from './Builder'
 import type { AddElement } from './Builder.element'
 
 export interface ModelBuilder<T extends AnyTypes> {
   addElement(element: Element): Builder<T>
-  addRelation(relation: Omit<Relation, 'id'>): Builder<T>
+  addRelation(relation: Omit<ModelRelation, 'id'>): Builder<T>
   /**
    * Create a fully qualified name from an id (for nested models)
    */
   fqn(id: string): Fqn
-  addSourcelessRelation(relation: Omit<Relation, 'id' | 'source'>): Builder<T>
+  addSourcelessRelation(relation: Omit<ModelRelation, 'id' | 'source'>): Builder<T>
 }
 
 export function model<

--- a/packages/core/src/builder/Builder.ts
+++ b/packages/core/src/builder/Builder.ts
@@ -21,7 +21,7 @@ import {
   type Link,
   type ModelGlobals,
   type NonEmptyArray,
-  type Relation,
+  type ModelRelation,
   type RelationId,
   type Tag
 } from '../types'
@@ -242,7 +242,7 @@ export interface Builder<T extends AnyTypes> {
 function builder<Spec extends BuilderSpecification, T extends AnyTypes>(
   spec: Spec,
   _elements = new Map<string, Element>(),
-  _relations = [] as Relation[],
+  _relations = [] as ModelRelation[],
   _views = new Map<string, LikeC4View>(),
   _globals = {
     predicates: {},

--- a/packages/core/src/compute-view/LikeC4ModelGraph.ts
+++ b/packages/core/src/compute-view/LikeC4ModelGraph.ts
@@ -1,12 +1,12 @@
 import { isArray, isString, reverse } from 'remeda'
 import { invariant } from '../errors'
-import { type Element, type Fqn, type ModelGlobals, type Relation, type RelationId } from '../types'
+import { type Element, type Fqn, type ModelGlobals, type ModelRelation, type RelationId } from '../types'
 import { ancestorsFqn, commonAncestor, getOrCreate, isSameHierarchy, parentFqn } from '../utils'
 import { intersection } from '../utils/set'
 
 export type Params = {
   elements: Record<Fqn, Element>
-  relations: Record<RelationId, Relation>
+  relations: Record<RelationId, ModelRelation>
   // Optional for tests
   globals?: ModelGlobals
 }
@@ -14,14 +14,14 @@ export type Params = {
 type RelationEdge = {
   source: Element
   target: Element
-  relations: Relation[]
+  relations: ModelRelation[]
 }
 
 type FqnOrElement = Fqn | Element
 type FqnsOrElements = ReadonlyArray<Fqn> | ReadonlyArray<Element>
 
-const RelationsSet = Set<Relation>
-const MapRelations = Map<Fqn, Set<Relation>>
+const RelationsSet = Set<ModelRelation>
+const MapRelations = Map<Fqn, Set<ModelRelation>>
 /**
  * Used only for views calculations.
  * Subject to change.
@@ -34,7 +34,7 @@ export class LikeC4ModelGraph {
   readonly #children = new Map<Fqn, Element[]>()
   readonly #rootElements = new Set<Element>()
 
-  readonly #relations = new Map<RelationId, Relation>()
+  readonly #relations = new Map<RelationId, ModelRelation>()
   // Incoming to an element or its descendants
   readonly #incoming = new MapRelations()
   // Outgoing from an element or its descendants
@@ -130,11 +130,11 @@ export class LikeC4ModelGraph {
     ])
   }
 
-  public incoming(element: Fqn | Element): ReadonlySet<Relation> {
+  public incoming(element: Fqn | Element): ReadonlySet<ModelRelation> {
     return this._incomingTo(isString(element) ? element : element.id)
   }
 
-  public outgoing(element: Fqn | Element): ReadonlySet<Relation> {
+  public outgoing(element: Fqn | Element): ReadonlySet<ModelRelation> {
     return this._outgoingFrom(isString(element) ? element : element.id)
   }
 
@@ -261,7 +261,7 @@ export class LikeC4ModelGraph {
     }
   }
 
-  private addRelation(rel: Relation) {
+  private addRelation(rel: ModelRelation) {
     if (this.#relations.has(rel.id)) {
       throw new Error(`Relation ${rel.id} already exists`)
     }

--- a/packages/core/src/compute-view/element-view/__test__/fixture.ts
+++ b/packages/core/src/compute-view/element-view/__test__/fixture.ts
@@ -24,7 +24,7 @@ import {
   isRelationWhere,
   type NonEmptyArray,
   type OutgoingExpr as C4OutgoingExpr,
-  type Relation,
+  type ModelRelation,
   type RelationExpr as C4RelationExpr,
   type RelationId,
   type RelationshipArrowType,
@@ -256,7 +256,7 @@ const rel = <Source extends FakeElementIds, Target extends FakeElementIds>({
     source: source as Fqn,
     target: target as Fqn,
     ...(props as any)
-  }) as Omit<Relation, 'id'> & { id: `${Source}:${Target}` }
+  }) as Omit<ModelRelation, 'id'> & { id: `${Source}:${Target}` }
 
 export const fakeRelations = [
   rel({

--- a/packages/core/src/compute-view/element-view/compute.spec.ts
+++ b/packages/core/src/compute-view/element-view/compute.spec.ts
@@ -1,6 +1,6 @@
 import { indexBy } from 'remeda'
 import { describe, expect, it } from 'vitest'
-import type { Element, ElementView, Relation, Tag, ViewId, ViewRule } from '../../types'
+import type { Element, ElementView, ModelRelation, Tag, ViewId, ViewRule } from '../../types'
 import { LikeC4ModelGraph } from '../LikeC4ModelGraph'
 import { withReadableEdges } from '../utils/with-readable-edges'
 import { $include, fakeElements } from './__test__/fixture'
@@ -10,12 +10,12 @@ function el(id: string): Element {
   return { id } as Element
 }
 
-function r(source: string, target: string): Relation {
+function r(source: string, target: string): ModelRelation {
   return {
     id: `${source}:${target}`,
     source,
     target
-  } as Relation
+  } as ModelRelation
 }
 
 function v(rules: ViewRule[]): ElementView {

--- a/packages/core/src/compute-view/element-view/compute.ts
+++ b/packages/core/src/compute-view/element-view/compute.ts
@@ -32,7 +32,7 @@ import {
   isViewRulePredicate,
   type NodeId,
   type NonEmptyArray,
-  type Relation,
+  type ModelRelation,
   type RelationPredicateExpression,
   type RelationshipArrowType,
   type RelationshipKind,
@@ -85,7 +85,7 @@ export namespace ComputeCtx {
   export interface Edge {
     source: Element
     target: Element
-    relations: Relation[]
+    relations: ModelRelation[]
   }
 }
 
@@ -319,7 +319,7 @@ export class ComputeCtx {
         line?: RelationshipLineType | undefined
         head?: RelationshipArrowType | undefined
         tail?: RelationshipArrowType | undefined
-        tags?: NonEmptyArray<Tag>
+        tags?: NonEmptyArray<Tag> | null
         navigateTo?: ViewId | undefined
       } | undefined
       relation = only(relations) ?? pipe(
@@ -473,7 +473,7 @@ export class ComputeCtx {
     })
   }
 
-  protected excludeRelation(...relations: Relation[]) {
+  protected excludeRelation(...relations: ModelRelation[]) {
     if (relations.length === 0) {
       return
     }
@@ -527,17 +527,17 @@ export class ComputeCtx {
   // Filter out edges if there are edges between descendants
   // i.e. remove implicit edges, derived from childs
   protected removeRedundantImplicitEdges() {
-    const processedRelations = new Set<Relation>()
+    const processedRelations = new Set<ModelRelation>()
 
     // Returns relations, that are not processed/included
-    const excludeProcessed = (relations: Relation[]) =>
+    const excludeProcessed = (relations: ModelRelation[]) =>
       relations.reduce((acc, rel) => {
         if (!processedRelations.has(rel)) {
           acc.push(rel)
           processedRelations.add(rel)
         }
         return acc
-      }, [] as Relation[])
+      }, [] as ModelRelation[])
 
     // Returns predicate
     const isNestedEdgeOf = (parent: ComputeCtx.Edge) => {

--- a/packages/core/src/compute-view/element-view/predicates.ts
+++ b/packages/core/src/compute-view/element-view/predicates.ts
@@ -1,7 +1,7 @@
 import { allPass, filter as remedaFilter, flatMap, isNullish as isNil, map, pipe, unique } from 'remeda'
 import type { Writable } from 'type-fest'
 import { nonexhaustive } from '../../errors'
-import type { Element, Relation } from '../../types'
+import type { Element, ModelRelation } from '../../types'
 import * as Expr from '../../types/expression'
 import { isAncestor, parentFqn } from '../../utils/fqn'
 import { elementExprToPredicate } from '../utils/elementExpressionToPredicate'
@@ -9,7 +9,7 @@ import type { ComputeCtx } from './compute'
 
 type Predicate<T> = (x: T) => boolean
 export type ElementPredicateFn = Predicate<Element>
-export type RelationPredicateFn = Predicate<Relation>
+export type RelationPredicateFn = Predicate<ModelRelation>
 // // type ElementPredicate = Predicate<Element>
 // type ElementPredicates<T> = T extends Element[] ? (x: T) => T : (T extends Element ? (x: T) => (Element | null) : never)
 // type ElementPredicate = ElementPredicates<Element | Element[]>

--- a/packages/core/src/compute-view/utils/derive-edge-props-from-relationships.ts
+++ b/packages/core/src/compute-view/utils/derive-edge-props-from-relationships.ts
@@ -1,9 +1,9 @@
 import { isTruthy, only, pick, pickBy, pipe, reduce, unique } from 'remeda'
 import type { Color, DeploymentRelation, Link, Tag, ViewId } from '../../types'
-import type { Relation, RelationshipArrowType, RelationshipKind, RelationshipLineType } from '../../types/relation'
+import type { ModelRelation, RelationshipArrowType, RelationshipKind, RelationshipLineType } from '../../types/relation'
 import { isNonEmptyArray } from '../../utils'
 
-export function pickRelationshipProps(relation: Relation | DeploymentRelation) {
+export function pickRelationshipProps(relation: ModelRelation | DeploymentRelation) {
   return pick(relation, [
     'title',
     'description',
@@ -20,7 +20,7 @@ export function pickRelationshipProps(relation: Relation | DeploymentRelation) {
 }
 type RelationshipProps = ReturnType<typeof pickRelationshipProps>
 
-export function deriveEdgePropsFromRelationships(relations: Array<Relation | DeploymentRelation>) {
+export function deriveEdgePropsFromRelationships(relations: Array<ModelRelation | DeploymentRelation>) {
   // TODO:
   const allprops = pipe(
     relations,

--- a/packages/core/src/compute-view/utils/relationExpressionToPredicates.ts
+++ b/packages/core/src/compute-view/utils/relationExpressionToPredicates.ts
@@ -10,12 +10,12 @@ import {
   type RelationWhereExpr
 } from '../../types/expression'
 import { whereOperatorAsPredicate } from '../../types/operators'
-import type { Relation } from '../../types/relation'
+import type { ModelRelation } from '../../types/relation'
 import type { ComputedNode } from '../../types/view'
 import { elementExprToPredicate } from './elementExpressionToPredicate'
 
 type Predicate<T> = (x: T) => boolean
-export type FilterableEdge = Pick<Relation, 'kind' | 'tags'> & {
+export type FilterableEdge = Pick<ModelRelation, 'kind' | 'tags'> & {
   source: ComputedNode
   target: ComputedNode
 }

--- a/packages/core/src/model/LikeC4Model.ts
+++ b/packages/core/src/model/LikeC4Model.ts
@@ -6,7 +6,7 @@ import type { ComputedView, DiagramView } from '../types'
 import type { Element } from '../types/element'
 import { type Tag as C4Tag } from '../types/element'
 import type { AnyLikeC4Model, ParsedLikeC4ModelDump } from '../types/model'
-import type { Relation } from '../types/relation'
+import type { ModelRelation } from '../types/relation'
 import { compareNatural } from '../utils'
 import { ancestorsFqn, commonAncestor, parentFqn } from '../utils/fqn'
 import type {
@@ -318,7 +318,7 @@ export class LikeC4Model<M extends AnyAux = LikeC4Model.Any> {
     return el
   }
 
-  private addRelation(relation: Relation) {
+  private addRelation(relation: ModelRelation) {
     if (this.#relations.has(relation.id)) {
       throw new Error(`Relation ${relation.id} already exists`)
     }

--- a/packages/core/src/model/RelationModel.ts
+++ b/packages/core/src/model/RelationModel.ts
@@ -1,6 +1,6 @@
 import { isEmpty } from 'remeda'
 import type { Link, Tag } from '../types/element'
-import type { Relation } from '../types/relation'
+import type { ModelRelation } from '../types/relation'
 import { commonAncestor } from '../utils/fqn'
 import type { ElementModel } from './ElementModel'
 import type { LikeC4Model } from './LikeC4Model'
@@ -21,7 +21,7 @@ export class RelationshipModel<M extends AnyAux> {
 
   constructor(
     public readonly model: LikeC4Model<M>,
-    public readonly $relationship: Relation
+    public readonly $relationship: ModelRelation
   ) {
     this.source = model.element($relationship.source)
     this.target = model.element($relationship.target)

--- a/packages/core/src/types/deployments.ts
+++ b/packages/core/src/types/deployments.ts
@@ -1,7 +1,7 @@
 import type { MergeExclusive, Simplify, Tagged, UnionToIntersection } from 'type-fest'
 import type { IconUrl, NonEmptyArray } from './_common'
 import type { ElementShape, ElementStyle, Fqn, Link, Tag } from './element'
-import type { RelationId, RelationshipArrowType, RelationshipKind, RelationshipLineType } from './relation'
+import type { AbstractRelation, RelationId, RelationshipArrowType, RelationshipKind, RelationshipLineType } from './relation'
 import type { Color } from './theme'
 import type { ViewId } from './view'
 
@@ -97,23 +97,10 @@ export interface DeploymentRef {
 /**
  * NOTE:
  */
-export interface DeploymentRelation {
+export interface DeploymentRelation extends AbstractRelation {
   readonly id: RelationId
   readonly source: DeploymentRef
   readonly target: DeploymentRef
-  readonly title?: string
-  readonly tags?: NonEmptyArray<Tag> | null
-  readonly description?: string
-  readonly technology?: string
-  readonly kind?: RelationshipKind
-  readonly color?: Color
-  readonly line?: RelationshipLineType
-  readonly head?: RelationshipArrowType
-  readonly tail?: RelationshipArrowType
-  readonly links?: NonEmptyArray<Link> | null
-  // Link to dynamic view
-  readonly navigateTo?: ViewId
-  readonly metadata?: { [key: string]: string }
 }
 // export interface DeploymentRelation
 

--- a/packages/core/src/types/model.ts
+++ b/packages/core/src/types/model.ts
@@ -7,7 +7,7 @@ import type {
 } from './deployments'
 import type { ElementKindSpecification, Tag, TypedElement } from './element'
 import type { ModelGlobals } from './global'
-import type { Relation, RelationId, RelationshipKindSpecification } from './relation'
+import type { ModelRelation, RelationId, RelationshipKindSpecification } from './relation'
 import type { ComputedView, DiagramView, LikeC4View } from './view'
 
 /**
@@ -28,7 +28,7 @@ export interface ParsedLikeC4Model<
     relationships: Record<RelationKinds, RelationshipKindSpecification>
   }
   elements: Record<Fqns, TypedElement<Fqns, ElementKinds, Tags>>
-  relations: Record<RelationId, Relation>
+  relations: Record<RelationId, ModelRelation>
   globals: ModelGlobals
   views: Record<Views, LikeC4View<Views, Tags>>
   /**

--- a/packages/core/src/types/relation.ts
+++ b/packages/core/src/types/relation.ts
@@ -26,24 +26,28 @@ export const DefaultLineStyle = 'dashed' satisfies RelationshipLineType
 export const DefaultArrowType = 'normal' satisfies RelationshipArrowType
 export const DefaultRelationshipColor = 'gray' satisfies ThemeColor
 
-// TODO: rename to Relationship
-export interface Relation {
+export interface AbstractRelation {
   readonly id: RelationId
-  readonly source: Fqn
-  readonly target: Fqn
-  readonly title: string
+  readonly title?: string
   readonly description?: string
   readonly technology?: string
-  readonly tags?: NonEmptyArray<Tag>
+  readonly tags?: NonEmptyArray<Tag> | null
   readonly kind?: RelationshipKind
   readonly color?: Color
   readonly line?: RelationshipLineType
   readonly head?: RelationshipArrowType
   readonly tail?: RelationshipArrowType
-  readonly links?: NonEmptyArray<Link>
+  readonly links?: NonEmptyArray<Link> | null
   // Link to dynamic view
   readonly navigateTo?: ViewId
   readonly metadata?: { [key: string]: string }
+}
+
+// TODO: rename to Relationship
+export interface ModelRelation extends AbstractRelation {
+  readonly source: Fqn
+  readonly target: Fqn
+  readonly title: string
 }
 
 export interface RelationshipKindSpecification {

--- a/packages/core/src/utils/relations.spec.ts
+++ b/packages/core/src/utils/relations.spec.ts
@@ -1,6 +1,6 @@
 import { sort } from 'remeda'
 import { describe, expect, it } from 'vitest'
-import type { Fqn, Relation, RelationId } from '../types'
+import type { Fqn, ModelRelation, RelationId } from '../types'
 import { compareRelations, isAnyBetween, isAnyInOut, isBetween, isIncoming, isInside, isOutgoing } from './relations'
 
 const relations = [
@@ -46,10 +46,10 @@ const relations = [
     target: 'cloud.backend.graphql' as Fqn,
     title: ''
   }
-] satisfies Relation[]
+] satisfies ModelRelation[]
 
 describe('relation predicates', () => {
-  const expectRelations = (predicate: (relation: Relation) => boolean) =>
+  const expectRelations = (predicate: (relation: ModelRelation) => boolean) =>
     expect(relations.filter(predicate).map(r => r.id))
 
   const customer = 'customer' as Fqn

--- a/packages/diagram/src/overlays/edge-details/EdgeDetailsXYFlow.tsx
+++ b/packages/diagram/src/overlays/edge-details/EdgeDetailsXYFlow.tsx
@@ -20,6 +20,7 @@ import { CompoundNode } from './xyflow/CompoundNode'
 import { ElementNode } from './xyflow/ElementNode'
 import { RelationshipEdge } from './xyflow/RelationshipEdge'
 import type { SharedTypes } from '../shared/xyflow/_types'
+import { only } from 'remeda'
 
 const nodeTypes = {
   element: ElementNode,
@@ -195,8 +196,10 @@ export const EdgeDetailsXYFlow = memo<{ edgeId: EdgeId }>(function EdgeDetailsXY
       // }}
       onEdgeClick={(e, edge) => {
         e.stopPropagation()
+        // edge-details only ever deals with edges that represent only one relation
+        let relationId = only(edge.data.relations)!.id;
         diagramStore.getState().onOpenSource?.({
-          relation: edge.data.relationId
+          relation: relationId
         })
       }}
       // onEdgeClick={(e, edge) => {

--- a/packages/diagram/src/overlays/edge-details/EdgeDetailsXYFlow.tsx
+++ b/packages/diagram/src/overlays/edge-details/EdgeDetailsXYFlow.tsx
@@ -19,6 +19,7 @@ import { useLayoutedEdgeDetails, ZIndexes } from './use-layouted-edge-details'
 import { CompoundNode } from './xyflow/CompoundNode'
 import { ElementNode } from './xyflow/ElementNode'
 import { RelationshipEdge } from './xyflow/RelationshipEdge'
+import type { SharedTypes } from '../shared/xyflow/_types'
 
 const nodeTypes = {
   element: ElementNode,
@@ -28,7 +29,7 @@ const edgeTypes = {
   relation: RelationshipEdge
 }
 
-const resetDimmedAndHovered = (xyflow: ReactFlowInstance<XYFlowTypes.Node, XYFlowTypes.Edge>) => {
+const resetDimmedAndHovered = (xyflow: ReactFlowInstance<SharedTypes.Node, XYFlowTypes.Edge>) => {
   xyflow.setEdges(edges =>
     edges.map(edge => ({
       ...edge,
@@ -49,12 +50,12 @@ const resetDimmedAndHovered = (xyflow: ReactFlowInstance<XYFlowTypes.Node, XYFlo
           dimmed: false,
           hovered: false
         }
-      }) as XYFlowTypes.Node
+      }) as SharedTypes.Node
     )
   )
 }
 
-const animateEdge = (node: XYFlowTypes.Node, animated = true) => (edges: XYFlowTypes.Edge[]) => {
+const animateEdge = (node: SharedTypes.Node, animated = true) => (edges: XYFlowTypes.Edge[]) => {
   return edges.map(edge => {
     const isConnected = edge.source === node.id || edge.target === node.id || isAncestor(node.id, edge.source)
       || isAncestor(node.id, edge.target)
@@ -78,8 +79,8 @@ export const EdgeDetailsXYFlow = memo<{ edgeId: EdgeId }>(function EdgeDetailsXY
 
   const boundsRef = useSyncedRef(bounds)
 
-  const xyflow = useReactFlow<XYFlowTypes.Node, XYFlowTypes.Edge>()
-  const xystore = useStoreApi<XYFlowTypes.Node, XYFlowTypes.Edge>()
+  const xyflow = useReactFlow<SharedTypes.Node, XYFlowTypes.Edge>()
+  const xystore = useStoreApi<SharedTypes.Node, XYFlowTypes.Edge>()
 
   const fitview = useDebouncedCallback(
     () => {
@@ -116,7 +117,7 @@ export const EdgeDetailsXYFlow = memo<{ edgeId: EdgeId }>(function EdgeDetailsXY
   return (
     <ReactFlow
       defaultEdges={[] as XYFlowTypes.Edge[]}
-      defaultNodes={[] as XYFlowTypes.Node[]}
+      defaultNodes={[] as SharedTypes.Node[]}
       nodeTypes={nodeTypes}
       edgeTypes={edgeTypes}
       defaultMarkerColor="var(--xy-edge-stroke)"
@@ -168,7 +169,7 @@ export const EdgeDetailsXYFlow = memo<{ edgeId: EdgeId }>(function EdgeDetailsXY
               ...n.data,
               dimmed: n.id !== edge.source && n.id !== edge.target
             }
-          } as XYFlowTypes.Node))
+          } as SharedTypes.Node))
         )
       }}
       onEdgeMouseLeave={() => {

--- a/packages/diagram/src/overlays/edge-details/EdgeDetailsXYFlow.tsx
+++ b/packages/diagram/src/overlays/edge-details/EdgeDetailsXYFlow.tsx
@@ -197,10 +197,12 @@ export const EdgeDetailsXYFlow = memo<{ edgeId: EdgeId }>(function EdgeDetailsXY
       onEdgeClick={(e, edge) => {
         e.stopPropagation()
         // edge-details only ever deals with edges that represent only one relation
-        let relationId = only(edge.data.relations)!.id;
-        diagramStore.getState().onOpenSource?.({
-          relation: relationId
-        })
+        let relationId = only(edge.data.relations)?.id;
+        if (relationId) {
+          diagramStore.getState().onOpenSource?.({
+            relation: relationId
+          })
+        }
       }}
       // onEdgeClick={(e, edge) => {
       //   e.stopPropagation()

--- a/packages/diagram/src/overlays/edge-details/_types.ts
+++ b/packages/diagram/src/overlays/edge-details/_types.ts
@@ -1,29 +1,8 @@
-import type { ComputedNode, Fqn, RelationId, ViewId } from '@likec4/core'
-import type { Edge as ReactFlowEdge, Node as ReactFlowNode } from '@xyflow/react'
+import type { RelationId, ViewId } from '@likec4/core'
+import type { Edge as ReactFlowEdge } from '@xyflow/react'
 import type { SetRequired } from 'type-fest'
 
 export namespace XYFlowTypes {
-  type NodeData = {
-    fqn: Fqn
-    element: Pick<ComputedNode, 'color' | 'title' | 'description' | 'shape' | 'kind'>
-    ports: {
-      in: string[]
-      out: string[]
-    }
-    navigateTo: ViewId | null
-    hovered?: boolean
-    /**
-     * Whether the node is dimmed
-     * 'immediate' means that the node is dimmed without delay
-     */
-    dimmed?: 'immediate' | boolean
-  }
-
-  export type ElementNode = SetRequired<ReactFlowNode<NodeData, 'element'>, 'type'>
-
-  export type CompoundNode = SetRequired<ReactFlowNode<NodeData, 'compound'>, 'type'>
-
-  export type Node = ElementNode | CompoundNode
 
   type EdgeData = {
     technology: string | null

--- a/packages/diagram/src/overlays/edge-details/_types.ts
+++ b/packages/diagram/src/overlays/edge-details/_types.ts
@@ -1,5 +1,5 @@
 import type { ComputedNode, Fqn, RelationId, ViewId } from '@likec4/core'
-import type { Edge as ReactFlowEdge, Node as ReactFlowNode, ReactFlowInstance } from '@xyflow/react'
+import type { Edge as ReactFlowEdge, Node as ReactFlowNode } from '@xyflow/react'
 import type { SetRequired } from 'type-fest'
 
 export namespace XYFlowTypes {
@@ -35,7 +35,5 @@ export namespace XYFlowTypes {
     dimmed?: boolean
   }
 
-  export type Edge = SetRequired<ReactFlowEdge<EdgeData, 'relation'>, 'data' | 'type'>;
-
-  export type Instance = ReactFlowInstance<Node, Edge>
+  export type Edge = SetRequired<ReactFlowEdge<EdgeData, 'relation'>, 'data' | 'type'>
 }

--- a/packages/diagram/src/overlays/edge-details/_types.ts
+++ b/packages/diagram/src/overlays/edge-details/_types.ts
@@ -1,18 +1,12 @@
-import type { AbstractRelation, ViewId } from '@likec4/core'
-import type { Edge as ReactFlowEdge } from '@xyflow/react'
-import type { SetRequired } from 'type-fest'
+import type { SharedTypes } from '../shared/xyflow/_types'
+import type { AddEdgeData } from '../../utils/types'
 
 export namespace XYFlowTypes {
 
-  type EdgeData = {
+  type EdgeDetailsEdgeData = {
     technology: string | null
     description: string | null
-    relations: [AbstractRelation, ...AbstractRelation[]]
-    // relation: Relation
-    navigateTo: ViewId | null
-    hovered?: boolean
-    dimmed?: boolean
   }
 
-  export type Edge = SetRequired<ReactFlowEdge<EdgeData, 'relation'>, 'data' | 'type'>
+  export type Edge = AddEdgeData<SharedTypes.Edge, EdgeDetailsEdgeData>
 }

--- a/packages/diagram/src/overlays/edge-details/_types.ts
+++ b/packages/diagram/src/overlays/edge-details/_types.ts
@@ -3,7 +3,7 @@ import type { Edge as ReactFlowEdge, Node as ReactFlowNode, ReactFlowInstance } 
 import type { SetRequired } from 'type-fest'
 
 export namespace XYFlowTypes {
-  type NodeProps = {
+  type NodeData = {
     fqn: Fqn
     element: Pick<ComputedNode, 'color' | 'title' | 'description' | 'shape' | 'kind'>
     ports: {
@@ -19,24 +19,23 @@ export namespace XYFlowTypes {
     dimmed?: 'immediate' | boolean
   }
 
-  export type ElementNode = SetRequired<ReactFlowNode<NodeProps, 'element'>, 'type'>
+  export type ElementNode = SetRequired<ReactFlowNode<NodeData, 'element'>, 'type'>
 
-  export type CompoundNode = SetRequired<ReactFlowNode<NodeProps, 'compound'>, 'type'>
+  export type CompoundNode = SetRequired<ReactFlowNode<NodeData, 'compound'>, 'type'>
 
   export type Node = ElementNode | CompoundNode
 
-  export type Edge = Omit<ReactFlowEdge, 'data' | 'type'> & {
-    data: {
-      technology: string | null
-      description: string | null
-      relationId: RelationId
-      // relation: Relation
-      navigateTo: ViewId | null
-      hovered?: boolean
-      dimmed?: boolean
-    }
-    type: 'relation'
+  type EdgeData = {
+    technology: string | null
+    description: string | null
+    relationId: RelationId
+    // relation: Relation
+    navigateTo: ViewId | null
+    hovered?: boolean
+    dimmed?: boolean
   }
+
+  export type Edge = SetRequired<ReactFlowEdge<EdgeData, 'relation'>, 'data' | 'type'>;
 
   export type Instance = ReactFlowInstance<Node, Edge>
 }

--- a/packages/diagram/src/overlays/edge-details/_types.ts
+++ b/packages/diagram/src/overlays/edge-details/_types.ts
@@ -1,4 +1,4 @@
-import type { RelationId, ViewId } from '@likec4/core'
+import type { AbstractRelation, ViewId } from '@likec4/core'
 import type { Edge as ReactFlowEdge } from '@xyflow/react'
 import type { SetRequired } from 'type-fest'
 
@@ -7,7 +7,7 @@ export namespace XYFlowTypes {
   type EdgeData = {
     technology: string | null
     description: string | null
-    relationId: RelationId
+    relations: [AbstractRelation, ...AbstractRelation[]]
     // relation: Relation
     navigateTo: ViewId | null
     hovered?: boolean

--- a/packages/diagram/src/overlays/edge-details/use-layouted-edge-details.ts
+++ b/packages/diagram/src/overlays/edge-details/use-layouted-edge-details.ts
@@ -1,5 +1,6 @@
 import dagre, { type GraphLabel, type Label } from '@dagrejs/dagre'
 import {
+  type AbstractRelation,
   compareFqnHierarchically,
   compareRelations,
   type DiagramEdge,
@@ -232,7 +233,7 @@ function layout(
       return {
         source: relation.source.id,
         target: relation.target.id,
-        relation: relation.$relationship
+        relation: relation.$relationship as AbstractRelation
       }
     })
     .sort(compareRelations)
@@ -281,7 +282,7 @@ function layout(
       sourceHandle: target.id,
       targetHandle: source.id,
       data: {
-        relationId: relation.id,
+        relations: [relation],
         navigateTo: relation.navigateTo ?? null,
         technology: relation.technology ?? null,
         description: relation.description ?? null

--- a/packages/diagram/src/overlays/edge-details/use-layouted-edge-details.ts
+++ b/packages/diagram/src/overlays/edge-details/use-layouted-edge-details.ts
@@ -269,14 +269,8 @@ function layout(
     const target = ctx.xynodes.get(points.target)
     invariant(target, 'target node not found')
 
-    source.data.ports.out.push({
-      id: target.id,
-      type: 'out'
-    })
-    target.data.ports.in.push({
-      id: source.id,
-      type: 'in'
-    })
+    source.data.ports.out.push(target.id)
+    target.data.ports.in.push(source.id)
 
     g.setEdge(graphId(source).port, graphId(target).port)
     const edge: XYFlowTypes.Edge = {
@@ -309,7 +303,7 @@ function layout(
   const nodebounds = applyDagreLayout(ctx.g)
 
   // Sort ports
-  const sortedPorts = (ports: SharedTypes.Port[]) => {
+  const sortedPorts = (ports: string[]) => {
     if (ports.length < 2) {
       return ports
     }
@@ -318,7 +312,7 @@ function layout(
       map(port => {
         return {
           port,
-          topY: nodebounds(port.id).position.y
+          topY: nodebounds(port).position.y
         }
       }),
       sortBy(prop('topY')),

--- a/packages/diagram/src/overlays/edge-details/xyflow/CompoundNode.tsx
+++ b/packages/diagram/src/overlays/edge-details/xyflow/CompoundNode.tsx
@@ -49,10 +49,10 @@ export function CompoundNode({
       >
         <Text className={css.compoundNodeTitle} maw={width - 20}>{element.title}</Text>
       </m.div>
-      {ports.out.map((p, i) => (
+      {ports.out.map((id, i) => (
         <Handle
-          key={p.id}
-          id={p.id}
+          key={id}
+          id={id}
           type={'source'}
           position={Position.Right}
           style={{
@@ -60,10 +60,10 @@ export function CompoundNode({
             top: `${16 + 20 * i}px`
           }} />
       ))}
-      {ports.in.map((p, i) => (
+      {ports.in.map((id, i) => (
         <Handle
-          key={p.id}
-          id={p.id}
+          key={id}
+          id={id}
           type={'target'}
           position={Position.Left}
           style={{

--- a/packages/diagram/src/overlays/edge-details/xyflow/CompoundNode.tsx
+++ b/packages/diagram/src/overlays/edge-details/xyflow/CompoundNode.tsx
@@ -2,14 +2,14 @@ import { Text as MantineText } from '@mantine/core'
 import { Handle, type NodeProps, Position } from '@xyflow/react'
 import clsx from 'clsx'
 import { m } from 'framer-motion'
-import type { XYFlowTypes } from '../_types'
 import * as css from './styles.css'
+import type { SharedTypes } from '../../shared/xyflow/_types'
 
 const Text = MantineText.withProps({
   component: 'div'
 })
 
-type CompoundNodeProps = NodeProps<XYFlowTypes.CompoundNode>
+type CompoundNodeProps = NodeProps<SharedTypes.CompoundNode>
 
 export function CompoundNode({
   data: {
@@ -49,10 +49,10 @@ export function CompoundNode({
       >
         <Text className={css.compoundNodeTitle} maw={width - 20}>{element.title}</Text>
       </m.div>
-      {ports.out.map((id, i) => (
+      {ports.out.map((p, i) => (
         <Handle
-          key={id}
-          id={id}
+          key={p.id}
+          id={p.id}
           type={'source'}
           position={Position.Right}
           style={{
@@ -60,10 +60,10 @@ export function CompoundNode({
             top: `${16 + 20 * i}px`
           }} />
       ))}
-      {ports.in.map((id, i) => (
+      {ports.in.map((p, i) => (
         <Handle
-          key={id}
-          id={id}
+          key={p.id}
+          id={p.id}
           type={'target'}
           position={Position.Left}
           style={{
@@ -71,10 +71,6 @@ export function CompoundNode({
             top: `${16 + 20 * i}px`
           }} />
       ))}
-      {
-        /* <Handle type="target" position={Position.Left}/>
-      <Handle type="source" position={Position.Right}/> */
-      }
     </>
   )
 }

--- a/packages/diagram/src/overlays/edge-details/xyflow/ElementNode.tsx
+++ b/packages/diagram/src/overlays/edge-details/xyflow/ElementNode.tsx
@@ -128,10 +128,10 @@ export function ElementNode({
           )}
         </Group>
       </m.div>
-      {ports.out.map((p, i) => (
+      {ports.out.map((id, i) => (
         <Handle
-          key={p.id}
-          id={p.id}
+          key={id}
+          id={id}
           type="source"
           position={Position.Right}
           style={{
@@ -139,10 +139,10 @@ export function ElementNode({
             top: `${15 + (i + 1) * ((h - 30) / (ports.out.length + 1))}px`
           }} />
       ))}
-      {ports.in.map((p, i) => (
+      {ports.in.map((id, i) => (
         <Handle
-          key={p.id}
-          id={p.id}
+          key={id}
+          id={id}
           type="target"
           position={Position.Left}
           style={{

--- a/packages/diagram/src/overlays/edge-details/xyflow/ElementNode.tsx
+++ b/packages/diagram/src/overlays/edge-details/xyflow/ElementNode.tsx
@@ -7,8 +7,8 @@ import { type DiagramState, useDiagramState } from '../../../hooks'
 import { ElementShapeSvg } from '../../../xyflow/nodes/element/ElementShapeSvg'
 import { stopPropagation } from '../../../xyflow/utils'
 import { useOverlayDialog } from '../../OverlayContext'
-import type { XYFlowTypes } from '../_types'
 import * as css from './styles.css'
+import type { SharedTypes } from '../../shared/xyflow/_types'
 
 const Action = ActionIcon.withProps({
   className: 'nodrag nopan ' + css.navigateBtn,
@@ -22,7 +22,7 @@ const Text = MantineText.withProps({
   component: 'div'
 })
 
-type ElementNodeProps = NodeProps<XYFlowTypes.ElementNode>
+type ElementNodeProps = NodeProps<SharedTypes.ElementNode>
 
 function selector(s: DiagramState) {
   return {
@@ -128,10 +128,10 @@ export function ElementNode({
           )}
         </Group>
       </m.div>
-      {ports.out.map((id, i) => (
+      {ports.out.map((p, i) => (
         <Handle
-          key={id}
-          id={id}
+          key={p.id}
+          id={p.id}
           type="source"
           position={Position.Right}
           style={{
@@ -139,10 +139,10 @@ export function ElementNode({
             top: `${15 + (i + 1) * ((h - 30) / (ports.out.length + 1))}px`
           }} />
       ))}
-      {ports.in.map((id, i) => (
+      {ports.in.map((p, i) => (
         <Handle
-          key={id}
-          id={id}
+          key={p.id}
+          id={p.id}
           type="target"
           position={Position.Left}
           style={{
@@ -150,10 +150,6 @@ export function ElementNode({
             top: `${15 + (i + 1) * ((h - 30) / (ports.in.length + 1))}px`
           }} />
       ))}
-      {
-        /* <Handle type="target" position={Position.Left} />
-      <Handle type="source" position={Position.Right} /> */
-      }
     </>
   )
 }

--- a/packages/diagram/src/overlays/edge-details/xyflow/RelationshipEdge.tsx
+++ b/packages/diagram/src/overlays/edge-details/xyflow/RelationshipEdge.tsx
@@ -7,7 +7,7 @@ import { stopPropagation } from '../../../xyflow/utils'
 import { useOverlayDialog } from '../../OverlayContext'
 import type { XYFlowTypes } from '../_types'
 import { ZIndexes } from '../use-layouted-edge-details'
-import * as css from './styles.css'
+import * as css from '../../shared/xyflow/RelationshipEdge.css'
 
 export function RelationshipEdge({
   data,

--- a/packages/diagram/src/overlays/edge-details/xyflow/styles.css.ts
+++ b/packages/diagram/src/overlays/edge-details/xyflow/styles.css.ts
@@ -1,6 +1,5 @@
 import { globalStyle, style } from '@vanilla-extract/css'
-import { mantine, transitions, vars, whereDark, xyvars } from '../../../theme-vars'
-import { mixColor } from '../../Overlays.css'
+import { mantine, vars } from '../../../theme-vars'
 
 export const elementNode = style({
   width: '100%',
@@ -82,63 +81,6 @@ export const cssShapeSvg = style({
       drop-shadow(0 5px 3px rgba(0, 0, 0, 0.1))
     `,
   zIndex: -1
-})
-
-const DimmedTransitionDelay = '400ms'
-
-export const edgeContainer = style({
-  opacity: 1,
-  transition: transitions.fast,
-  vars: {
-    [xyvars.edge.stroke]: vars.relation.lineColor,
-    [xyvars.edge.strokeSelected]: `color-mix(in srgb, ${vars.relation.lineColor}, ${mixColor} 35%)`,
-    [xyvars.edge.labelColor]: `color-mix(in srgb, ${vars.relation.labelColor}, rgba(255 255 255 / 0.85) 50%)`,
-    [xyvars.edge.labelBgColor]: `color-mix(in srgb, ${vars.relation.labelBgColor}, transparent 20%)`
-  },
-  selectors: {
-    [`&[data-edge-dimmed='true']`]: {
-      opacity: 0.2,
-      transitionDelay: DimmedTransitionDelay
-    },
-    [`&[data-edge-dimmed='immediate']`]: {
-      opacity: 0.2
-    },
-    [`${whereDark} &`]: {
-      vars: {
-        [xyvars.edge.labelBgColor]: `color-mix(in srgb, ${vars.relation.labelBgColor}, transparent 50%)`
-      }
-    }
-  }
-})
-
-export const edgeLabel = style([edgeContainer, {
-  padding: '2px 5px',
-  fontFamily: vars.likec4.font,
-  position: 'absolute',
-  cursor: 'pointer',
-  width: 'fit-content',
-  color: xyvars.edge.labelColor,
-  backgroundColor: xyvars.edge.labelBgColor,
-  borderRadius: 4,
-  // everything inside EdgeLabelRenderer has no pointer events by default
-  // if you have an interactive element, set pointer-events: all
-  pointerEvents: 'all',
-  textWrap: 'pretty',
-  whiteSpace: 'preserve-breaks'
-}])
-
-export const edgeLabelText = style({
-  textAlign: 'center',
-  whiteSpaceCollapse: 'preserve-breaks',
-  fontSize: mantine.fontSizes.md,
-  lineHeight: mantine.lineHeights.xs
-})
-
-export const edgeLabelTechnology = style({
-  textAlign: 'center',
-  whiteSpaceCollapse: 'preserve-breaks',
-  fontSize: mantine.fontSizes.sm,
-  lineHeight: 1
 })
 
 export const navigateBtnBox = style({

--- a/packages/diagram/src/overlays/relationships-of/RelationshipsXYFlow.tsx
+++ b/packages/diagram/src/overlays/relationships-of/RelationshipsXYFlow.tsx
@@ -1,4 +1,4 @@
-import { delay, type DiagramView, type Fqn, isAncestor, type Relation } from '@likec4/core'
+import { type AbstractRelation, delay, type DiagramView, type Fqn, isAncestor } from '@likec4/core'
 import { useId } from '@mantine/hooks'
 import { useDebouncedCallback, useDeepCompareEffect, useSyncedRef } from '@react-hookz/web'
 import {
@@ -78,10 +78,10 @@ const animateEdge = (node: XYFlowTypes.Node, animated = true) => (edges: XYFlowT
   })
 }
 
-const onlyOneUnique = <T extends keyof Relation>(
+const onlyOneUnique = <T extends keyof AbstractRelation>(
   data: XYFlowTypes.Edge['data'],
   property: T
-): Relation[T] | undefined => {
+): AbstractRelation[T] | undefined => {
   return only(unique(map(data.relations, prop(property))))
 }
 

--- a/packages/diagram/src/overlays/relationships-of/RelationshipsXYFlow.tsx
+++ b/packages/diagram/src/overlays/relationships-of/RelationshipsXYFlow.tsx
@@ -183,7 +183,7 @@ function RelationshipsXYFlowWrapped({
 
     // If subject node is the same, don't animate
     if (currentSubjectNode && nextSubjectNode?.data.fqn === currentSubjectNode.data.fqn) {
-      setNodes(map(nodes, setPath(['data', 'initialAnimation'], false)))
+      setNodes(map(nodes, setPath(['data', 'entering'], false)))
       setEdges(edges)
       fitview()
       return
@@ -282,7 +282,7 @@ function RelationshipsXYFlowWrapped({
         isCancelled = true
       }
     }
-    setNodes(map(nodes, setPath(['data', 'initialAnimation'], false)))
+    setNodes(map(nodes, setPath(['data', 'entering'], false)))
     setEdges(edges)
     fitview()
     return undefined

--- a/packages/diagram/src/overlays/relationships-of/_types.ts
+++ b/packages/diagram/src/overlays/relationships-of/_types.ts
@@ -1,8 +1,5 @@
-import type { AbstractRelation } from '@likec4/core'
-import type { Edge as ReactFlowEdge } from '@xyflow/react'
-import type { SetRequired } from 'type-fest'
 import type { SharedTypes } from '../shared/xyflow/_types'
-import type { AddNodeData } from '../../utils/types'
+import type { AddEdgeData, AddNodeData } from '../../utils/types'
 
 export namespace XYFlowTypes {
 
@@ -23,12 +20,9 @@ export namespace XYFlowTypes {
 
   export type Node = NonEmptyNode | EmptyNode
 
-  type EdgeData = {
-    relations: [AbstractRelation, ...AbstractRelation[]]
+  type RelationshipsOfEdgeData = {
     existsInCurrentView: boolean
-    hovered?: boolean
-    dimmed?: 'immediate' | boolean
   }
 
-  export type Edge = SetRequired<ReactFlowEdge<EdgeData, 'relation'>, 'data' | 'type'>
+  export type Edge = AddEdgeData<SharedTypes.Edge, RelationshipsOfEdgeData>
 }

--- a/packages/diagram/src/overlays/relationships-of/_types.ts
+++ b/packages/diagram/src/overlays/relationships-of/_types.ts
@@ -1,51 +1,25 @@
-import type { ComputedNode, Fqn, Relation, ViewId } from '@likec4/core'
-import type { Edge as ReactFlowEdge, Node as ReactFlowNode } from '@xyflow/react'
+import type { Relation } from '@likec4/core'
+import type { Edge as ReactFlowEdge } from '@xyflow/react'
 import type { SetRequired } from 'type-fest'
+import type { SharedTypes } from '../shared/xyflow/_types'
+import type { AddNodeData } from '../../utils/types'
 
 export namespace XYFlowTypes {
 
-  type NodeData = {
+  type RelationshipsOfNodeData = {
     depth?: number
     column: 'incomers' | 'subjects' | 'outgoers'
-    fqn: Fqn
     existsInCurrentView: boolean
-    element: Pick<ComputedNode, 'color' | 'title' | 'description' | 'shape' | 'kind'>
-    ports: {
-      in: string[]
-      out: string[]
-    }
-    navigateTo: ViewId | null
-    hovered?: boolean
     layoutId?: string
-    leaving?: boolean
-    /**
-     * @default true
-     */
-    entering?: boolean
-    /**
-     * Whether the node is dimmed
-     * 'immediate' means that the node is dimmed without delay
-     */
-    dimmed?: 'immediate' | boolean
   }
 
-  export type ElementNode = SetRequired<ReactFlowNode<NodeData, 'element'>, 'type'>
+  export type ElementNode = AddNodeData<SharedTypes.ElementNode, RelationshipsOfNodeData>
 
-  export type CompoundNode = SetRequired<ReactFlowNode<NodeData, 'compound'>, 'type'>
+  export type CompoundNode = AddNodeData<SharedTypes.CompoundNode, RelationshipsOfNodeData>
 
   export type NonEmptyNode = ElementNode | CompoundNode
 
-  type EmptyNodeData = {
-    column: 'incomers' | 'subjects' | 'outgoers'
-    hovered?: boolean
-    dimmed?: boolean
-    /**
-     * @default true
-     */
-    entering?: boolean
-  };
-
-  export type EmptyNode = SetRequired<ReactFlowNode<EmptyNodeData, 'empty'>, 'type'>
+  export type EmptyNode = AddNodeData<SharedTypes.EmptyNode, RelationshipsOfNodeData>
 
   export type Node = NonEmptyNode | EmptyNode
 

--- a/packages/diagram/src/overlays/relationships-of/_types.ts
+++ b/packages/diagram/src/overlays/relationships-of/_types.ts
@@ -16,7 +16,7 @@ export namespace XYFlowTypes {
     type: 'in' | 'out'
   }
 
-  type NodeProps = {
+  type NodeData = {
     depth?: number
     column: 'incomers' | 'subjects' | 'outgoers'
     fqn: Fqn
@@ -41,36 +41,34 @@ export namespace XYFlowTypes {
     dimmed?: 'immediate' | boolean
   }
 
-  export type ElementNode = SetRequired<ReactFlowNode<NodeProps, 'element'>, 'type'>
+  export type ElementNode = SetRequired<ReactFlowNode<NodeData, 'element'>, 'type'>
 
-  export type CompoundNode = SetRequired<ReactFlowNode<NodeProps, 'compound'>, 'type'>
+  export type CompoundNode = SetRequired<ReactFlowNode<NodeData, 'compound'>, 'type'>
 
   export type NonEmptyNode = ElementNode | CompoundNode
 
-  export type EmptyNode = SetRequired<
-    ReactFlowNode<{
-      column: 'incomers' | 'subjects' | 'outgoers'
-      hovered?: boolean
-      dimmed?: boolean
-      /**
-       * @default true
-       */
-      initialAnimation?: boolean
-    }, 'empty'>,
-    'type'
-  >
+  type EmptyNodeData = {
+    column: 'incomers' | 'subjects' | 'outgoers'
+    hovered?: boolean
+    dimmed?: boolean
+    /**
+     * @default true
+     */
+    initialAnimation?: boolean
+  };
+
+  export type EmptyNode = SetRequired<ReactFlowNode<EmptyNodeData, 'empty'>, 'type'>
 
   export type Node = NonEmptyNode | EmptyNode
 
-  export type Edge = Omit<ReactFlowEdge, 'data' | 'type'> & {
-    data: {
-      relations: [Relation, ...Relation[]]
-      includedInCurrentView: boolean
-      hovered?: boolean
-      dimmed?: 'immediate' | boolean
-    }
-    type: 'relation'
+  type EdgeData = {
+    relations: [Relation, ...Relation[]]
+    includedInCurrentView: boolean
+    hovered?: boolean
+    dimmed?: 'immediate' | boolean
   }
+
+  export type Edge = SetRequired<ReactFlowEdge<EdgeData, 'relation'>, 'data' | 'type'>;
 
   export type Instance = ReactFlowInstance<Node, Edge>
 

--- a/packages/diagram/src/overlays/relationships-of/_types.ts
+++ b/packages/diagram/src/overlays/relationships-of/_types.ts
@@ -1,15 +1,9 @@
 import type { ComputedNode, Fqn, Relation, ViewId } from '@likec4/core'
 import type { Edge as ReactFlowEdge, Node as ReactFlowNode } from '@xyflow/react'
 import type { SetRequired } from 'type-fest'
+import type { SharedTypes } from '../shared/xyflow/_types'
 
 export namespace XYFlowTypes {
-  /**
-   * Handle in ReactFlow terms
-   */
-  export type Port = {
-    id: string
-    type: 'in' | 'out'
-  }
 
   type NodeData = {
     depth?: number
@@ -18,8 +12,8 @@ export namespace XYFlowTypes {
     existsInCurrentView: boolean
     element: Pick<ComputedNode, 'color' | 'title' | 'description' | 'shape' | 'kind'>
     ports: {
-      left: Port[]
-      right: Port[]
+      in: SharedTypes.Port[]
+      out: SharedTypes.Port[]
     }
     navigateTo: ViewId | null
     hovered?: boolean

--- a/packages/diagram/src/overlays/relationships-of/_types.ts
+++ b/packages/diagram/src/overlays/relationships-of/_types.ts
@@ -33,7 +33,7 @@ export namespace XYFlowTypes {
     /**
      * @default true
      */
-    initialAnimation?: boolean
+    entering?: boolean
     /**
      * Whether the node is dimmed
      * 'immediate' means that the node is dimmed without delay
@@ -54,7 +54,7 @@ export namespace XYFlowTypes {
     /**
      * @default true
      */
-    initialAnimation?: boolean
+    entering?: boolean
   };
 
   export type EmptyNode = SetRequired<ReactFlowNode<EmptyNodeData, 'empty'>, 'type'>

--- a/packages/diagram/src/overlays/relationships-of/_types.ts
+++ b/packages/diagram/src/overlays/relationships-of/_types.ts
@@ -1,7 +1,6 @@
 import type { ComputedNode, Fqn, Relation, ViewId } from '@likec4/core'
 import type { Edge as ReactFlowEdge, Node as ReactFlowNode } from '@xyflow/react'
 import type { SetRequired } from 'type-fest'
-import type { SharedTypes } from '../shared/xyflow/_types'
 
 export namespace XYFlowTypes {
 
@@ -12,8 +11,8 @@ export namespace XYFlowTypes {
     existsInCurrentView: boolean
     element: Pick<ComputedNode, 'color' | 'title' | 'description' | 'shape' | 'kind'>
     ports: {
-      in: SharedTypes.Port[]
-      out: SharedTypes.Port[]
+      in: string[]
+      out: string[]
     }
     navigateTo: ViewId | null
     hovered?: boolean

--- a/packages/diagram/src/overlays/relationships-of/_types.ts
+++ b/packages/diagram/src/overlays/relationships-of/_types.ts
@@ -1,4 +1,4 @@
-import type { Relation } from '@likec4/core'
+import type { AbstractRelation } from '@likec4/core'
 import type { Edge as ReactFlowEdge } from '@xyflow/react'
 import type { SetRequired } from 'type-fest'
 import type { SharedTypes } from '../shared/xyflow/_types'
@@ -24,7 +24,7 @@ export namespace XYFlowTypes {
   export type Node = NonEmptyNode | EmptyNode
 
   type EdgeData = {
-    relations: [Relation, ...Relation[]]
+    relations: [AbstractRelation, ...AbstractRelation[]]
     existsInCurrentView: boolean
     hovered?: boolean
     dimmed?: 'immediate' | boolean

--- a/packages/diagram/src/overlays/relationships-of/_types.ts
+++ b/packages/diagram/src/overlays/relationships-of/_types.ts
@@ -1,10 +1,5 @@
 import type { ComputedNode, Fqn, Relation, ViewId } from '@likec4/core'
-import type {
-  Edge as ReactFlowEdge,
-  InternalNode as ReactFlowInternalNode,
-  Node as ReactFlowNode,
-  ReactFlowInstance
-} from '@xyflow/react'
+import type { Edge as ReactFlowEdge, Node as ReactFlowNode } from '@xyflow/react'
 import type { SetRequired } from 'type-fest'
 
 export namespace XYFlowTypes {
@@ -68,9 +63,5 @@ export namespace XYFlowTypes {
     dimmed?: 'immediate' | boolean
   }
 
-  export type Edge = SetRequired<ReactFlowEdge<EdgeData, 'relation'>, 'data' | 'type'>;
-
-  export type Instance = ReactFlowInstance<Node, Edge>
-
-  export type InternalNode = ReactFlowInternalNode<Node>
+  export type Edge = SetRequired<ReactFlowEdge<EdgeData, 'relation'>, 'data' | 'type'>
 }

--- a/packages/diagram/src/overlays/relationships-of/_types.ts
+++ b/packages/diagram/src/overlays/relationships-of/_types.ts
@@ -52,7 +52,7 @@ export namespace XYFlowTypes {
 
   type EdgeData = {
     relations: [Relation, ...Relation[]]
-    includedInCurrentView: boolean
+    existsInCurrentView: boolean
     hovered?: boolean
     dimmed?: 'immediate' | boolean
   }

--- a/packages/diagram/src/overlays/relationships-of/use-layouted-relationships.ts
+++ b/packages/diagram/src/overlays/relationships-of/use-layouted-relationships.ts
@@ -308,13 +308,13 @@ function applyDagreLayout(g: dagre.graphlib.Graph) {
 function addEdge(
   ctx: Context,
   props: {
-    includedInCurrentView: boolean
+    existsInCurrentView: boolean
     source: string
     target: string
     relations: XYFlowTypes.Edge['data']['relations']
   }
 ) {
-  const { source, target, relations, includedInCurrentView } = props
+  const { source, target, relations, existsInCurrentView } = props
   const ids = relations.map(r => r.id).join('_')
   const label = only(relations)?.title ?? 'untitled'
 
@@ -327,7 +327,7 @@ function addEdge(
     sourceHandle: target,
     targetHandle: source,
     data: {
-      includedInCurrentView,
+      existsInCurrentView: existsInCurrentView,
       relations
     },
     label: isMultiple ? `${relations.length} relationships` : label,
@@ -501,7 +501,7 @@ function layout(
           relation,
           source,
           target,
-          includedInCurrentView: viewRelationships.has(relation.id),
+          existsInCurrentView: viewRelationships.has(relation.id),
           id: `${source.id}:${target.id}`
         })
       })
@@ -531,7 +531,7 @@ function layout(
 
       addEdge(ctx, {
         // if view does not include subject - do not highlight
-        includedInCurrentView: !viewIncludesSubject || grouped.every(g => g.includedInCurrentView),
+        existsInCurrentView: !viewIncludesSubject || grouped.every(g => g.existsInCurrentView),
         source: source.id,
         target: target.id,
         relations

--- a/packages/diagram/src/overlays/relationships-of/use-layouted-relationships.ts
+++ b/packages/diagram/src/overlays/relationships-of/use-layouted-relationships.ts
@@ -39,6 +39,7 @@ import {
 } from 'remeda'
 import { useLikeC4Model } from '../../likec4model'
 import type { XYFlowTypes } from './_types'
+import type { SharedTypes } from '../shared/xyflow/_types'
 
 const columns = ['incomers', 'subjects', 'outgoers'] as const
 type ColumnKey = typeof columns[number]
@@ -183,8 +184,8 @@ function nodeData(
     },
     navigateTo: diagramNode?.navigateTo ?? element.defaultView?.id ?? null,
     ports: {
-      left: [],
-      right: []
+      in: [],
+      out: []
     }
   }
 }
@@ -512,11 +513,11 @@ function layout(
       const { source, target } = grouped[0]
       const relations = map(grouped, g => g.relation)
 
-      source.data.ports.right.push({
+      source.data.ports.out.push({
         id: target.id,
         type: 'out'
       })
-      target.data.ports.left.push({
+      target.data.ports.in.push({
         id: source.id,
         type: 'in'
       })
@@ -555,7 +556,7 @@ function layout(
     if (subject.type !== 'element') {
       continue
     }
-    const subjectPortsCount = Math.max(subject.data.ports.left.length, subject.data.ports.right.length)
+    const subjectPortsCount = Math.max(subject.data.ports.in.length, subject.data.ports.out.length)
     if (subjectPortsCount > 2) {
       g.node(subject.id).height = Sizes.hodeHeight + (subjectPortsCount - 3) * 14
     }
@@ -628,7 +629,7 @@ function layout(
   }
 
   // Sort ports in subject vertically
-  const sortedPorts = (ports: XYFlowTypes.Port[]) => {
+  const sortedPorts = (ports: SharedTypes.Port[]) => {
     return pipe(
       ports,
       map(port => {
@@ -658,11 +659,11 @@ function layout(
       continue
     }
     // Sort ports by their position
-    if (node.data.ports.left.length > 1) {
-      node.data.ports.left = sortedPorts(node.data.ports.left)
+    if (node.data.ports.in.length > 1) {
+      node.data.ports.in = sortedPorts(node.data.ports.in)
     }
-    if (node.data.ports.right.length > 1) {
-      node.data.ports.right = sortedPorts(node.data.ports.right)
+    if (node.data.ports.out.length > 1) {
+      node.data.ports.out = sortedPorts(node.data.ports.out)
     }
   }
 

--- a/packages/diagram/src/overlays/relationships-of/use-layouted-relationships.ts
+++ b/packages/diagram/src/overlays/relationships-of/use-layouted-relationships.ts
@@ -39,7 +39,6 @@ import {
 } from 'remeda'
 import { useLikeC4Model } from '../../likec4model'
 import type { XYFlowTypes } from './_types'
-import type { SharedTypes } from '../shared/xyflow/_types'
 
 const columns = ['incomers', 'subjects', 'outgoers'] as const
 type ColumnKey = typeof columns[number]
@@ -513,14 +512,8 @@ function layout(
       const { source, target } = grouped[0]
       const relations = map(grouped, g => g.relation)
 
-      source.data.ports.out.push({
-        id: target.id,
-        type: 'out'
-      })
-      target.data.ports.in.push({
-        id: source.id,
-        type: 'in'
-      })
+      source.data.ports.out.push(target.id)
+      target.data.ports.in.push(source.id)
 
       const isAnyCompound = source.type === 'compound' || target.type === 'compound'
 
@@ -629,13 +622,13 @@ function layout(
   }
 
   // Sort ports in subject vertically
-  const sortedPorts = (ports: SharedTypes.Port[]) => {
+  const sortedPorts = (ports: string[]) => {
     return pipe(
       ports,
       map(port => {
         return {
           port,
-          topY: nodeBounds(port.id).position.y
+          topY: nodeBounds(port).position.y
         }
       }),
       sortBy(prop('topY')),

--- a/packages/diagram/src/overlays/relationships-of/use-layouted-relationships.ts
+++ b/packages/diagram/src/overlays/relationships-of/use-layouted-relationships.ts
@@ -205,7 +205,8 @@ function createEmptyNode(
     id,
     position: { x: 0, y: 0 },
     data: {
-      column
+      column,
+      existsInCurrentView: true
     },
     zIndex: ZIndexes.empty
   }

--- a/packages/diagram/src/overlays/relationships-of/xyflow/CompoundNode.tsx
+++ b/packages/diagram/src/overlays/relationships-of/xyflow/CompoundNode.tsx
@@ -20,7 +20,7 @@ export const CompoundNode = memo<CompoundNodeProps>(({
     ports,
     layoutId = id,
     leaving = false,
-    initialAnimation = true,
+    entering = true,
     ...data
   },
   width = 200,
@@ -61,7 +61,7 @@ export const CompoundNode = memo<CompoundNodeProps>(({
         layoutId={layoutId}
         data-compound-depth={data.depth ?? 1}
         data-likec4-color={element.color}
-        initial={(layoutId === id && initialAnimation)
+        initial={(layoutId === id && entering)
           ? {
             ...scale(-20),
             opacity: 0,

--- a/packages/diagram/src/overlays/relationships-of/xyflow/CompoundNode.tsx
+++ b/packages/diagram/src/overlays/relationships-of/xyflow/CompoundNode.tsx
@@ -99,22 +99,22 @@ export const CompoundNode = memo<CompoundNodeProps>(({
           {element.title}
         </Text>
       </m.div>
-      {ports.in.map(({ id, type }, i) => (
+      {ports.in.map((id, i) => (
         <Handle
           key={id}
           id={id}
-          type={type === 'in' ? 'target' : 'source'}
+          type='target'
           position={Position.Left}
           style={{
             visibility: 'hidden',
             top: `${20 * (i + 1)}px`
           }} />
       ))}
-      {ports.out.map(({ id, type }, i) => (
+      {ports.out.map((id, i) => (
         <Handle
           key={id}
           id={id}
-          type={type === 'in' ? 'target' : 'source'}
+          type='source'
           position={Position.Right}
           style={{
             visibility: 'hidden',

--- a/packages/diagram/src/overlays/relationships-of/xyflow/CompoundNode.tsx
+++ b/packages/diagram/src/overlays/relationships-of/xyflow/CompoundNode.tsx
@@ -99,7 +99,7 @@ export const CompoundNode = memo<CompoundNodeProps>(({
           {element.title}
         </Text>
       </m.div>
-      {ports.left.map(({ id, type }, i) => (
+      {ports.in.map(({ id, type }, i) => (
         <Handle
           key={id}
           id={id}
@@ -110,7 +110,7 @@ export const CompoundNode = memo<CompoundNodeProps>(({
             top: `${20 * (i + 1)}px`
           }} />
       ))}
-      {ports.right.map(({ id, type }, i) => (
+      {ports.out.map(({ id, type }, i) => (
         <Handle
           key={id}
           id={id}

--- a/packages/diagram/src/overlays/relationships-of/xyflow/ElementNode.tsx
+++ b/packages/diagram/src/overlays/relationships-of/xyflow/ElementNode.tsx
@@ -42,7 +42,7 @@ export const ElementNode = memo<ElementNodeProps>(({
     navigateTo,
     layoutId = id,
     leaving = false,
-    initialAnimation = true,
+    entering = true,
     ...data
   },
   selectable = true,
@@ -82,7 +82,7 @@ export const ElementNode = memo<ElementNodeProps>(({
         ])}
         layoutId={layoutId}
         data-likec4-color={element.color}
-        initial={(layoutId === id && initialAnimation)
+        initial={(layoutId === id && entering)
           ? {
             ...scale(-20),
             opacity: 0,

--- a/packages/diagram/src/overlays/relationships-of/xyflow/ElementNode.tsx
+++ b/packages/diagram/src/overlays/relationships-of/xyflow/ElementNode.tsx
@@ -168,22 +168,22 @@ export const ElementNode = memo<ElementNodeProps>(({
           )}
         </Group>
       </m.div>
-      {ports.in.map(({ id, type }, i) => (
+      {ports.in.map((id, i) => (
         <Handle
           key={id}
           id={id}
-          type={type === 'in' ? 'target' : 'source'}
+          type='target'
           position={Position.Left}
           style={{
             visibility: 'hidden',
             top: `${15 + (i + 1) * ((h - 30) / (ports.in.length + 1))}px`
           }} />
       ))}
-      {ports.out.map(({ id, type }, i) => (
+      {ports.out.map((id, i) => (
         <Handle
           key={id}
           id={id}
-          type={type === 'in' ? 'target' : 'source'}
+          type='source'
           position={Position.Right}
           style={{
             visibility: 'hidden',

--- a/packages/diagram/src/overlays/relationships-of/xyflow/ElementNode.tsx
+++ b/packages/diagram/src/overlays/relationships-of/xyflow/ElementNode.tsx
@@ -168,7 +168,7 @@ export const ElementNode = memo<ElementNodeProps>(({
           )}
         </Group>
       </m.div>
-      {ports.left.map(({ id, type }, i) => (
+      {ports.in.map(({ id, type }, i) => (
         <Handle
           key={id}
           id={id}
@@ -176,10 +176,10 @@ export const ElementNode = memo<ElementNodeProps>(({
           position={Position.Left}
           style={{
             visibility: 'hidden',
-            top: `${15 + (i + 1) * ((h - 30) / (ports.left.length + 1))}px`
+            top: `${15 + (i + 1) * ((h - 30) / (ports.in.length + 1))}px`
           }} />
       ))}
-      {ports.right.map(({ id, type }, i) => (
+      {ports.out.map(({ id, type }, i) => (
         <Handle
           key={id}
           id={id}
@@ -187,7 +187,7 @@ export const ElementNode = memo<ElementNodeProps>(({
           position={Position.Right}
           style={{
             visibility: 'hidden',
-            top: `${15 + (i + 1) * ((h - 30) / (ports.right.length + 1))}px`
+            top: `${15 + (i + 1) * ((h - 30) / (ports.out.length + 1))}px`
           }} />
       ))}
     </>

--- a/packages/diagram/src/overlays/relationships-of/xyflow/RelationshipEdge.tsx
+++ b/packages/diagram/src/overlays/relationships-of/xyflow/RelationshipEdge.tsx
@@ -45,7 +45,7 @@ export function RelationshipEdge({
         className={css.edgeContainer}
         data-edge-dimmed={data.dimmed}
         data-edge-hovered={data.hovered}
-        data-likec4-color={data.includedInCurrentView ? 'gray' : 'amber'}
+        data-likec4-color={data.existsInCurrentView ? 'gray' : 'amber'}
       >
         <BaseEdge
           path={edgePath}
@@ -67,11 +67,11 @@ export function RelationshipEdge({
           ])}
           data-edge-dimmed={data.dimmed}
           data-edge-hovered={data.hovered}
-          data-likec4-color={data.includedInCurrentView ? 'gray' : 'amber'}
-          // {...data.includedInCurrentView === false && { 'data-likec4-color': 'amber' }}
+          data-likec4-color={data.existsInCurrentView ? 'gray' : 'amber'}
+          // {...data.existsInCurrentView === false && { 'data-likec4-color': 'amber' }}
         >
           {label && (
-            <Tooltip label="Not included in current view" disabled={data.includedInCurrentView} color={'orange'}>
+            <Tooltip label="Not included in current view" disabled={data.existsInCurrentView} color={'orange'}>
               <Group gap={6} wrap="nowrap">
                 {isMultiRelation && (
                   <ThemeIcon size={'sm'} variant="transparent" color="orange">

--- a/packages/diagram/src/overlays/relationships-of/xyflow/RelationshipEdge.tsx
+++ b/packages/diagram/src/overlays/relationships-of/xyflow/RelationshipEdge.tsx
@@ -8,7 +8,7 @@ import { stopPropagation } from '../../../xyflow/utils'
 import { useOverlayDialog } from '../../OverlayContext'
 import type { XYFlowTypes } from '../_types'
 import { ZIndexes } from '../use-layouted-relationships'
-import * as css from './styles.css'
+import * as css from '../../shared/xyflow/RelationshipEdge.css'
 
 const Tooltip = MantineTooltip.withProps({
   color: 'dark',

--- a/packages/diagram/src/overlays/shared/xyflow/RelationshipEdge.css.ts
+++ b/packages/diagram/src/overlays/shared/xyflow/RelationshipEdge.css.ts
@@ -1,0 +1,60 @@
+import { style } from "@vanilla-extract/css"
+import { mantine, transitions, vars, whereDark, xyvars } from "../../../theme-vars"
+import { mixColor } from "../../Overlays.css"
+
+const DimmedTransitionDelay = '400ms'
+
+export const edgeContainer = style({
+  opacity: 1,
+  transition: transitions.fast,
+  vars: {
+    [xyvars.edge.stroke]: vars.relation.lineColor,
+    [xyvars.edge.strokeSelected]: `color-mix(in srgb, ${vars.relation.lineColor}, ${mixColor} 35%)`,
+    [xyvars.edge.labelColor]: `color-mix(in srgb, ${vars.relation.labelColor}, rgba(255 255 255 / 0.85) 50%)`,
+    [xyvars.edge.labelBgColor]: `color-mix(in srgb, ${vars.relation.labelBgColor}, transparent 20%)`
+  },
+  selectors: {
+    [`&[data-edge-dimmed='true']`]: {
+      opacity: 0.2,
+      transitionDelay: DimmedTransitionDelay
+    },
+    [`&[data-edge-dimmed='immediate']`]: {
+      opacity: 0.2
+    },
+    [`${whereDark} &`]: {
+      vars: {
+        [xyvars.edge.labelBgColor]: `color-mix(in srgb, ${vars.relation.labelBgColor}, transparent 50%)`
+      }
+    }
+  }
+})
+
+export const edgeLabel = style([edgeContainer, {
+  padding: '2px 5px',
+  fontFamily: vars.likec4.font,
+  position: 'absolute',
+  cursor: 'pointer',
+  width: 'fit-content',
+  color: xyvars.edge.labelColor,
+  backgroundColor: xyvars.edge.labelBgColor,
+  borderRadius: 4,
+  // everything inside EdgeLabelRenderer has no pointer events by default
+  // if you have an interactive element, set pointer-events: all
+  pointerEvents: 'all',
+  textWrap: 'pretty',
+  whiteSpace: 'preserve-breaks'
+}])
+
+export const edgeLabelText = style({
+  textAlign: 'center',
+  whiteSpaceCollapse: 'preserve-breaks',
+  fontSize: mantine.fontSizes.md,
+  lineHeight: mantine.lineHeights.xs
+})
+
+export const edgeLabelTechnology = style({
+  textAlign: 'center',
+  whiteSpaceCollapse: 'preserve-breaks',
+  fontSize: mantine.fontSizes.sm,
+  lineHeight: 1
+})

--- a/packages/diagram/src/overlays/shared/xyflow/_types.ts
+++ b/packages/diagram/src/overlays/shared/xyflow/_types.ts
@@ -1,6 +1,6 @@
-import type { ComputedNode, Fqn, ViewId } from "@likec4/core"
+import type { AbstractRelation, ComputedNode, Fqn, ViewId } from "@likec4/core"
 import type { SetRequired } from "type-fest"
-import type { Node as ReactFlowNode } from '@xyflow/react'
+import type { Edge as ReactFlowEdge, Node as ReactFlowNode } from '@xyflow/react'
 
 export namespace SharedTypes {
 
@@ -60,4 +60,26 @@ export namespace SharedTypes {
   export type EmptyNode = SetRequired<ReactFlowNode<EmptyNodeData, 'empty'>, 'type'>
 
   export type Node = NonEmptyNode | EmptyNode
+
+  export type EdgeData = {
+    /**
+     * The model's relations represented by this edge
+     */
+    relations: [AbstractRelation, ...AbstractRelation[]]
+    /**
+     * Whether the cursor is hovering over the node
+     */
+    hovered?: boolean
+    /**
+     * Whether the node is dimmed
+     * 'immediate' means that the node is dimmed without delay
+     */
+    dimmed?: 'immediate' | boolean
+    /**
+     * The id of the view that should be navigated to when clicking the edge
+     */
+    navigateTo?: ViewId | null
+  }
+
+  export type Edge = SetRequired<ReactFlowEdge<EdgeData, 'relation'>, 'data' | 'type'>
 }

--- a/packages/diagram/src/overlays/shared/xyflow/_types.ts
+++ b/packages/diagram/src/overlays/shared/xyflow/_types.ts
@@ -4,14 +4,6 @@ import type { Node as ReactFlowNode } from '@xyflow/react'
 
 export namespace SharedTypes {
 
-  /**
-   * Handle in ReactFlow terms
-   */
-  export type Port = {
-    id: string
-    type: 'in' | 'out'
-  }
-
   export type EmptyNodeData = {
     /**
      * Whether the cursor is hovering over the node
@@ -46,8 +38,8 @@ export namespace SharedTypes {
      * The node's incoming and outgoing ports
      */
     ports: {
-      in: Port[]
-      out: Port[]
+      in: string[]
+      out: string[]
     }
     /**
      * The id of the view that should be navigated to when clicking the navigate button

--- a/packages/diagram/src/overlays/shared/xyflow/_types.ts
+++ b/packages/diagram/src/overlays/shared/xyflow/_types.ts
@@ -1,0 +1,71 @@
+import type { ComputedNode, Fqn, ViewId } from "@likec4/core"
+import type { SetRequired } from "type-fest"
+import type { Node as ReactFlowNode } from '@xyflow/react'
+
+export namespace SharedTypes {
+
+  /**
+   * Handle in ReactFlow terms
+   */
+  export type Port = {
+    id: string
+    type: 'in' | 'out'
+  }
+
+  export type EmptyNodeData = {
+    /**
+     * Whether the cursor is hovering over the node
+     */
+    hovered?: boolean
+    /**
+     * Whether the node is currently leaving the overlay
+     */
+    leaving?: boolean
+    /**
+     * Whether the node is currently entering the overlay
+     * @default true
+     */
+    entering?: boolean
+    /**
+     * Whether the node is dimmed
+     * 'immediate' means that the node is dimmed without delay
+     */
+    dimmed?: 'immediate' | boolean
+  }
+
+  export type NodeData = EmptyNodeData & {
+    /**
+     * The node's fully qualified name
+     */
+    fqn: Fqn
+    /**
+     * The ComputedNode backing this node
+     */
+    element: Pick<ComputedNode, 'color' | 'title' | 'description' | 'shape' | 'kind'>
+    /**
+     * The node's incoming and outgoing ports
+     */
+    ports: {
+      in: Port[]
+      out: Port[]
+    }
+    /**
+     * The id of the view that should be navigated to when clicking the navigate button
+     */
+    navigateTo: ViewId | null
+    /**
+     * The node's visual depth on the screen, 1 being the highest
+     */
+    depth?: Number
+  }
+
+  export type ElementNode = SetRequired<ReactFlowNode<NodeData, 'element'>, 'type'>
+
+  export type CompoundNode = SetRequired<ReactFlowNode<NodeData, 'compound'>, 'type'>
+
+  export type NonEmptyNode = ElementNode | CompoundNode
+
+  export type EmptyNode = SetRequired<ReactFlowNode<EmptyNodeData, 'empty'>, 'type'>
+
+  export type Node = NonEmptyNode | EmptyNode
+}

--- a/packages/diagram/src/overlays/shared/xyflow/_types.ts
+++ b/packages/diagram/src/overlays/shared/xyflow/_types.ts
@@ -48,7 +48,7 @@ export namespace SharedTypes {
     /**
      * The node's visual depth on the screen, 1 being the highest
      */
-    depth?: Number
+    depth?: number
   }
 
   export type ElementNode = SetRequired<ReactFlowNode<NodeData, 'element'>, 'type'>

--- a/packages/diagram/src/utils/types.ts
+++ b/packages/diagram/src/utils/types.ts
@@ -1,0 +1,4 @@
+import type { Merge } from "type-fest";
+import type { Node } from '@xyflow/react'
+
+export type AddNodeData<T extends Node, Data> = Omit<T, "data"> & { data: Merge<T["data"], Data> }

--- a/packages/diagram/src/utils/types.ts
+++ b/packages/diagram/src/utils/types.ts
@@ -1,4 +1,6 @@
 import type { Merge } from "type-fest";
-import type { Node } from '@xyflow/react'
+import type { Edge, Node } from '@xyflow/react'
 
 export type AddNodeData<T extends Node, Data> = Omit<T, "data"> & { data: Merge<T["data"], Data> }
+
+export type AddEdgeData<T extends Edge, Data> = Omit<T, "data"> & { data: Merge<T["data"], Data> }

--- a/packages/language-server/src/model/model-builder.ts
+++ b/packages/language-server/src/model/model-builder.ts
@@ -189,7 +189,7 @@ function buildModel(services: LikeC4Services, docs: ParsedLikeC4LangiumDocument[
       links: unresolvedLinks,
       id,
       ...model
-    }: ParsedAstRelation): c4.Relation | null => {
+    }: ParsedAstRelation): c4.ModelRelation | null => {
       if (isNullish(elements[source]) || isNullish(elements[target])) {
         logger.warn(
           `Invalid relation ${id} at ${doc.uri.path} ${astPath}, source: ${source}(${!!elements[
@@ -209,7 +209,7 @@ function buildModel(services: LikeC4Services, docs: ParsedLikeC4LangiumDocument[
           target,
           kind,
           id
-        } satisfies c4.Relation
+        } satisfies c4.ModelRelation
       }
       return {
         ...links && { links },
@@ -217,7 +217,7 @@ function buildModel(services: LikeC4Services, docs: ParsedLikeC4LangiumDocument[
         source,
         target,
         id
-      } satisfies c4.Relation
+      } satisfies c4.ModelRelation
     }
   }
 

--- a/packages/layouts/src/graphviz/__fixtures__/model.ts
+++ b/packages/layouts/src/graphviz/__fixtures__/model.ts
@@ -6,7 +6,7 @@ import type {
   IconUrl,
   NonEmptyArray,
   ParsedLikeC4Model,
-  Relation,
+  ModelRelation,
   RelationId,
   ViewId
 } from '@likec4/core'
@@ -218,7 +218,7 @@ const fakeRelations = {
     target: 'cloud.backend.graphql' as Fqn,
     title: 'fetches data in zero trust network with sso authentification'
   }
-} satisfies Record<string, Relation>
+} satisfies Record<string, ModelRelation>
 
 export const indexView = {
   __: 'element',

--- a/packages/likec4/src/index.ts
+++ b/packages/likec4/src/index.ts
@@ -32,7 +32,7 @@ export type {
   NodeId,
   ParsedLikeC4Model,
   Point,
-  Relation,
+  AbstractRelation,
   RelationExpr,
   RelationId,
   StepEdgeId,


### PR DESCRIPTION
The goal of this PR is to reduce the amount of duplicate code in the codebase and to get to a more maintainable state in general. I am focusing on the overlays for now, because they are very similar.

I consider this to be the first in a chain of PRs. It addresses the types for xyflow backing the overlays. Prior to this PR, each overlay defines its own set of types. These types share some common identical properties (albeit defines separately), but also differ in some key points.

### Example
The properties `fqn` and `element` are identical between the two definitions. `existsInCurrentView` and `hovered` exist in only one of them, whereas `ports` has conflicting definitions.

**relationships-of/_types.ts**
```ts
type NodeProps {
  fqn: Fqn,
  element: Pick<ComputedNode, 'color' | 'title' | 'description' | 'shape' | 'kind'>
  existsInCurrentView: boolean
  ports: {
    left: Port[]
    right: Port[]
  }
}
```

**edge-details/_types.ts**
```ts
type NodeProps {
  fqn: Fqn,
  element: Pick<ComputedNode, 'color' | 'title' | 'description' | 'shape' | 'kind'>
  hovered: boolean
  ports: {
    in: string[]
    out: string[]
  }
}
```

### Solution

I extracted common properties into shared base types in the new [`packages/diagram/src/overlays/shared/xyflow/_types.ts`](https://github.com/likec4/likec4/blob/6f4828452c71d116bb7ac2ae7f773dd101b15006/packages/diagram/src/overlays/shared/xyflow/_types.ts). I included the properties used for animations (`hovered`, `leaving`, `entering` and `dimmed`) in the common base class, such that we can standardize animations in a follow up PR. This means we have one source of truth for these properties and are less prone to diverging implementations in the future.

Here is a list of direct consequences that have made it into this PR:
1. The overlay specific `_types.ts` no longer define their own `Node` and `Edge` types from the ground up. Instead they extend the types from `SharedTypes` with only those properties that are unique to them.
2. The handling of `ports` has been standardized. Before some places simply used a list of target/source ids as strings, while others used objects including the id and the type (`in`/`out`). Now all places use two lists of ids.
3. By getting rid of diverging code, code duplication in other places is becoming more and more obvious. For example, the handling of ports in all `ElementNode.tsx` and `CompoundNode.tsx` is clearly visible.

### Minor Changes
I also included a couple of minor changes, that are aimed and simply cleaning up some stuff.

1. Rename `includedInCurrentView` to `existsInCurrentView` for edges in `relatioonships-of` to align the wording with the same property in nodes.
2. Add comments for all shared types' properties.
3. Standardize handling of relations between `edge-details` and `relationships-of` overlays.