### PR TITLE
refactor: extract control components (deduplication part 3)

### DIFF
--- a/packages/diagram/src/LikeC4Diagram.tsx
+++ b/packages/diagram/src/LikeC4Diagram.tsx
@@ -17,7 +17,7 @@ import { EnsureMantine } from './ui/EnsureMantine'
 import { FramerMotionConfig } from './ui/FramerMotionConfig'
 import { FitViewOnDiagramChange } from './xyflow/FitviewOnDiagramChange'
 import { SelectEdgesOnNodeFocus } from './xyflow/SelectEdgesOnNodeFocus'
-import type { XYFlowEdge, XYFlowNode } from './xyflow/types'
+import type { DiagramFlowTypes } from './xyflow/types'
 import { XYFlow } from './xyflow/XYFlow'
 import { XYFlowInner } from './xyflow/XYFlowInner'
 
@@ -63,8 +63,8 @@ export function LikeC4Diagram({
 }: LikeC4DiagramProps) {
   const hasLikec4model = !!useLikeC4Model()
   const initialRef = useRef({
-    defaultNodes: [] as XYFlowNode[],
-    defaultEdges: [] as XYFlowEdge[],
+    defaultNodes: [] as DiagramFlowTypes.Node[],
+    defaultEdges: [] as DiagramFlowTypes.Edge[],
     initialWidth: initialWidth ?? view.bounds.width,
     initialHeight: initialHeight ?? view.bounds.height
   })

--- a/packages/diagram/src/LikeC4Search.tsx
+++ b/packages/diagram/src/LikeC4Search.tsx
@@ -51,7 +51,6 @@ export const LikeC4Search = memo(() => {
       ],
       onClick: () => {
         store.setState({
-          hoveredNodeId: null,
           lastOnNavigate: {
             fromView: view.id,
             toView: v.id,

--- a/packages/diagram/src/controls/Text.ts
+++ b/packages/diagram/src/controls/Text.ts
@@ -1,0 +1,5 @@
+import { Text as MantineText } from '@mantine/core'
+
+export const Text = MantineText.withProps({
+  component: 'div'
+})

--- a/packages/diagram/src/controls/action-button-bar/ActionButtonBar.css.ts
+++ b/packages/diagram/src/controls/action-button-bar/ActionButtonBar.css.ts
@@ -1,0 +1,13 @@
+import { style } from "@vanilla-extract/css";
+
+export const container = style({
+  zIndex: 100,
+  width: '100%',
+  display: 'flex',
+  flexDirection: 'row',
+  flexWrap: 'nowrap',
+  alignItems: 'center',
+  gap: 2,
+  justifyContent: 'center',
+  pointerEvents: 'none',
+})

--- a/packages/diagram/src/controls/action-button-bar/ActionButtonBar.tsx
+++ b/packages/diagram/src/controls/action-button-bar/ActionButtonBar.tsx
@@ -1,0 +1,82 @@
+import { Box, type ActionIconProps } from "@mantine/core"
+import { m, type HTMLMotionProps, type Variants } from "framer-motion"
+import type { PropsWithoutRef, ReactNode } from "react"
+import * as css from './ActionButtonBar.css'
+import clsx from "clsx";
+
+const TRANSLATE_DIFF = 4;
+
+type ShiftX = 'left' | 'spread' | 'right'
+type ShiftY = 'top' | 'spread' | 'bottom'
+type ShiftMode = number | 'spread'
+
+type ActionButtonBarProps = PropsWithoutRef<
+  ActionIconProps & HTMLMotionProps<'div'> & {
+    shiftX?: ShiftX
+    shiftY?: ShiftY
+    children: ReactNode | ReactNode[]
+  }
+>
+
+const elementVariants = (index: number, count: number, shiftX: ShiftMode, shiftY: ShiftMode) => {
+
+  const translation = {
+    x: shiftX === 'spread' ? 1 - count + index*2 : shiftX,
+    y: shiftY === 'spread' ? 1 - count + index*2 : shiftY,
+  }
+
+  const variants = {
+    idle: {
+      scale: 1,
+      opacity: 0.5,
+      translateX: 0,
+      translateY: 0
+    },
+    hovered: {
+      scale: 1.32,
+      opacity: 1,
+      translateX: translation.x*TRANSLATE_DIFF,
+      translateY: translation.y*TRANSLATE_DIFF
+    },
+    selected: {}
+  } satisfies Variants
+  variants['selected'] = variants['hovered']
+  return variants
+}
+
+export const ActionButtonBar = ({
+  shiftX = 'spread',
+  shiftY = 'spread',
+  children,
+  ...props
+}: ActionButtonBarProps) => {
+
+  const childrenArray = Array.isArray(children) ? children : [children]
+
+  // determine offsets for shifting
+  let shiftDiffX: ShiftMode = 'spread'
+  if (shiftX == 'left')
+    shiftDiffX = -1
+  else if (shiftX == 'right')
+    shiftDiffX = 1
+
+  let shiftDiffY: ShiftMode = 'spread'
+  if (shiftY == 'top')
+    shiftDiffY = -1
+  else if (shiftY == 'bottom')
+    shiftDiffY = 1
+
+  return (
+    <Box className={clsx(css.container)}>
+      {childrenArray.filter(child => !!child).map((child, i) => (
+        <m.div
+          key={i}
+          variants={elementVariants(i, childrenArray.length, shiftDiffX, shiftDiffY)}
+          {...props}
+          >
+          {child}
+        </m.div>
+      ))}
+    </Box>
+  )
+}

--- a/packages/diagram/src/controls/action-buttons/ActionButton.css.ts
+++ b/packages/diagram/src/controls/action-buttons/ActionButton.css.ts
@@ -1,0 +1,18 @@
+import { style } from "@vanilla-extract/css";
+import { mantine, vars } from "../../theme-vars";
+
+export const btn = style({
+  pointerEvents: 'all',
+  color: vars.element.loContrast,
+  cursor: 'pointer',
+  backgroundColor: 'var(--ai-bg)',
+  'vars': {
+    '--ai-bg-idle': `color-mix(in srgb , ${vars.element.fill},  transparent 99%)`,
+    '--ai-bg': `var(--ai-bg-idle)`,
+    '--ai-bg-hover': `color-mix(in srgb , ${vars.element.fill} 65%, ${vars.element.stroke})`,
+    '--ai-hover': `color-mix(in srgb , ${vars.element.fill} 50%, ${vars.element.stroke})`
+  },
+  ':hover': {
+    boxShadow: mantine.shadows.md
+  }
+})

--- a/packages/diagram/src/controls/action-buttons/ActionButton.tsx
+++ b/packages/diagram/src/controls/action-buttons/ActionButton.tsx
@@ -1,0 +1,60 @@
+import { ActionIcon, Tooltip } from "@mantine/core"
+import { stopPropagation } from "../../xyflow/utils"
+import * as css from "./ActionButton.css"
+import clsx from "clsx"
+import { m, type Variants } from "framer-motion"
+
+export type ActionButtonProps = {
+  onClick: ((e: React.MouseEvent) => void)
+  IconComponent: React.ComponentType<any>
+  tooltipLabel?: string
+}
+
+const variants = {
+  idle: {
+    '--icon-scale': 'scale(1)',
+    '--ai-bg': 'var(--ai-bg-idle)',
+  },
+  hovered: {
+    '--icon-scale': 'scale(1)',
+    '--ai-bg': 'var(--ai-bg-hover)',
+  },
+  selected: {}
+} satisfies Variants
+variants['selected'] = variants['hovered']
+
+export const ActionButton = ({
+  onClick: action,
+  IconComponent,
+  tooltipLabel,
+  ...props
+}: ActionButtonProps) => {
+
+return (
+  <Tooltip
+    fz="xs"
+    color="dark"
+    label={tooltipLabel ?? ''}
+    disabled={!tooltipLabel}
+    withinPortal={false}
+    offset={2}
+    openDelay={600}>
+    <ActionIcon
+      component={m.div}
+      variants={variants}
+      className={clsx('nodrag nopan', css.btn)}
+      radius="md"
+      role="button"
+      onClick={action}
+      onDoubleClick={stopPropagation}
+      {...props}
+      >
+      <IconComponent
+        style={{
+          width: '70%',
+          transform: 'var(--icon-scale)'
+        }} />
+      </ActionIcon>
+  </Tooltip>
+  )
+}

--- a/packages/diagram/src/controls/action-buttons/ActionButtons.tsx
+++ b/packages/diagram/src/controls/action-buttons/ActionButtons.tsx
@@ -1,0 +1,111 @@
+import type { Fqn } from "@likec4/core"
+import { useCallback } from "react"
+import { useDiagramState, useDiagramStoreApi } from "../../hooks"
+import { ActionButton } from "./ActionButton"
+import { IconFileSymlink, IconId, IconTransform, IconZoomScan } from "@tabler/icons-react"
+
+export type NodeActionButtonProps = {
+  fqn: Fqn
+}
+
+// Browse Relationships
+
+export const BrowseRelationshipsButton = ({
+  fqn
+}: NodeActionButtonProps) => {
+
+  const {
+    openOverlay
+  } = useDiagramState(s => ({
+    openOverlay: s.openOverlay
+  }))
+
+  const onBrowseRelationships = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation()
+    openOverlay({ relationshipsOf: fqn })
+  }, [openOverlay, fqn])
+
+  return (
+    <ActionButton
+      onClick={onBrowseRelationships}
+      IconComponent={IconTransform}
+      tooltipLabel='Browse relationships'
+      />
+  )
+}
+
+// Navigate to
+
+export const NavigateToButton = ({
+  fqn
+}: NodeActionButtonProps) => {
+
+  const {
+    triggerOnNavigateTo
+  } = useDiagramState(s => ({
+    triggerOnNavigateTo: s.triggerOnNavigateTo
+  }))
+
+  const onNavigateTo = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation()
+    triggerOnNavigateTo(fqn, e)
+  }, [triggerOnNavigateTo, fqn])
+
+  return (
+    <ActionButton
+      onClick={onNavigateTo}
+      IconComponent={IconZoomScan}
+      tooltipLabel='Open scoped view'
+      />
+  )
+}
+
+// Open details
+
+export const OpenDetailsButton = ({
+  fqn
+}: NodeActionButtonProps) => {
+
+  const {
+    openOverlay
+  } = useDiagramState(s => ({
+    openOverlay: s.openOverlay
+  }))
+
+  const onOpenDetails = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation()
+    openOverlay({ elementDetails: fqn })
+  }, [openOverlay, fqn])
+
+  return (
+    <ActionButton
+      onClick={onOpenDetails}
+      IconComponent={IconId}
+      tooltipLabel='Open details'
+      />
+  )
+}
+
+// Open element source
+
+export const OpenSourceButton = ({
+  fqn
+}: NodeActionButtonProps) => {
+
+  const diagramApi = useDiagramStoreApi()
+
+  const onOpenSource = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation()
+    diagramApi.getState().onOpenSource?.({
+      element: fqn
+    })
+  }, [diagramApi.getState(), fqn])
+
+  return (
+    <ActionButton
+      onClick={onOpenSource}
+      IconComponent={IconFileSymlink}
+      tooltipLabel='Open source'
+      />
+  )
+}

--- a/packages/diagram/src/hooks/useXYFlow.ts
+++ b/packages/diagram/src/hooks/useXYFlow.ts
@@ -1,15 +1,15 @@
 import { useInternalNode, useNodesData, useReactFlow, useStore, useStoreApi } from '@xyflow/react'
 import { deepEqual, shallowEqual } from 'fast-equals'
 import { useCallback } from 'react'
-import type { XYFlowEdge, XYFlowNode, XYFlowState } from '../xyflow/types'
+import type { DiagramFlowTypes } from '../xyflow/types'
 
-export const useXYFlow = useReactFlow<XYFlowNode, XYFlowEdge>
+export const useXYFlow = useReactFlow<DiagramFlowTypes.Node, DiagramFlowTypes.Edge>
 
-export const useXYNodesData = useNodesData<XYFlowNode>
-export const useXYInternalNode = useInternalNode<XYFlowNode>
+export const useXYNodesData = useNodesData<DiagramFlowTypes.Node>
+export const useXYInternalNode = useInternalNode<DiagramFlowTypes.Node>
 
 export function useXYStore<StateSlice = unknown>(
-  selector: (state: XYFlowState) => StateSlice,
+  selector: (state: DiagramFlowTypes.XYFlowState) => StateSlice,
   equalityFn?: (a: StateSlice, b: StateSlice) => boolean
 ): StateSlice {
   return useStore(
@@ -17,15 +17,15 @@ export function useXYStore<StateSlice = unknown>(
     equalityFn ?? shallowEqual
   )
 }
-export const useXYStoreApi = useStoreApi<XYFlowNode, XYFlowEdge>
+export const useXYStoreApi = useStoreApi<DiagramFlowTypes.Node, DiagramFlowTypes.Edge>
 export type XYStoreApi = ReturnType<typeof useXYStoreApi>
 
-export function useXYEdgesData(edgeIds: string[]): Pick<XYFlowEdge, 'id' | 'data'>[] {
+export function useXYEdgesData(edgeIds: string[]): Pick<DiagramFlowTypes.Edge, 'id' | 'data'>[] {
   const ids = edgeIds.join(',')
   const edgesData = useXYStore(
     useCallback(
       (s) => {
-        const data = [] as Pick<XYFlowEdge, 'id' | 'data'>[]
+        const data = [] as Pick<DiagramFlowTypes.Edge, 'id' | 'data'>[]
         for (const id of edgeIds) {
           const edge = s.edgeLookup.get(id)
           if (edge) {

--- a/packages/diagram/src/overlays/edge-details/EdgeDetailsXYFlow.tsx
+++ b/packages/diagram/src/overlays/edge-details/EdgeDetailsXYFlow.tsx
@@ -13,8 +13,8 @@ import {
 import { memo, useEffect } from 'react'
 import { only } from 'remeda'
 import { useDiagramStoreApi } from '../../hooks/useDiagramState'
-import type { SharedTypes } from '../shared/xyflow/_types'
-import type { XYFlowTypes } from './_types'
+import type { SharedFlowTypes } from '../shared/xyflow/_types'
+import type { EdgeDetailsFlowTypes } from './_types'
 import { SelectEdge } from './SelectEdge'
 import * as css from './SelectEdge.css'
 import { useLayoutedEdgeDetails, ZIndexes } from './use-layouted-edge-details'
@@ -30,7 +30,7 @@ const edgeTypes = {
   relation: RelationshipEdge
 }
 
-const resetDimmedAndHovered = (xyflow: ReactFlowInstance<SharedTypes.Node, XYFlowTypes.Edge>) => {
+const resetDimmedAndHovered = (xyflow: ReactFlowInstance<SharedFlowTypes.Node, EdgeDetailsFlowTypes.Edge>) => {
   xyflow.setEdges(edges =>
     edges.map(edge => ({
       ...edge,
@@ -51,12 +51,12 @@ const resetDimmedAndHovered = (xyflow: ReactFlowInstance<SharedTypes.Node, XYFlo
           dimmed: false,
           hovered: false
         }
-      }) as SharedTypes.Node
+      }) as SharedFlowTypes.Node
     )
   )
 }
 
-const animateEdge = (node: SharedTypes.Node, animated = true) => (edges: XYFlowTypes.Edge[]) => {
+const animateEdge = (node: SharedFlowTypes.Node, animated = true) => (edges: EdgeDetailsFlowTypes.Edge[]) => {
   return edges.map(edge => {
     const isConnected = edge.source === node.id || edge.target === node.id || isAncestor(node.id, edge.source)
       || isAncestor(node.id, edge.target)
@@ -80,8 +80,8 @@ export const EdgeDetailsXYFlow = memo<{ edgeId: EdgeId }>(function EdgeDetailsXY
 
   const boundsRef = useSyncedRef(bounds)
 
-  const xyflow = useReactFlow<SharedTypes.Node, XYFlowTypes.Edge>()
-  const xystore = useStoreApi<SharedTypes.Node, XYFlowTypes.Edge>()
+  const xyflow = useReactFlow<SharedFlowTypes.Node, EdgeDetailsFlowTypes.Edge>()
+  const xystore = useStoreApi<SharedFlowTypes.Node, EdgeDetailsFlowTypes.Edge>()
 
   const fitview = useDebouncedCallback(
     () => {
@@ -117,8 +117,8 @@ export const EdgeDetailsXYFlow = memo<{ edgeId: EdgeId }>(function EdgeDetailsXY
 
   return (
     <ReactFlow
-      defaultEdges={[] as XYFlowTypes.Edge[]}
-      defaultNodes={[] as SharedTypes.Node[]}
+      defaultEdges={[] as EdgeDetailsFlowTypes.Edge[]}
+      defaultNodes={[] as SharedFlowTypes.Node[]}
       nodeTypes={nodeTypes}
       edgeTypes={edgeTypes}
       defaultMarkerColor="var(--xy-edge-stroke)"
@@ -170,7 +170,7 @@ export const EdgeDetailsXYFlow = memo<{ edgeId: EdgeId }>(function EdgeDetailsXY
               ...n.data,
               dimmed: n.id !== edge.source && n.id !== edge.target
             }
-          } as SharedTypes.Node))
+          } as SharedFlowTypes.Node))
         )
       }}
       onEdgeMouseLeave={() => {

--- a/packages/diagram/src/overlays/edge-details/_types.ts
+++ b/packages/diagram/src/overlays/edge-details/_types.ts
@@ -1,11 +1,18 @@
 import type { AddEdgeData } from '../../utils/types'
-import type { SharedTypes } from '../shared/xyflow/_types'
+import type { SharedFlowTypes } from '../shared/xyflow/_types'
 
-export namespace XYFlowTypes {
+export namespace EdgeDetailsFlowTypes {
+
+  /**
+   * Data that is exclusive to the edge-details overlay. It will be merged into the edge types
+   * provided by SharedFlowTypes.
+   */
   type EdgeDetailsEdgeData = {
     technology: string | null
     description: string | null
   }
 
-  export type Edge = AddEdgeData<SharedTypes.Edge, EdgeDetailsEdgeData>
+  // Extend the edge types provided by SharedFlowTypes with EdgeDetailsEdgeData
+
+  export type Edge = AddEdgeData<SharedFlowTypes.Edge, EdgeDetailsEdgeData>
 }

--- a/packages/diagram/src/overlays/edge-details/use-layouted-edge-details.ts
+++ b/packages/diagram/src/overlays/edge-details/use-layouted-edge-details.ts
@@ -17,8 +17,8 @@ import { useMemo } from 'react'
 import { filter, first, forEach, isTruthy, map, pipe, prop, reverse, sort, sortBy, takeWhile } from 'remeda'
 import { useDiagramState } from '../../hooks/useDiagramState'
 import { useLikeC4Model } from '../../likec4model'
-import type { SharedTypes } from '../shared/xyflow/_types'
-import type { XYFlowTypes } from './_types'
+import type { SharedFlowTypes } from '../shared/xyflow/_types'
+import type { EdgeDetailsFlowTypes } from './_types'
 
 /**
  * All constants related to the layout
@@ -69,16 +69,16 @@ function createGraph() {
 type Context = {
   g: dagre.graphlib.Graph
   diagramNodes: Map<Fqn, DiagramNode>
-  xynodes: Map<Fqn, SharedTypes.NonEmptyNode>
+  xynodes: Map<Fqn, SharedFlowTypes.NonEmptyNode>
   edge: DiagramEdge
-  edges: XYFlowTypes.Edge[]
+  edges: EdgeDetailsFlowTypes.Edge[]
 }
 const sized = (height: number = Sizes.hodeHeight) => ({
   width: Sizes.nodeWidth,
   height
 })
 
-const graphId = (node: SharedTypes.Node) => ({
+const graphId = (node: SharedFlowTypes.Node) => ({
   id: node.id,
   port: node.type === 'compound' ? `${node.id}::port` : node.id,
   body: `${node.id}`,
@@ -88,7 +88,7 @@ const graphId = (node: SharedTypes.Node) => ({
 function nodeData(
   element: LikeC4Model.Element,
   ctx: Context
-): SharedTypes.NodeData {
+): SharedFlowTypes.OverlayNodeData {
   // We try to inherit style from existing diagram node
   let diagramNode = ctx.diagramNodes.get(element.id)
 
@@ -119,10 +119,10 @@ function nodeData(
 }
 
 function createNode(
-  nodeType: SharedTypes.NonEmptyNode['type'],
+  nodeType: SharedFlowTypes.NonEmptyNode['type'],
   element: LikeC4Model.Element,
   ctx: Context
-): SharedTypes.Node {
+): SharedFlowTypes.Node {
   let node = ctx.xynodes.get(element.id)
   if (node) {
     return node
@@ -137,7 +137,7 @@ function createNode(
     found => found ? createNode('compound', found, ctx) : null
   )
 
-  const xynode: SharedTypes.NonEmptyNode = {
+  const xynode: SharedFlowTypes.NonEmptyNode = {
     type: nodeType,
     id: element.id,
     position: { x: 0, y: 0 },
@@ -183,7 +183,7 @@ function createNode(
  * And return a function to get node bounds for xyflow
  */
 function applyDagreLayout(g: dagre.graphlib.Graph) {
-  type NodeBounds = Required<Pick<SharedTypes.Node, 'position' | 'width' | 'height'>>
+  type NodeBounds = Required<Pick<SharedFlowTypes.Node, 'position' | 'width' | 'height'>>
   dagre.layout(g)
   return function nodeBounds(nodeId: string, relativeTo?: string): NodeBounds {
     const { x, y, width, height } = g.node(nodeId)
@@ -217,8 +217,8 @@ function layout(
 ): {
   view: DiagramView
   edge: DiagramEdge
-  nodes: SharedTypes.Node[]
-  edges: XYFlowTypes.Edge[]
+  nodes: SharedFlowTypes.Node[]
+  edges: EdgeDetailsFlowTypes.Edge[]
   bounds: { x: number; y: number; width: number; height: number }
 } {
   const edge = view.edges.find(e => e.id === edgeId)
@@ -274,7 +274,7 @@ function layout(
     target.data.ports.in.push(source.id)
 
     g.setEdge(graphId(source).port, graphId(target).port)
-    const edge: XYFlowTypes.Edge = {
+    const edge: EdgeDetailsFlowTypes.Edge = {
       id: relation.id,
       type: 'relation',
       source: source.id,

--- a/packages/diagram/src/overlays/edge-details/xyflow/CompoundNode.tsx
+++ b/packages/diagram/src/overlays/edge-details/xyflow/CompoundNode.tsx
@@ -2,14 +2,14 @@ import { Text as MantineText } from '@mantine/core'
 import { Handle, type NodeProps, Position } from '@xyflow/react'
 import clsx from 'clsx'
 import { m } from 'framer-motion'
-import type { SharedTypes } from '../../shared/xyflow/_types'
+import type { SharedFlowTypes } from '../../shared/xyflow/_types'
 import * as css from './styles.css'
 
 const Text = MantineText.withProps({
   component: 'div'
 })
 
-type CompoundNodeProps = NodeProps<SharedTypes.CompoundNode>
+type CompoundNodeProps = NodeProps<SharedFlowTypes.CompoundNode>
 
 export function CompoundNode({
   data: {

--- a/packages/diagram/src/overlays/edge-details/xyflow/CompoundNode.tsx
+++ b/packages/diagram/src/overlays/edge-details/xyflow/CompoundNode.tsx
@@ -1,13 +1,9 @@
-import { Text as MantineText } from '@mantine/core'
 import { Handle, type NodeProps, Position } from '@xyflow/react'
 import clsx from 'clsx'
 import { m } from 'framer-motion'
 import type { SharedFlowTypes } from '../../shared/xyflow/_types'
 import * as css from './styles.css'
-
-const Text = MantineText.withProps({
-  component: 'div'
-})
+import { Text } from '../../../controls/Text'
 
 type CompoundNodeProps = NodeProps<SharedFlowTypes.CompoundNode>
 

--- a/packages/diagram/src/overlays/edge-details/xyflow/ElementNode.tsx
+++ b/packages/diagram/src/overlays/edge-details/xyflow/ElementNode.tsx
@@ -1,4 +1,4 @@
-import { ActionIcon, Box, Group, Text as MantineText } from '@mantine/core'
+import { ActionIcon, Box, Group } from '@mantine/core'
 import { IconFileSymlink, IconTransform, IconZoomScan } from '@tabler/icons-react'
 import { Handle, type NodeProps, Position } from '@xyflow/react'
 import clsx from 'clsx'
@@ -9,6 +9,7 @@ import { stopPropagation } from '../../../xyflow/utils'
 import { useOverlayDialog } from '../../OverlayContext'
 import type { SharedFlowTypes } from '../../shared/xyflow/_types'
 import * as css from './styles.css'
+import { Text } from '../../../controls/Text'
 
 const Action = ActionIcon.withProps({
   className: 'nodrag nopan ' + css.navigateBtn,
@@ -16,10 +17,6 @@ const Action = ActionIcon.withProps({
   role: 'button',
   onDoubleClick: stopPropagation,
   onPointerDownCapture: stopPropagation
-})
-
-const Text = MantineText.withProps({
-  component: 'div'
 })
 
 type ElementNodeProps = NodeProps<SharedFlowTypes.ElementNode>

--- a/packages/diagram/src/overlays/edge-details/xyflow/ElementNode.tsx
+++ b/packages/diagram/src/overlays/edge-details/xyflow/ElementNode.tsx
@@ -7,7 +7,7 @@ import { type DiagramState, useDiagramState } from '../../../hooks'
 import { ElementShapeSvg } from '../../../xyflow/nodes/element/ElementShapeSvg'
 import { stopPropagation } from '../../../xyflow/utils'
 import { useOverlayDialog } from '../../OverlayContext'
-import type { SharedTypes } from '../../shared/xyflow/_types'
+import type { SharedFlowTypes } from '../../shared/xyflow/_types'
 import * as css from './styles.css'
 
 const Action = ActionIcon.withProps({
@@ -22,7 +22,7 @@ const Text = MantineText.withProps({
   component: 'div'
 })
 
-type ElementNodeProps = NodeProps<SharedTypes.ElementNode>
+type ElementNodeProps = NodeProps<SharedFlowTypes.ElementNode>
 
 function selector(s: DiagramState) {
   return {

--- a/packages/diagram/src/overlays/edge-details/xyflow/RelationshipEdge.tsx
+++ b/packages/diagram/src/overlays/edge-details/xyflow/RelationshipEdge.tsx
@@ -6,14 +6,14 @@ import { useDiagramState } from '../../../hooks/useDiagramState'
 import { stopPropagation } from '../../../xyflow/utils'
 import { useOverlayDialog } from '../../OverlayContext'
 import * as css from '../../shared/xyflow/RelationshipEdge.css'
-import type { XYFlowTypes } from '../_types'
+import type { EdgeDetailsFlowTypes } from '../_types'
 import { ZIndexes } from '../use-layouted-edge-details'
 
 export function RelationshipEdge({
   data,
   label,
   ...props
-}: EdgeProps<XYFlowTypes.Edge>) {
+}: EdgeProps<EdgeDetailsFlowTypes.Edge>) {
   const overlay = useOverlayDialog()
   const onNavigateTo = useDiagramState(s => s.onNavigateTo)
   const [edgePath, labelX, labelY] = getBezierPath(props)

--- a/packages/diagram/src/overlays/relationships-of/RelationshipsXYFlow.tsx
+++ b/packages/diagram/src/overlays/relationships-of/RelationshipsXYFlow.tsx
@@ -19,7 +19,7 @@ import { isNullish, map, omit, only, prop, setPath, unique } from 'remeda'
 import { useUpdateEffect } from '../../hooks'
 import { centerXYInternalNode } from '../../xyflow/utils'
 import { cssReactflowMarker } from '../Overlays.css'
-import type { XYFlowTypes } from './_types'
+import type { RelationshipsOfFlowTypes } from './_types'
 import { ZIndexes } from './use-layouted-relationships'
 import { CompoundNode } from './xyflow/CompoundNode'
 import { ElementNode } from './xyflow/ElementNode'
@@ -38,10 +38,10 @@ const edgeTypes = {
 /**
  * Root node in 'subjects' column
  */
-const findRootSubject = (nodes: XYFlowTypes.Node[]) =>
-  nodes.find((n): n is XYFlowTypes.ElementNode => n.data.column === 'subjects' && isNullish(n.parentId))
+const findRootSubject = (nodes: RelationshipsOfFlowTypes.Node[]) =>
+  nodes.find((n): n is RelationshipsOfFlowTypes.ElementNode => n.data.column === 'subjects' && isNullish(n.parentId))
 
-const resetDimmedAndHovered = (xyflow: ReactFlowInstance<XYFlowTypes.Node, XYFlowTypes.Edge>) => {
+const resetDimmedAndHovered = (xyflow: ReactFlowInstance<RelationshipsOfFlowTypes.Node, RelationshipsOfFlowTypes.Edge>) => {
   xyflow.setEdges(edges =>
     edges.map(edge => ({
       ...edge,
@@ -62,12 +62,12 @@ const resetDimmedAndHovered = (xyflow: ReactFlowInstance<XYFlowTypes.Node, XYFlo
           dimmed: false,
           hovered: false
         }
-      }) as XYFlowTypes.Node
+      }) as RelationshipsOfFlowTypes.Node
     )
   )
 }
 
-const animateEdge = (node: XYFlowTypes.Node, animated = true) => (edges: XYFlowTypes.Edge[]) => {
+const animateEdge = (node: RelationshipsOfFlowTypes.Node, animated = true) => (edges: RelationshipsOfFlowTypes.Edge[]) => {
   return edges.map(edge => {
     const isConnected = edge.source === node.id || edge.target === node.id || isAncestor(node.id, edge.source)
       || isAncestor(node.id, edge.target)
@@ -79,7 +79,7 @@ const animateEdge = (node: XYFlowTypes.Node, animated = true) => (edges: XYFlowT
 }
 
 const onlyOneUnique = <T extends keyof AbstractRelation>(
-  data: XYFlowTypes.Edge['data'],
+  data: RelationshipsOfFlowTypes.Edge['data'],
   property: T
 ): AbstractRelation[T] | undefined => {
   return only(unique(map(data.relations, prop(property))))
@@ -89,8 +89,8 @@ type RelationshipsXYFlowProps =
   & PropsWithChildren<{
     subjectId: Fqn
     view: DiagramView
-    nodes: XYFlowTypes.Node[]
-    edges: XYFlowTypes.Edge[]
+    nodes: RelationshipsOfFlowTypes.Node[]
+    edges: RelationshipsOfFlowTypes.Edge[]
     bounds: {
       x: number
       y: number
@@ -100,7 +100,7 @@ type RelationshipsXYFlowProps =
     viewportPadding?: number | undefined
   }>
   & Pick<
-    ReactFlowProps<XYFlowTypes.Node, XYFlowTypes.Edge>,
+    ReactFlowProps<RelationshipsOfFlowTypes.Node, RelationshipsOfFlowTypes.Edge>,
     | 'onNodeClick'
     | 'elementsSelectable'
     | 'maxZoom'
@@ -122,10 +122,10 @@ function RelationshipsXYFlowWrapped({
 }: RelationshipsXYFlowProps) {
   const id = useId()
 
-  const lastClickedNodeRef = useRef<XYFlowTypes.NonEmptyNode | null>(null)
+  const lastClickedNodeRef = useRef<RelationshipsOfFlowTypes.NonEmptyNode | null>(null)
 
-  const xyflow = useReactFlow<XYFlowTypes.Node, XYFlowTypes.Edge>()
-  const xystore = useStoreApi<XYFlowTypes.Node, XYFlowTypes.Edge>()
+  const xyflow = useReactFlow<RelationshipsOfFlowTypes.Node, RelationshipsOfFlowTypes.Edge>()
+  const xystore = useStoreApi<RelationshipsOfFlowTypes.Node, RelationshipsOfFlowTypes.Edge>()
 
   const [zoomOnDoubleClick, setZoomOnDoubleClick] = useState(true)
 
@@ -227,7 +227,7 @@ function RelationshipsXYFlowWrapped({
               dimmed: n.data.column === 'subjects' ? 'immediate' : false
             }
             // hidden: n.data.column === 'subjects'
-          } as XYFlowTypes.Node
+          } as RelationshipsOfFlowTypes.Node
         }
         // Move existing node
         return {
@@ -242,7 +242,7 @@ function RelationshipsXYFlowWrapped({
             leaving: false,
             dimmed: false
           }
-        } as XYFlowTypes.Node
+        } as RelationshipsOfFlowTypes.Node
       }))
       setEdges(_edges.map(e => ({
         ...e,
@@ -291,8 +291,8 @@ function RelationshipsXYFlowWrapped({
   return (
     <ReactFlow
       id={id}
-      defaultEdges={[] as XYFlowTypes.Edge[]}
-      defaultNodes={[] as XYFlowTypes.Node[]}
+      defaultEdges={[] as RelationshipsOfFlowTypes.Edge[]}
+      defaultNodes={[] as RelationshipsOfFlowTypes.Node[]}
       nodeTypes={nodeTypes}
       edgeTypes={edgeTypes}
       defaultMarkerColor="var(--likec4-relation-lineColor)"
@@ -344,7 +344,7 @@ function RelationshipsXYFlowWrapped({
               ...n.data,
               dimmed: n.id !== edge.source && n.id !== edge.target
             }
-          } as XYFlowTypes.Node))
+          } as RelationshipsOfFlowTypes.Node))
         )
       }}
       onEdgeMouseLeave={() => {

--- a/packages/diagram/src/overlays/relationships-of/_types.ts
+++ b/packages/diagram/src/overlays/relationships-of/_types.ts
@@ -1,7 +1,12 @@
 import type { AddEdgeData, AddNodeData } from '../../utils/types'
-import type { SharedTypes } from '../shared/xyflow/_types'
+import type { SharedFlowTypes } from '../shared/xyflow/_types'
 
-export namespace XYFlowTypes {
+export namespace RelationshipsOfFlowTypes {
+
+  /**
+   * Data that is exclusive to the relationships-of overlay. It will be merged into the node types
+   * provided by SharedFlowTypes.
+   */
   type RelationshipsOfNodeData = {
     depth?: number
     column: 'incomers' | 'subjects' | 'outgoers'
@@ -9,19 +14,27 @@ export namespace XYFlowTypes {
     layoutId?: string
   }
 
-  export type ElementNode = AddNodeData<SharedTypes.ElementNode, RelationshipsOfNodeData>
+  // Extend the node types provided by SharedFlowTypes with RelationshipsOfNodeData
 
-  export type CompoundNode = AddNodeData<SharedTypes.CompoundNode, RelationshipsOfNodeData>
+  export type ElementNode = AddNodeData<SharedFlowTypes.ElementNode, RelationshipsOfNodeData>
+
+  export type CompoundNode = AddNodeData<SharedFlowTypes.CompoundNode, RelationshipsOfNodeData>
 
   export type NonEmptyNode = ElementNode | CompoundNode
 
-  export type EmptyNode = AddNodeData<SharedTypes.EmptyNode, RelationshipsOfNodeData>
+  export type EmptyNode = AddNodeData<SharedFlowTypes.EmptyNode, RelationshipsOfNodeData>
 
   export type Node = NonEmptyNode | EmptyNode
 
+  /**
+   * Data that is exclusive to the relationships-of overlay. It will be merged into the edge types
+   * provided by SharedFlowTypes.
+   */
   type RelationshipsOfEdgeData = {
     existsInCurrentView: boolean
   }
 
-  export type Edge = AddEdgeData<SharedTypes.Edge, RelationshipsOfEdgeData>
+  // Extend the edge types provided by SharedFlowTypes with RelationshipsOfEdgeData
+
+  export type Edge = AddEdgeData<SharedFlowTypes.Edge, RelationshipsOfEdgeData>
 }

--- a/packages/diagram/src/overlays/relationships-of/use-layouted-relationships.ts
+++ b/packages/diagram/src/overlays/relationships-of/use-layouted-relationships.ts
@@ -38,7 +38,7 @@ import {
   tap
 } from 'remeda'
 import { useLikeC4Model } from '../../likec4model'
-import type { XYFlowTypes } from './_types'
+import type { RelationshipsOfFlowTypes } from './_types'
 
 const columns = ['incomers', 'subjects', 'outgoers'] as const
 type ColumnKey = typeof columns[number]
@@ -134,11 +134,11 @@ type Context = {
     outgoers: Set<Fqn>
   }
   columns: {
-    incomers: Map<Fqn, XYFlowTypes.Node>
-    subjects: Map<Fqn, XYFlowTypes.Node>
-    outgoers: Map<Fqn, XYFlowTypes.Node>
+    incomers: Map<Fqn, RelationshipsOfFlowTypes.Node>
+    subjects: Map<Fqn, RelationshipsOfFlowTypes.Node>
+    outgoers: Map<Fqn, RelationshipsOfFlowTypes.Node>
   }
-  edges: XYFlowTypes.Edge[]
+  edges: RelationshipsOfFlowTypes.Edge[]
 }
 
 const sized = (height: number = Sizes.hodeHeight) => ({
@@ -146,7 +146,7 @@ const sized = (height: number = Sizes.hodeHeight) => ({
   height
 })
 
-const graphId = (node: XYFlowTypes.Node) => ({
+const graphId = (node: RelationshipsOfFlowTypes.Node) => ({
   id: node.id,
   port: node.type === 'compound' ? `${node.id}::port` : node.id,
   body: `${node.id}`,
@@ -156,7 +156,7 @@ const graphId = (node: XYFlowTypes.Node) => ({
 function nodeData(
   element: LikeC4Model.Element,
   ctx: Context
-): Omit<XYFlowTypes.NonEmptyNode['data'], 'column'> {
+): Omit<RelationshipsOfFlowTypes.NonEmptyNode['data'], 'column'> {
   // We try to inherit style from existing diagram node
   let diagramNode = ctx.diagramNodes.get(element.id)
 
@@ -192,7 +192,7 @@ function nodeData(
 function createEmptyNode(
   column: ColumnKey,
   ctx: Context
-): XYFlowTypes.EmptyNode {
+): RelationshipsOfFlowTypes.EmptyNode {
   const id = `${column}__empty` as Fqn
   const xynodes = ctx.columns[column]
   let node = xynodes.get(id)
@@ -200,7 +200,7 @@ function createEmptyNode(
     invariant(node.type === 'empty', 'Node is not empty')
     return node
   }
-  const xynode: XYFlowTypes.EmptyNode = {
+  const xynode: RelationshipsOfFlowTypes.EmptyNode = {
     type: 'empty',
     id,
     position: { x: 0, y: 0 },
@@ -225,11 +225,11 @@ function createEmptyNode(
 
 function createNode(
   column: ColumnKey,
-  nodeType: Exclude<XYFlowTypes.Node['type'], 'empty'>,
+  nodeType: Exclude<RelationshipsOfFlowTypes.Node['type'], 'empty'>,
   element: LikeC4Model.Element,
   ctx: Context,
   depth: number = 0
-): XYFlowTypes.ElementNode | XYFlowTypes.CompoundNode {
+): RelationshipsOfFlowTypes.ElementNode | RelationshipsOfFlowTypes.CompoundNode {
   const xynodes = ctx.columns[column]
   let node = xynodes.get(element.id)
   if (node) {
@@ -252,7 +252,7 @@ function createNode(
     found => found ? createNode(column, 'compound', found, ctx, depth + 2) : null
   )
 
-  const xynode: XYFlowTypes.NonEmptyNode = {
+  const xynode: RelationshipsOfFlowTypes.NonEmptyNode = {
     type: nodeType,
     id: `${column}::${element.id}`,
     position: { x: 0, y: 0 },
@@ -290,7 +290,7 @@ function createNode(
  * And return a function to get node bounds for xyflow
  */
 function applyDagreLayout(g: dagre.graphlib.Graph) {
-  type NodeBounds = Required<Pick<XYFlowTypes.Node, 'position' | 'width' | 'height'>>
+  type NodeBounds = Required<Pick<RelationshipsOfFlowTypes.Node, 'position' | 'width' | 'height'>>
   dagre.layout(g)
   return function nodeBounds(nodeId: string): NodeBounds {
     const { x, y, width, height } = g.node(nodeId)
@@ -311,7 +311,7 @@ function addEdge(
     existsInCurrentView: boolean
     source: string
     target: string
-    relations: XYFlowTypes.Edge['data']['relations']
+    relations: RelationshipsOfFlowTypes.Edge['data']['relations']
   }
 ) {
   const { source, target, relations, existsInCurrentView } = props
@@ -319,7 +319,7 @@ function addEdge(
   const label = only(relations)?.title ?? 'untitled'
 
   const isMultiple = relations.length > 1
-  const edge: XYFlowTypes.Edge = {
+  const edge: RelationshipsOfFlowTypes.Edge = {
     id: `rel${ctx.edges.length + 1}_${ids}`,
     type: 'relation',
     source,
@@ -362,8 +362,8 @@ function layout(
   viewIncludesSubject: boolean
   notIncludedRelations: number
   subject: LikeC4Model.Element
-  nodes: XYFlowTypes.Node[]
-  edges: XYFlowTypes.Edge[]
+  nodes: RelationshipsOfFlowTypes.Node[]
+  edges: RelationshipsOfFlowTypes.Edge[]
   bounds: {
     x: number
     y: number

--- a/packages/diagram/src/overlays/relationships-of/xyflow/CompoundNode.tsx
+++ b/packages/diagram/src/overlays/relationships-of/xyflow/CompoundNode.tsx
@@ -4,14 +4,14 @@ import clsx from 'clsx'
 import { deepEqual, shallowEqual } from 'fast-equals'
 import { m } from 'framer-motion'
 import { memo, useCallback } from 'react'
-import type { XYFlowTypes } from '../_types'
+import type { RelationshipsOfFlowTypes } from '../_types'
 import * as css from './styles.css'
 
 const Text = MantineText.withProps({
   component: 'div'
 })
 
-type CompoundNodeProps = NodeProps<XYFlowTypes.CompoundNode>
+type CompoundNodeProps = NodeProps<RelationshipsOfFlowTypes.CompoundNode>
 
 export const CompoundNode = memo<CompoundNodeProps>(({
   id,

--- a/packages/diagram/src/overlays/relationships-of/xyflow/CompoundNode.tsx
+++ b/packages/diagram/src/overlays/relationships-of/xyflow/CompoundNode.tsx
@@ -1,4 +1,3 @@
-import { Text as MantineText } from '@mantine/core'
 import { Handle, type NodeProps, Position, useStore } from '@xyflow/react'
 import clsx from 'clsx'
 import { deepEqual, shallowEqual } from 'fast-equals'
@@ -6,10 +5,7 @@ import { m } from 'framer-motion'
 import { memo, useCallback } from 'react'
 import type { RelationshipsOfFlowTypes } from '../_types'
 import * as css from './styles.css'
-
-const Text = MantineText.withProps({
-  component: 'div'
-})
+import { Text } from '../../../controls/Text'
 
 type CompoundNodeProps = NodeProps<RelationshipsOfFlowTypes.CompoundNode>
 

--- a/packages/diagram/src/overlays/relationships-of/xyflow/ElementNode.tsx
+++ b/packages/diagram/src/overlays/relationships-of/xyflow/ElementNode.tsx
@@ -1,4 +1,4 @@
-import { ActionIcon, Box, Group, Text as MantineText } from '@mantine/core'
+import { ActionIcon, Box, Group } from '@mantine/core'
 import { IconFileSymlink, IconTransform, IconZoomScan } from '@tabler/icons-react'
 import { Handle, type NodeProps, Position } from '@xyflow/react'
 import clsx from 'clsx'
@@ -11,6 +11,7 @@ import { stopPropagation } from '../../../xyflow/utils'
 import { useOverlayDialog } from '../../OverlayContext'
 import type { RelationshipsOfFlowTypes } from '../_types'
 import * as css from './styles.css'
+import { Text } from '../../../controls/Text'
 
 const Action = ActionIcon.withProps({
   className: 'nodrag nopan ' + css.navigateBtn,
@@ -18,10 +19,6 @@ const Action = ActionIcon.withProps({
   role: 'button',
   onDoubleClick: stopPropagation,
   onPointerDownCapture: stopPropagation
-})
-
-const Text = MantineText.withProps({
-  component: 'div'
 })
 
 type ElementNodeProps = NodeProps<RelationshipsOfFlowTypes.ElementNode>

--- a/packages/diagram/src/overlays/relationships-of/xyflow/ElementNode.tsx
+++ b/packages/diagram/src/overlays/relationships-of/xyflow/ElementNode.tsx
@@ -9,7 +9,7 @@ import { type DiagramState, useDiagramState } from '../../../hooks'
 import { ElementShapeSvg } from '../../../xyflow/nodes/element/ElementShapeSvg'
 import { stopPropagation } from '../../../xyflow/utils'
 import { useOverlayDialog } from '../../OverlayContext'
-import type { XYFlowTypes } from '../_types'
+import type { RelationshipsOfFlowTypes } from '../_types'
 import * as css from './styles.css'
 
 const Action = ActionIcon.withProps({
@@ -24,7 +24,7 @@ const Text = MantineText.withProps({
   component: 'div'
 })
 
-type ElementNodeProps = NodeProps<XYFlowTypes.ElementNode>
+type ElementNodeProps = NodeProps<RelationshipsOfFlowTypes.ElementNode>
 
 function selector(s: DiagramState) {
   return {

--- a/packages/diagram/src/overlays/relationships-of/xyflow/EmptyNode.tsx
+++ b/packages/diagram/src/overlays/relationships-of/xyflow/EmptyNode.tsx
@@ -1,11 +1,8 @@
-import { Box, Text as MantineText } from '@mantine/core'
+import { Box } from '@mantine/core'
 import { type NodeProps } from '@xyflow/react'
 import type { RelationshipsOfFlowTypes } from '../_types'
 import * as css from './styles.css'
-
-const Text = MantineText.withProps({
-  component: 'div'
-})
+import { Text } from '../../../controls/Text'
 
 type EmptyNodeProps = NodeProps<RelationshipsOfFlowTypes.EmptyNode>
 

--- a/packages/diagram/src/overlays/relationships-of/xyflow/EmptyNode.tsx
+++ b/packages/diagram/src/overlays/relationships-of/xyflow/EmptyNode.tsx
@@ -1,13 +1,13 @@
 import { Box, Text as MantineText } from '@mantine/core'
 import { type NodeProps } from '@xyflow/react'
-import type { XYFlowTypes } from '../_types'
+import type { RelationshipsOfFlowTypes } from '../_types'
 import * as css from './styles.css'
 
 const Text = MantineText.withProps({
   component: 'div'
 })
 
-type EmptyNodeProps = NodeProps<XYFlowTypes.EmptyNode>
+type EmptyNodeProps = NodeProps<RelationshipsOfFlowTypes.EmptyNode>
 
 export function EmptyNode({
   data: {

--- a/packages/diagram/src/overlays/relationships-of/xyflow/RelationshipEdge.tsx
+++ b/packages/diagram/src/overlays/relationships-of/xyflow/RelationshipEdge.tsx
@@ -7,7 +7,7 @@ import { useDiagramState } from '../../../hooks/useDiagramState'
 import { stopPropagation } from '../../../xyflow/utils'
 import { useOverlayDialog } from '../../OverlayContext'
 import * as css from '../../shared/xyflow/RelationshipEdge.css'
-import type { XYFlowTypes } from '../_types'
+import type { RelationshipsOfFlowTypes } from '../_types'
 import { ZIndexes } from '../use-layouted-relationships'
 
 const Tooltip = MantineTooltip.withProps({
@@ -25,7 +25,7 @@ export function RelationshipEdge({
   data,
   label,
   ...props
-}: EdgeProps<XYFlowTypes.Edge>) {
+}: EdgeProps<RelationshipsOfFlowTypes.Edge>) {
   const {
     viewId,
     onNavigateTo

--- a/packages/diagram/src/overlays/shared/xyflow/_types.ts
+++ b/packages/diagram/src/overlays/shared/xyflow/_types.ts
@@ -2,7 +2,7 @@ import type { AbstractRelation, ComputedNode, Fqn, ViewId } from '@likec4/core'
 import type { Edge as ReactFlowEdge, Node as ReactFlowNode } from '@xyflow/react'
 import type { SetRequired } from 'type-fest'
 
-export namespace SharedTypes {
+export namespace SharedFlowTypes {
   export type EmptyNodeData = {
     /**
      * Whether the cursor is hovering over the node
@@ -24,11 +24,14 @@ export namespace SharedTypes {
     dimmed?: 'immediate' | boolean
   }
 
-  export type NodeData = EmptyNodeData & {
+  export type NonEmptyNodeData = EmptyNodeData & {
     /**
      * The node's fully qualified name
      */
     fqn: Fqn
+  }
+
+  export type OverlayNodeData = NonEmptyNodeData & {
     /**
      * The ComputedNode backing this node
      */
@@ -50,9 +53,9 @@ export namespace SharedTypes {
     depth?: number
   }
 
-  export type ElementNode = SetRequired<ReactFlowNode<NodeData, 'element'>, 'type'>
+  export type ElementNode = SetRequired<ReactFlowNode<OverlayNodeData, 'element'>, 'type'>
 
-  export type CompoundNode = SetRequired<ReactFlowNode<NodeData, 'compound'>, 'type'>
+  export type CompoundNode = SetRequired<ReactFlowNode<OverlayNodeData, 'compound'>, 'type'>
 
   export type NonEmptyNode = ElementNode | CompoundNode
 

--- a/packages/diagram/src/state/diagram-to-xyflow.ts
+++ b/packages/diagram/src/state/diagram-to-xyflow.ts
@@ -1,10 +1,9 @@
 import { type DiagramEdge, DiagramNode, type DiagramView, ElementKind, type Fqn } from '@likec4/core'
 import { nonNullable, whereOperatorAsPredicate } from '@likec4/core'
 import { hasAtLeast } from 'remeda'
-import type { UnionToIntersection } from 'type-fest'
 import type { WhereOperator } from '../LikeC4Diagram.props'
 import { ZIndexes } from '../xyflow/const'
-import type { XYFlowEdge, XYFlowNode } from '../xyflow/types'
+import type { DiagramFlowTypes } from '../xyflow/types'
 
 // const nodeZIndex = (node: DiagramNode) => node.level - (node.children.length > 0 ? 1 : 0)
 
@@ -16,12 +15,12 @@ export function diagramViewToXYFlowData(
     selectable: boolean
   }
 ): {
-  xynodes: XYFlowNode[]
-  xyedges: XYFlowEdge[]
+  xynodes: DiagramFlowTypes.Node[]
+  xyedges: DiagramFlowTypes.Edge[]
 } {
   const isDynamicView = view.__ === 'dynamic',
-    xynodes = [] as XYFlowNode[],
-    xyedges = [] as XYFlowEdge[],
+    xynodes = [] as DiagramFlowTypes.Node[],
+    xyedges = [] as DiagramFlowTypes.Edge[],
     nodeLookup = new Map<Fqn, DiagramNode>()
 
   const traverse = view.nodes.reduce(
@@ -72,7 +71,7 @@ export function diagramViewToXYFlowData(
 
     const id = ns + node.id
 
-    const base: Omit<UnionToIntersection<XYFlowNode>, 'data'> = {
+    const base: Omit<DiagramFlowTypes.Node, 'data' | 'type'> = {
       id,
       draggable: opts.draggable,
       selectable: opts.selectable && node.kind !== ElementKind.Group,

--- a/packages/diagram/src/state/diagramStore.layout.ts
+++ b/packages/diagram/src/state/diagramStore.layout.ts
@@ -1,11 +1,10 @@
 import { nonexhaustive } from '@likec4/core'
-import type { InternalNode } from '@xyflow/react'
 import { getNodeDimensions } from '@xyflow/system'
 import { hasAtLeast } from 'remeda'
 import type { DiagramState } from '../hooks'
-import type { XYFlowNode } from '../xyflow/types'
 import { createLayoutConstraints } from '../xyflow/useLayoutConstraints'
 import { type Aligner, getLinearAligner, GridAligner, type GridAlignmentMode, type LinearAlignmentMode, type NodeRect } from './aligners'
+import type { DiagramFlowTypes } from '../xyflow/types'
 
 export type AlignmentMode = LinearAlignmentMode | GridAlignmentMode
 
@@ -40,7 +39,7 @@ export function align(get: () => DiagramState) {
   }
 }
 
-function toNodeRect(node: InternalNode<XYFlowNode>): NodeRect {
+function toNodeRect(node: DiagramFlowTypes.InternalNode): NodeRect {
   return {
     ...node.internals.positionAbsolute,
     id: node.id,

--- a/packages/diagram/src/state/diagramStore.ts
+++ b/packages/diagram/src/state/diagramStore.ts
@@ -44,7 +44,7 @@ import type {
 } from '../LikeC4Diagram.props'
 import { type Vector, vector } from '../utils/vector'
 import { MinZoom } from '../xyflow/const'
-import type { XYFlowEdge, XYFlowInstance, XYFlowNode } from '../xyflow/types'
+import type { DiagramFlowTypes } from '../xyflow/types'
 import { bezierControlPoints, isInside, isSamePoint, toDomPrecision } from '../xyflow/utils'
 import { diagramViewToXYFlowData } from './diagram-to-xyflow'
 import { align, type AlignmentMode } from './diagramStore.layout'
@@ -78,7 +78,7 @@ export type DiagramInitialState = {
   // If Dynamic View
   enableDynamicViewWalkthrough: boolean
 
-  xyflow: XYFlowInstance
+  xyflow: DiagramFlowTypes.XYFlowInstance
   xystore: XYStoreApi
 
   // Diagram Container, for Mantine Portal
@@ -94,8 +94,8 @@ export type DiagramState = Simplify<
     readonly storeDevId: string
 
     // Internal state
-    xynodes: XYFlowNode[]
-    xyedges: XYFlowEdge[]
+    xynodes: DiagramFlowTypes.Node[]
+    xyedges: DiagramFlowTypes.Edge[]
     viewSyncDebounceTimeout: number | null
     viewportChanged: boolean
 
@@ -176,15 +176,15 @@ export type DiagramState = Simplify<
     goForward: () => void
 
     nextDynamicStep: (increment?: number) => void
-    activateWalkthrough: (step: EdgeId | XYFlowEdge) => void
+    activateWalkthrough: (step: EdgeId | DiagramFlowTypes.Edge) => void
     stopWalkthrough: () => void
 
     openOverlay: (overlay: NonNullable<DiagramState['activeOverlay']>) => void
     closeOverlay: () => void
 
-    onInit: (xyflow: XYFlowInstance) => void
-    onNodesChange: OnNodesChange<XYFlowNode>
-    onEdgesChange: OnEdgesChange<XYFlowEdge>
+    onInit: (xyflow: DiagramFlowTypes.XYFlowInstance) => void
+    onNodesChange: OnNodesChange<DiagramFlowTypes.Node>
+    onEdgesChange: OnEdgesChange<DiagramFlowTypes.Edge>
 
     highlightByElementNotation: (notation: ElementNotation, onlyOfKind?: NodeKind) => void
 
@@ -417,14 +417,14 @@ export function createDiagramStore(props: DiagramInitialState) {
                 return {
                   ...existing,
                   ...update
-                } as XYFlowNode
+                } as DiagramFlowTypes.Node
               }
               return update
             })
             // Merge with existing edges, but only if the view is the same
             // and the edges have no layout drift
             if (isSameView && !nextView.hasLayoutDrift) {
-              update.xyedges = update.xyedges.map((update): XYFlowEdge => {
+              update.xyedges = update.xyedges.map((update): DiagramFlowTypes.Edge => {
                 const existing = xyedges.find(n => n.id === update.id)
                 if (existing) {
                   if (
@@ -919,7 +919,7 @@ export function createDiagramStore(props: DiagramInitialState) {
             }
           },
 
-          activateWalkthrough: (step: EdgeId | XYFlowEdge) => {
+          activateWalkthrough: (step: EdgeId | DiagramFlowTypes.Edge) => {
             const stepId = typeof step === 'string' ? step : step.data.edge.id
             invariant(isStepEdgeId(stepId), `stepId ${stepId} is not a step edge id`)
             let {
@@ -949,7 +949,7 @@ export function createDiagramStore(props: DiagramInitialState) {
                 )
                 .map(({ id }) => id)
             )
-            const selected = [] as XYFlowNode[]
+            const selected = [] as DiagramFlowTypes.Node[]
             for (const n of xyflow.getNodes()) {
               if (n.id === edge.source || n.id === edge.target) {
                 selected.push(n)
@@ -1035,7 +1035,7 @@ export function createDiagramStore(props: DiagramInitialState) {
 
             scheduleSaveManualLayout()
 
-            function getNodeCenter(node: XYFlowNode, nodes: XYFlowNode[]) {
+            function getNodeCenter(node: DiagramFlowTypes.Node, nodes: DiagramFlowTypes.Node[]) {
               const dimensions = vector({ x: node.width || 0, y: node.height || 0 })
               let position = vector(node.position)
                 .add(dimensions.mul(0.5))
@@ -1055,7 +1055,7 @@ export function createDiagramStore(props: DiagramInitialState) {
               return position
             }
 
-            function getControlPointForEdge(edge: XYFlowEdge): XYPoint[] {
+            function getControlPointForEdge(edge: DiagramFlowTypes.Edge): XYPoint[] {
               const source = xynodes.find(x => x.id == edge.source)
               const target = xynodes.find(x => x.id == edge.target)
               if (!source || !target) {
@@ -1076,7 +1076,7 @@ export function createDiagramStore(props: DiagramInitialState) {
               return []
             }
 
-            function getBorderPointOnVector(node: XYFlowNode, nodeCenter: Vector, v: Vector) {
+            function getBorderPointOnVector(node: DiagramFlowTypes.Node, nodeCenter: Vector, v: Vector) {
               const xScale = (node.width || 0) / 2 / v.x
               const yScale = (node.height || 0) / 2 / v.y
 

--- a/packages/diagram/src/state/diagramStore.ts
+++ b/packages/diagram/src/state/diagramStore.ts
@@ -125,7 +125,6 @@ export type DiagramState = Simplify<
     lastClickedNodeId: string | null
     lastClickedEdgeId: string | null
     focusedNodeId: string | null
-    hoveredNodeId: string | null
     hoveredEdgeId: string | null
 
     // id's of nodes / edges that
@@ -151,7 +150,6 @@ export type DiagramState = Simplify<
      */
     focusOnNode: (nodeId: string | false) => void
 
-    setHoveredNode: (nodeId: string | null) => void
     setHoveredEdge: (edgeId: string | null) => void
 
     setLastClickedNode: (nodeId: string | null) => void
@@ -209,7 +207,6 @@ const DEFAULT_PROPS: Except<
   activeOverlay: null,
   activeWalkthrough: null,
   focusedNodeId: null,
-  hoveredNodeId: null,
   hoveredEdgeId: null,
   lastClickedNodeId: null,
   lastClickedEdgeId: null,
@@ -285,7 +282,6 @@ export function createDiagramStore(props: DiagramInitialState) {
               nodesDraggable,
               nodesSelectable,
               hoveredEdgeId,
-              hoveredNodeId,
               xyedges,
               xynodes
             } = get()
@@ -303,9 +299,6 @@ export function createDiagramStore(props: DiagramInitialState) {
               // Reset clicked/hovered node/edge if the node/edge is not in the new view
               if (lastClickedNodeId && !nodeIds.has(lastClickedNodeId)) {
                 lastClickedNodeId = null
-              }
-              if (hoveredNodeId && !nodeIds.has(hoveredNodeId)) {
-                hoveredNodeId = null
               }
               if (focusedNodeId && !nodeIds.has(focusedNodeId)) {
                 focusedNodeId = null
@@ -385,7 +378,6 @@ export function createDiagramStore(props: DiagramInitialState) {
               lastClickedEdgeId = null
               lastClickedNodeId = null
               hoveredEdgeId = null
-              hoveredNodeId = null
               focusedNodeId = null
               activeWalkthrough = null
               activeOverlay = null
@@ -460,7 +452,6 @@ export function createDiagramStore(props: DiagramInitialState) {
                 lastClickedEdgeId,
                 focusedNodeId,
                 hoveredEdgeId,
-                hoveredNodeId,
                 navigationHistory,
                 navigationHistoryIndex,
                 dimmed,
@@ -515,12 +506,6 @@ export function createDiagramStore(props: DiagramInitialState) {
                 noReplace,
                 `focus on node: ${nodeId}`
               )
-            }
-          },
-
-          setHoveredNode: (nodeId) => {
-            if (nodeId !== get().hoveredNodeId) {
-              set({ hoveredNodeId: nodeId })
             }
           },
 

--- a/packages/diagram/src/xyflow/SelectEdgesOnNodeFocus.tsx
+++ b/packages/diagram/src/xyflow/SelectEdgesOnNodeFocus.tsx
@@ -5,7 +5,7 @@ import { getBoundsOfRects, getViewportForBounds } from '@xyflow/system'
 import { useUpdateEffect } from '../hooks'
 import { useDiagramState, useDiagramStoreApi } from '../hooks/useDiagramState'
 import { MinZoom } from './const'
-import type { XYFlowEdge, XYFlowNode } from './types'
+import type { DiagramFlowTypes } from './types'
 import { nodeToRect } from './utils'
 
 export function SelectEdgesOnNodeFocus() {
@@ -22,8 +22,8 @@ export function SelectEdgesOnNodeFocus() {
       return
     }
 
-    const edgeChanges = [] as EdgeChange<XYFlowEdge>[]
-    const nodeChanges = [] as NodeChange<XYFlowNode>[]
+    const edgeChanges = [] as EdgeChange<DiagramFlowTypes.Edge>[]
+    const nodeChanges = [] as NodeChange<DiagramFlowTypes.Node>[]
     const {
       edgeLookup,
       nodeLookup,

--- a/packages/diagram/src/xyflow/XYFlow.tsx
+++ b/packages/diagram/src/xyflow/XYFlow.tsx
@@ -8,9 +8,9 @@ import { MaxZoom, MinZoom } from './const'
 import { RelationshipEdge } from './edges/RelationshipEdge'
 import { CompoundNode } from './nodes/compound'
 import { ElementNode } from './nodes/element'
-import { XYFlowEdge, XYFlowNode } from './types'
 import { useLayoutConstraints } from './useLayoutConstraints'
 import { useXYFlowEvents } from './useXYFlowEvents'
+import type { DiagramFlowTypes } from './types'
 
 const nodeTypes = {
   element: ElementNode,
@@ -117,7 +117,7 @@ export function XYFlow({
   // }, [])
 
   return (
-    <ReactFlow<XYFlowNode, XYFlowEdge>
+    <ReactFlow<DiagramFlowTypes.Node, DiagramFlowTypes.Edge>
       className={className}
       style={style}
       {...colorMode && { colorMode }}

--- a/packages/diagram/src/xyflow/edges/EdgeLabel.tsx
+++ b/packages/diagram/src/xyflow/edges/EdgeLabel.tsx
@@ -21,14 +21,14 @@ import { type PropsWithChildren, type ReactNode, useState } from 'react'
 import { isTruthy } from 'remeda'
 import { useDiagramState, useDiagramStoreApi, useMantinePortalProps } from '../../hooks'
 import { useLikeC4Model } from '../../likec4model/useLikeC4Model'
-import type { RelationshipData } from '../types'
 import { stopPropagation } from '../utils'
 import * as edgesCss from './edges.css'
 import { RelationshipsDropdownMenu } from './RelationshipsDropdownMenu'
+import type { DiagramFlowTypes } from '../types'
 
 export interface EdgeLabelProps extends Omit<BoxProps, 'label'> {
   isDimmed: boolean
-  edgeData: RelationshipData
+  edgeData: DiagramFlowTypes.DiagramEdgeData
 }
 
 export const EdgeLabel = ({

--- a/packages/diagram/src/xyflow/edges/RelationshipEdge.tsx
+++ b/packages/diagram/src/xyflow/edges/RelationshipEdge.tsx
@@ -20,11 +20,11 @@ import { useXYStoreApi } from '../../hooks/useXYFlow'
 import { vector, VectorImpl } from '../../utils/vector'
 import { ZIndexes } from '../const'
 import { EdgeMarkers, type EdgeMarkerType } from '../EdgeMarkers'
-import { type XYFlowEdge } from '../types'
 import { bezierControlPoints } from '../utils'
 import { EdgeLabel } from './EdgeLabel'
 import * as edgesCss from './edges.css'
 import { getNodeIntersectionFromCenterToPoint } from './utils'
+import type { DiagramFlowTypes } from '../types'
 // import { getEdgeParams } from './utils'
 
 // function getBend(a: XYPosition, b: XYPosition, c: XYPosition, size = 8): string {
@@ -115,7 +115,9 @@ const sameControlPoints = (a: XYPosition[] | null, b: XYPosition[] | null) => {
   return a.every((ap, i) => isSamePoint(ap, b[i]!))
 }
 
-const isEqualProps = (prev: EdgeProps<XYFlowEdge>, next: EdgeProps<XYFlowEdge>) => (
+type DiagramEdgeProps = EdgeProps<DiagramFlowTypes.Edge>
+
+const isEqualProps = (prev: DiagramEdgeProps, next: DiagramEdgeProps) => (
   prev.id === next.id
   && eq(prev.source, next.source)
   && eq(prev.target, next.target)
@@ -134,7 +136,7 @@ const curve = d3line<XYPosition>()
   .x(d => d.x)
   .y(d => d.y)
 
-export const RelationshipEdge = memo<EdgeProps<XYFlowEdge>>(function RelationshipEdgeR({
+export const RelationshipEdge = memo<DiagramEdgeProps>(function RelationshipEdgeR({
   id,
   data,
   sourceX,

--- a/packages/diagram/src/xyflow/edges/RelationshipsDropdownMenu.tsx
+++ b/packages/diagram/src/xyflow/edges/RelationshipsDropdownMenu.tsx
@@ -22,8 +22,8 @@ import { forwardRef, Fragment, type MouseEventHandler, type PropsWithChildren, u
 import { filter, isTruthy, map, partition, pick, pipe } from 'remeda'
 import { useDiagramState, useDiagramStoreApi, useMantinePortalProps, useXYNodesData } from '../../hooks'
 import { Link } from '../../ui/Link'
-import type { RelationshipData } from '../types'
 import * as css from './RelationshipsDropdownMenu.css'
+import type { DiagramFlowTypes } from '../types'
 
 const stopPropagation: MouseEventHandler = (e) => e.stopPropagation()
 
@@ -44,7 +44,7 @@ export function RelationshipsDropdownMenu({
   likec4model,
   children
 }: PropsWithChildren<{
-  edge: RelationshipData['edge']
+  edge: DiagramFlowTypes.DiagramEdgeData['edge']
   disabled?: boolean | undefined
   likec4model: LikeC4Model
 }>) {
@@ -157,7 +157,7 @@ const Relationship = forwardRef<
   HTMLDivElement,
   StackProps & {
     relationship: LikeC4Model.AnyRelation
-    edge: RelationshipData['edge']
+    edge: DiagramFlowTypes.DiagramEdgeData['edge']
     sourceNode: DiagramNode
     targetNode: DiagramNode
   }

--- a/packages/diagram/src/xyflow/edges/utils.ts
+++ b/packages/diagram/src/xyflow/edges/utils.ts
@@ -1,8 +1,8 @@
 import { Position, type XYPosition } from '@xyflow/react'
 import { getNodeDimensions } from '@xyflow/system'
-import type { InternalXYFlowNode } from '../types'
+import type { DiagramFlowTypes } from '../types'
 
-export function getNodeCenter(node: InternalXYFlowNode): XYPosition {
+export function getNodeCenter(node: DiagramFlowTypes.InternalNode): XYPosition {
   const { width, height } = getNodeDimensions(node)
   const { x, y } = node.internals.positionAbsolute
 
@@ -15,7 +15,7 @@ export function getNodeCenter(node: InternalXYFlowNode): XYPosition {
 // this helper function returns the intersection point
 // of the line between the center of the intersectionNode and the target node
 export function getNodeIntersectionFromCenterToPoint(
-  intersectionNode: InternalXYFlowNode,
+  intersectionNode: DiagramFlowTypes.InternalNode,
   { x: x1, y: y1 }: XYPosition
 ) {
   // https://math.stackexchange.com/questions/1724792/an-algorithm-for-finding-the-intersection-point-between-a-center-of-vision-and-a
@@ -47,7 +47,7 @@ export function getNodeIntersectionFromCenterToPoint(
 
 // this helper function returns the intersection point
 // of the line between the center of the intersectionNode and the target node
-function getNodeIntersection(intersectionNode: InternalXYFlowNode, targetNode: InternalXYFlowNode): XYPosition {
+function getNodeIntersection(intersectionNode: DiagramFlowTypes.InternalNode, targetNode: DiagramFlowTypes.InternalNode): XYPosition {
   // https://math.stackexchange.com/questions/1724792/an-algorithm-for-finding-the-intersection-point-between-a-center-of-vision-and-a
   const {
     width: intersectionNodeWidth,
@@ -81,7 +81,7 @@ function getNodeIntersection(intersectionNode: InternalXYFlowNode, targetNode: I
 }
 
 // returns the position (top,right,bottom or right) passed node compared to the intersection point
-export function getPointPosition(node: InternalXYFlowNode, intersectionPoint: XYPosition) {
+export function getPointPosition(node: DiagramFlowTypes.InternalNode, intersectionPoint: XYPosition) {
   const n = {
     // x: node.data.element.position[0],
     // y: node.data.element.position[1],
@@ -135,7 +135,7 @@ export function getPointPosition(node: InternalXYFlowNode, intersectionPoint: XY
 }
 
 // returns the parameters (sx, sy, tx, ty, sourcePos, targetPos) you need to create an edge
-export function getEdgeParams(source: InternalXYFlowNode, target: InternalXYFlowNode) {
+export function getEdgeParams(source: DiagramFlowTypes.InternalNode, target: DiagramFlowTypes.InternalNode) {
   const sourceIntersectionPoint = getNodeIntersection(source, target)
   const targetIntersectionPoint = getNodeIntersection(target, source)
 

--- a/packages/diagram/src/xyflow/nodes/AnimateVariants.ts
+++ b/packages/diagram/src/xyflow/nodes/AnimateVariants.ts
@@ -1,5 +1,47 @@
+import type { Variants } from 'framer-motion'
 import { useMemo, useState } from 'react'
 import { isEmpty, isString } from 'remeda'
+
+const DEFAULT_SCALE_BY  = 0
+const SELECTED_SCALE_BY = 16
+const HOVERED_SCALE_BY  = 12
+const TAP_SCALE_BY      = -16
+
+const DELAY_NODE = 0.1
+const DELAY_NODE_CHILDREN = 0.06
+
+export type VariantKeys = 'hoverd' | 'idle' | 'selected' | 'tap'
+
+export const NodeVariants = (width: number, height: number) => {
+
+  const scaleBy = (diffPx: number) => ({
+    scaleX: (width + diffPx) / width,
+    scaleY: (height + diffPx) / height
+  })
+
+  return {
+    idle: {
+      ...scaleBy(DEFAULT_SCALE_BY),
+      transition: {
+          delay: DELAY_NODE,
+          delayChildren: DELAY_NODE_CHILDREN
+      }
+    },
+    selected: {
+      ...scaleBy(SELECTED_SCALE_BY)
+    },
+    hovered: {
+      ...scaleBy(HOVERED_SCALE_BY),
+      transition: {
+        delay: DELAY_NODE,
+        delayChildren: DELAY_NODE_CHILDREN
+      }
+    },
+    tap: {
+      ...scaleBy(TAP_SCALE_BY)
+    }
+  } satisfies Variants
+}
 
 export function useFramerAnimateVariants() {
   const [variants, setVariants] = useState<string[] | null>(null)

--- a/packages/diagram/src/xyflow/nodes/AnimateVariants.ts
+++ b/packages/diagram/src/xyflow/nodes/AnimateVariants.ts
@@ -1,6 +1,8 @@
+import { fallbackVar } from '@vanilla-extract/css'
 import type { Variants } from 'framer-motion'
 import { useMemo, useState } from 'react'
 import { isEmpty, isString } from 'remeda'
+import { vars } from '../../theme-vars'
 
 const DEFAULT_SCALE_BY  = 0
 const SELECTED_SCALE_BY = 16
@@ -10,7 +12,10 @@ const TAP_SCALE_BY      = -16
 const DELAY_NODE = 0.1
 const DELAY_NODE_CHILDREN = 0.06
 
-export type VariantKeys = 'hoverd' | 'idle' | 'selected' | 'tap'
+const DIMMED_OPACITY = 0.15
+const DIMMED_DELAY = 0.2
+
+export type VariantKeys = 'dimmed' | 'hoverd' | 'idle' | 'selected' | 'tap'
 
 export const NodeVariants = (width: number, height: number) => {
 
@@ -20,12 +25,22 @@ export const NodeVariants = (width: number, height: number) => {
   })
 
   return {
+    dimmed: {
+      filter: `grayscale(0.85) ${fallbackVar(vars.safariAnimationHook, 'blur(1px)')}`,
+      opacity: DIMMED_OPACITY,
+      transition: {
+        delay: DIMMED_DELAY,
+        ease: 'easeInOut'
+      },
+      willChange: 'opacity, filter'
+    },
     idle: {
       ...scaleBy(DEFAULT_SCALE_BY),
       transition: {
           delay: DELAY_NODE,
           delayChildren: DELAY_NODE_CHILDREN
-      }
+      },
+      filter: `grayscale(0) ${fallbackVar(vars.safariAnimationHook, 'blur(0px)')}`
     },
     selected: {
       ...scaleBy(SELECTED_SCALE_BY)

--- a/packages/diagram/src/xyflow/nodes/Node.css.ts
+++ b/packages/diagram/src/xyflow/nodes/Node.css.ts
@@ -1,0 +1,44 @@
+import { style } from "@vanilla-extract/css";
+
+export const topLeftBtnContainer = style({
+  position: 'absolute',
+  left: 3,
+  top: 6
+})
+
+export const topRightBtnContainer = style({
+  position: 'absolute',
+  top: 2,
+  right: 2,
+  selectors: {
+    [`:where([data-likec4-shape='browser']) &`]: {
+      right: 5
+    },
+    ':where([data-likec4-shape="cylinder"], [data-likec4-shape="storage"]) &': {
+      top: 14
+    },
+    ':where([data-likec4-shape="queue"]) &': {
+      top: 1,
+      right: 12
+    }
+  }
+})
+
+export const bottomBtnContainer = style({
+  zIndex: 100,
+  position: 'absolute',
+  left: 0,
+  width: '100%',
+  bottom: 2,
+  display: 'flex',
+  flexDirection: 'row',
+  flexWrap: 'nowrap',
+  alignItems: 'center',
+  justifyContent: 'center',
+  pointerEvents: 'none',
+  selectors: {
+    [`:where([data-likec4-shape='browser']) &`]: {
+      bottom: 4
+    }
+  }
+})

--- a/packages/diagram/src/xyflow/nodes/compound/CompoundNode.css.ts
+++ b/packages/diagram/src/xyflow/nodes/compound/CompoundNode.css.ts
@@ -1,7 +1,7 @@
 import { rem } from '@mantine/core'
 import { createVar, fallbackVar, globalStyle, keyframes, style } from '@vanilla-extract/css'
 import { calc } from '@vanilla-extract/css-utils'
-import { mantine, vars, whereLight } from '../../../theme-vars'
+import { mantine, vars } from '../../../theme-vars'
 
 // For framer motion
 export const containerForFramer = style({
@@ -232,59 +232,6 @@ globalStyle(`:where([data-mantine-color-scheme='light'] .likec4-compound-transpa
     [navigateBtnColor]: vars.element.stroke
   }
 })
-
-const btn = style({
-  pointerEvents: 'all',
-  cursor: 'pointer',
-  color: `var(--_compound-title-color,${navigateBtnColor})`,
-  opacity: 'var(--ai-opacity)',
-  backgroundColor: 'var(--ai-bg)',
-  vars: {
-    '--ai-opacity': '1',
-    '--ai-bg-idle': `color-mix(in srgb , ${vars.element.fill},  transparent 99%)`,
-    '--ai-bg': `var(--ai-bg-idle)`,
-    '--ai-bg-hover': `color-mix(in srgb , ${vars.element.fill} 65%, ${vars.element.stroke})`,
-    '--ai-hover': `color-mix(in srgb , ${vars.element.fill} 50%, ${vars.element.stroke})`
-  },
-  ':hover': {
-    boxShadow: mantine.shadows.md
-  },
-  selectors: {
-    [`${whereLight} .likec4-compound-transparent &`]: {
-      opacity: 0.85,
-      vars: {
-        '--ai-bg-hover': `color-mix(in srgb , ${vars.element.fill},  transparent 20%)`,
-        '--ai-hover': `color-mix(in srgb , ${vars.element.fill},  transparent 10%)`,
-        '--ai-bg': `color-mix(in srgb , ${vars.element.fill},  transparent 99%)`
-      }
-    }
-  }
-})
-
-export const navigateBtn = style([btn, {
-  position: 'absolute',
-  left: 3,
-  top: 6
-}])
-
-export const detailsBtn = style([btn, {
-  // position: 'absolute',
-  // top: 2,
-  // right: 2,
-  // selectors: {
-  //   [`:where([data-likec4-shape='browser']) &`]: {
-  //     top: 3,
-  //     right: 5
-  //   },
-  //   ':where([data-likec4-shape="cylinder"], [data-likec4-shape="storage"]) &': {
-  //     top: 14
-  //   },
-  //   ':where([data-likec4-shape="queue"]) &': {
-  //     top: 1,
-  //     right: 12
-  //   }
-  // }
-}])
 
 export const elementIcon = style({
   flex: `0 0 ${iconSize}`,

--- a/packages/diagram/src/xyflow/nodes/compound/CompoundNode.css.ts
+++ b/packages/diagram/src/xyflow/nodes/compound/CompoundNode.css.ts
@@ -39,16 +39,6 @@ export const nodeHandlerInCenter = style({
   visibility: 'hidden'
 })
 
-export const dimmed = style({})
-
-globalStyle(`.react-flow__node-compound:has(${dimmed})`, {
-  opacity: 0.25,
-  transition: 'opacity 600ms ease-in-out, filter 600ms ease-in-out',
-  transitionDelay: '200ms',
-  filter: `grayscale(0.85) ${fallbackVar(vars.safariAnimationHook, 'blur(1px)')}`,
-  willChange: 'opacity, filter'
-})
-
 globalStyle(`:where([data-mantine-color-scheme='dark'] .likec4-compound-transparent)`, {
   vars: {
     ['--_compound-border-color']: `color-mix(in srgb, ${vars.compound.titleColor} 25%, ${vars.element.stroke})`

--- a/packages/diagram/src/xyflow/nodes/compound/CompoundNode.tsx
+++ b/packages/diagram/src/xyflow/nodes/compound/CompoundNode.tsx
@@ -145,6 +145,9 @@ export const CompoundNodeMemo = /* @__PURE__ */ memo<CompoundNodeProps>((
     case dragging:
       animateVariant = 'idle'
       break
+    case isDimmed:
+      animateVariant = 'dimmed'
+      break
     case selected:
       animateVariant = 'selected'
       break
@@ -198,8 +201,7 @@ export const CompoundNodeMemo = /* @__PURE__ */ memo<CompoundNodeProps>((
           className={clsx(
             css.container,
             'likec4-compound-node',
-            opacity < 1 && 'likec4-compound-transparent',
-            isDimmed && css.dimmed
+            opacity < 1 && 'likec4-compound-transparent'
           )}
 
           initial={false}

--- a/packages/diagram/src/xyflow/nodes/compound/CompoundNode.tsx
+++ b/packages/diagram/src/xyflow/nodes/compound/CompoundNode.tsx
@@ -1,21 +1,23 @@
 import { DiagramNode, type ThemeColor } from '@likec4/core'
-import { ActionIcon, Box, Text, Tooltip } from '@mantine/core'
+import { Box, Text } from '@mantine/core'
 import { useDebouncedValue } from '@mantine/hooks'
-import { IconId, IconZoomScan } from '@tabler/icons-react'
 import { assignInlineVars } from '@vanilla-extract/dynamic'
 import { Handle, type NodeProps, Position } from '@xyflow/react'
 import clsx from 'clsx'
 import { deepEqual as eq } from 'fast-equals'
-import { m, type Variants } from 'framer-motion'
-import { memo, useCallback, useState } from 'react'
+import { m } from 'framer-motion'
+import { memo, useState } from 'react'
 import { clamp } from 'remeda'
 import { useDiagramState } from '../../../hooks/useDiagramState'
-import { stopPropagation, toDomPrecision } from '../../utils'
+import { toDomPrecision } from '../../utils'
 import { ElementIcon } from '../shared/ElementIcon'
 import { CompoundToolbar } from '../shared/Toolbar'
 import { NodeVariants, useFramerAnimateVariants, type VariantKeys } from '../AnimateVariants'
 import * as css from './CompoundNode.css'
+import * as nodeCss from '../Node.css'
 import type { DiagramFlowTypes } from '../../types'
+import { ActionButtonBar } from '../../../controls/action-button-bar/ActionButtonBar'
+import { NavigateToButton, OpenDetailsButton } from '../../../controls/action-buttons/ActionButtons'
 
 type CompoundNodeProps = NodeProps<DiagramFlowTypes.CompoundNode>
 
@@ -25,57 +27,6 @@ const isEqualProps = (prev: CompoundNodeProps, next: CompoundNodeProps) => (
   && eq(prev.dragging ?? false, next.dragging ?? false)
   && eq(prev.data, next.data)
 )
-
-const VariantsNavigate = {
-  idle: {
-    '--ai-bg': 'var(--ai-bg-idle)',
-    scale: 1,
-    opacity: 0.8,
-    originX: 1,
-    originY: 0.25,
-    translateX: 0,
-    translateY: 0
-  },
-  selected: {},
-  hovered: {
-    '--ai-bg': 'var(--ai-bg-hover)',
-    scale: 1.25,
-    opacity: 1,
-    translateX: -1
-  },
-  'hovered:navigate': {
-    scale: 1.42
-  },
-  'hovered:details': {},
-  'tap:navigate': {
-    scale: 1.15
-  }
-} satisfies Variants
-VariantsNavigate['selected'] = VariantsNavigate.hovered
-VariantsNavigate['hovered:details'] = VariantsNavigate.idle
-
-const VariantsDetailsBtn = {
-  idle: {
-    '--ai-bg': 'var(--ai-bg-idle)',
-    scale: 1,
-    opacity: 0.3,
-    originX: 0.45,
-    originY: 0.55
-  },
-  selected: {},
-  hovered: {
-    scale: 1.2,
-    opacity: 0.6
-  },
-  'hovered:details': {
-    scale: 1.42,
-    opacity: 1
-  },
-  'tap:details': {
-    scale: 1.15
-  }
-} satisfies Variants
-VariantsDetailsBtn['selected'] = VariantsDetailsBtn['hovered']
 
 export const CompoundNodeMemo = /* @__PURE__ */ memo<CompoundNodeProps>((
   {
@@ -105,8 +56,6 @@ export const CompoundNodeMemo = /* @__PURE__ */ memo<CompoundNodeProps>((
 
   const {
     viewId,
-    triggerOnNavigateTo,
-    openOverlay,
     isEditable,
     isDimmed,
     isInteractive,
@@ -116,8 +65,6 @@ export const CompoundNodeMemo = /* @__PURE__ */ memo<CompoundNodeProps>((
     enableElementDetails
   } = useDiagramState(s => ({
     viewId: s.view.id,
-    triggerOnNavigateTo: s.triggerOnNavigateTo,
-    openOverlay: s.openOverlay,
     isEditable: s.readonly !== true,
     isDimmed: s.dimmed.has(id),
     isInteractive: s.nodesDraggable || s.nodesSelectable || s.enableElementDetails
@@ -163,16 +110,6 @@ export const CompoundNodeMemo = /* @__PURE__ */ memo<CompoundNodeProps>((
   const nodeVariants = NodeVariants(w, h)
 
   const [previewColor, setPreviewColor] = useState<ThemeColor | null>(null)
-
-  const onNavigateTo = useCallback((e: React.MouseEvent) => {
-    e.stopPropagation()
-    triggerOnNavigateTo(id, e)
-  }, [triggerOnNavigateTo, id])
-
-  const onOpenDetails = useCallback((e: React.MouseEvent) => {
-    e.stopPropagation()
-    openOverlay({ elementDetails: element.id })
-  }, [openOverlay, element])
 
   const elementIcon = ElementIcon({
     element,
@@ -263,48 +200,20 @@ export const CompoundNodeMemo = /* @__PURE__ */ memo<CompoundNodeProps>((
                 {element.title}
               </Text>
               {enableElementDetails && !!modelRef && (
-                <Tooltip
-                  fz="xs"
-                  color="dark"
-                  label="Open details"
-                  withinPortal={false}
-                  offset={2}
-                  openDelay={600}>
-                  <ActionIcon
-                    key={`${id}details`}
-                    component={m.div}
-                    variants={VariantsDetailsBtn}
-                    data-animate-target="details"
-                    className={clsx('nodrag nopan', css.detailsBtn)}
-                    radius="md"
-                    style={{ zIndex: 100 }}
-                    role="button"
-                    onClick={onOpenDetails}
-                    onDoubleClick={stopPropagation}
-                    {...isInteractive && animateHandlers}
-                  >
-                    <IconId stroke={1.8} style={{ width: '75%' }} />
-                  </ActionIcon>
-                </Tooltip>
+                <Box className={clsx(nodeCss.topRightBtnContainer)}>
+                  <ActionButtonBar shiftX='right'>
+                    <OpenDetailsButton fqn={element.id} />
+                  </ActionButtonBar>
+                </Box>
               )}
             </Box>
           </Box>
           {isNavigable && (
-            <ActionIcon
-              key={`${id}navigate`}
-              component={m.div}
-              variants={VariantsNavigate}
-              data-animate-target="navigate"
-              className={clsx('nodrag nopan', css.navigateBtn)}
-              radius="md"
-              style={{ zIndex: 100 }}
-              onClick={onNavigateTo}
-              role="button"
-              onDoubleClick={stopPropagation}
-              {...isInteractive && animateHandlers}
-            >
-              <IconZoomScan style={{ width: '75%' }} />
-            </ActionIcon>
+            <Box className={clsx(nodeCss.topLeftBtnContainer)}>
+              <ActionButtonBar shiftX='left'>
+                <NavigateToButton fqn={element.id} />
+              </ActionButtonBar>
+            </Box>
           )}
         </Box>
       </Box>

--- a/packages/diagram/src/xyflow/nodes/compound/CompoundNode.tsx
+++ b/packages/diagram/src/xyflow/nodes/compound/CompoundNode.tsx
@@ -10,17 +10,14 @@ import { m, type Variants } from 'framer-motion'
 import { memo, useCallback, useState } from 'react'
 import { clamp } from 'remeda'
 import { useDiagramState } from '../../../hooks/useDiagramState'
-import type { CompoundXYFlowNode } from '../../types'
 import { stopPropagation } from '../../utils'
 import { ElementIcon } from '../shared/ElementIcon'
 import { CompoundToolbar } from '../shared/Toolbar'
 import { useFramerAnimateVariants } from '../use-animate-variants'
 import * as css from './CompoundNode.css'
+import type { DiagramFlowTypes } from '../../types'
 
-type CompoundNodeProps = Pick<
-  NodeProps<CompoundXYFlowNode>,
-  'id' | 'data' | 'selected' | 'dragging'
->
+type CompoundNodeProps = NodeProps<DiagramFlowTypes.CompoundNode>
 
 const isEqualProps = (prev: CompoundNodeProps, next: CompoundNodeProps) => (
   prev.id === next.id

--- a/packages/diagram/src/xyflow/nodes/element/ElementLink.tsx
+++ b/packages/diagram/src/xyflow/nodes/element/ElementLink.tsx
@@ -16,12 +16,11 @@ import clsx from 'clsx'
 import { useId } from 'react'
 import { clamp } from 'remeda'
 import { useMantinePortalProps } from '../../../hooks/useMantinePortalProps'
-import { type DiagramState } from '../../../state/diagramStore'
-import type { XYFlowNode } from '../../types'
 import { elementLink, trigger } from './ElementLink.css'
+import type { DiagramFlowTypes } from '../../types'
 
 type ElementLinkProps = {
-  element: XYFlowNode['data']['element']
+  element: DiagramFlowTypes.Node['data']['element']
 }
 
 const stopEventPropagation = (e: React.MouseEvent) => e.stopPropagation()

--- a/packages/diagram/src/xyflow/nodes/element/ElementNode.tsx
+++ b/packages/diagram/src/xyflow/nodes/element/ElementNode.tsx
@@ -9,13 +9,13 @@ import { type HTMLMotionProps, m, type Variants } from 'framer-motion'
 import React, { memo, type PropsWithoutRef, useCallback, useState } from 'react'
 import { isNumber, isTruthy } from 'remeda'
 import { useDiagramState } from '../../../hooks/useDiagramState'
-import type { ElementXYFlowNode } from '../../types'
 import { stopPropagation, toDomPrecision } from '../../utils'
 import { ElementIcon } from '../shared/ElementIcon'
 import { ElementToolbar } from '../shared/Toolbar'
 import { useFramerAnimateVariants } from '../use-animate-variants'
 import * as css from './element.css'
 import { ElementShapeSvg, SelectedIndicator } from './ElementShapeSvg'
+import type { DiagramFlowTypes } from '../../types'
 
 const Text = MantineText.withProps({
   component: 'div'
@@ -124,7 +124,7 @@ const VariantsDetailsBtn = {
 } satisfies Variants
 VariantsDetailsBtn['selected'] = VariantsDetailsBtn['hovered']
 
-type ElementNodeProps = NodeProps<ElementXYFlowNode>
+type ElementNodeProps = NodeProps<DiagramFlowTypes.ElementNode>
 const isEqualProps = (prev: ElementNodeProps, next: ElementNodeProps) => (
   prev.id === next.id
   && eq(prev.selected ?? false, next.selected ?? false)

--- a/packages/diagram/src/xyflow/nodes/element/ElementNode.tsx
+++ b/packages/diagram/src/xyflow/nodes/element/ElementNode.tsx
@@ -159,6 +159,9 @@ export const ElementNodeMemo = memo<ElementNodeProps>(function ElementNode({
     case dragging:
       animateVariant = 'idle'
       break
+    case isDimmed:
+      animateVariant = 'dimmed'
+      break
     case selected:
       animateVariant = 'selected'
       break
@@ -210,7 +213,6 @@ export const ElementNodeMemo = memo<ElementNodeProps>(function ElementNode({
         component={m.div}
         className={clsx([
           css.container,
-          isDimmed && css.dimmed,
           animateVariant !== 'idle' && css.containerAnimated,
           'likec4-element-node'
         ])}

--- a/packages/diagram/src/xyflow/nodes/element/ElementNode.tsx
+++ b/packages/diagram/src/xyflow/nodes/element/ElementNode.tsx
@@ -1,5 +1,5 @@
 import { DiagramNode, type ThemeColor } from '@likec4/core'
-import { Box, Text as MantineText } from '@mantine/core'
+import { Box } from '@mantine/core'
 import { useDebouncedValue } from '@mantine/hooks'
 import { Handle, type NodeProps, Position } from '@xyflow/react'
 import clsx from 'clsx'
@@ -18,10 +18,7 @@ import { ElementShapeSvg, SelectedIndicator } from './ElementShapeSvg'
 import type { DiagramFlowTypes } from '../../types'
 import { ActionButtonBar } from '../../../controls/action-button-bar/ActionButtonBar'
 import { BrowseRelationshipsButton, NavigateToButton, OpenDetailsButton } from '../../../controls/action-buttons/ActionButtons'
-
-const Text = MantineText.withProps({
-  component: 'div'
-})
+import { Text } from '../../../controls/Text'
 
 type ElementNodeProps = NodeProps<DiagramFlowTypes.ElementNode>
 const isEqualProps = (prev: ElementNodeProps, next: ElementNodeProps) => (

--- a/packages/diagram/src/xyflow/nodes/element/ElementNode.tsx
+++ b/packages/diagram/src/xyflow/nodes/element/ElementNode.tsx
@@ -1,97 +1,27 @@
 import { DiagramNode, type ThemeColor } from '@likec4/core'
-import { ActionIcon, type ActionIconProps, Box, Text as MantineText, Tooltip } from '@mantine/core'
+import { Box, Text as MantineText } from '@mantine/core'
 import { useDebouncedValue } from '@mantine/hooks'
-import { IconId, IconTransform, IconZoomScan } from '@tabler/icons-react'
 import { Handle, type NodeProps, Position } from '@xyflow/react'
 import clsx from 'clsx'
 import { deepEqual as eq } from 'fast-equals'
-import { type HTMLMotionProps, m, type Variants } from 'framer-motion'
-import React, { memo, type PropsWithoutRef, useCallback, useState } from 'react'
+import { m } from 'framer-motion'
+import { memo, useState } from 'react'
 import { isTruthy } from 'remeda'
 import { useDiagramState } from '../../../hooks/useDiagramState'
-import { stopPropagation, toDomPrecision } from '../../utils'
+import { toDomPrecision } from '../../utils'
 import { ElementIcon } from '../shared/ElementIcon'
 import { ElementToolbar } from '../shared/Toolbar'
 import { NodeVariants, useFramerAnimateVariants, type VariantKeys } from '../AnimateVariants'
 import * as css from './element.css'
+import * as nodeCss from '../Node.css'
 import { ElementShapeSvg, SelectedIndicator } from './ElementShapeSvg'
 import type { DiagramFlowTypes } from '../../types'
+import { ActionButtonBar } from '../../../controls/action-button-bar/ActionButtonBar'
+import { BrowseRelationshipsButton, NavigateToButton, OpenDetailsButton } from '../../../controls/action-buttons/ActionButtons'
 
 const Text = MantineText.withProps({
   component: 'div'
 })
-
-// Frame-motion variants
-
-const variantsBottomButton = (target: 'navigate' | 'relationships', align: 'left' | 'right' | false) => {
-  const variants = {
-    idle: {
-      '--icon-scale': 'scale(1)',
-      '--ai-bg': 'var(--ai-bg-idle)',
-      scale: 1,
-      opacity: 0.5,
-      originX: 0.5,
-      originY: 0.35,
-      translateY: 0,
-      ...align === 'left' && {
-        originX: 0.75,
-        translateX: -1
-      },
-      ...align === 'right' && {
-        originX: 0.25,
-        translateX: 1
-      }
-    },
-    selected: {},
-    hovered: {
-      '--icon-scale': 'scale(1)',
-      '--ai-bg': 'var(--ai-bg-hover)',
-      translateY: 3,
-      scale: 1.32,
-      opacity: 1,
-      ...align === 'left' && {
-        translateX: -4
-      },
-      ...align === 'right' && {
-        translateX: 4
-      }
-    },
-    'hovered:details': {},
-    [`hovered:${target}`]: {
-      '--icon-scale': 'scale(1.08)',
-      scale: 1.45
-    },
-    [`tap:${target}`]: {
-      scale: 1.15
-    }
-  } satisfies Variants
-  variants['selected'] = variants['hovered']
-  variants['hovered:details'] = variants.idle
-  return variants
-}
-
-const VariantsDetailsBtn = {
-  idle: {
-    '--ai-bg': 'var(--ai-bg-idle)',
-    scale: 1,
-    opacity: 0.5,
-    originX: 0.45,
-    originY: 0.55
-  },
-  selected: {},
-  hovered: {
-    scale: 1.2,
-    opacity: 0.7
-  },
-  'hovered:details': {
-    scale: 1.44,
-    opacity: 1
-  },
-  'tap:details': {
-    scale: 1.15
-  }
-} satisfies Variants
-VariantsDetailsBtn['selected'] = VariantsDetailsBtn['hovered']
 
 type ElementNodeProps = NodeProps<DiagramFlowTypes.ElementNode>
 const isEqualProps = (prev: ElementNodeProps, next: ElementNodeProps) => (
@@ -123,8 +53,6 @@ export const ElementNodeMemo = memo<ElementNodeProps>(function ElementNode({
     isInteractive,
     enableElementDetails,
     enableRelationshipBrowser,
-    triggerOnNavigateTo,
-    openOverlay,
     isInActiveOverlay,
     renderIcon
   } = useDiagramState(s => ({
@@ -182,23 +110,6 @@ export const ElementNodeMemo = memo<ElementNodeProps>(function ElementNode({
   })
 
   const [previewColor, setPreviewColor] = useState<ThemeColor | null>(null)
-
-  const onNavigateTo = useCallback((e: React.MouseEvent) => {
-    e.stopPropagation()
-    triggerOnNavigateTo(id, e)
-  }, [triggerOnNavigateTo, id])
-
-  const onOpenDetails = useCallback((e: React.MouseEvent) => {
-    e.stopPropagation()
-    openOverlay({ elementDetails: element.id })
-  }, [openOverlay, element.id])
-
-  const onOpenRelationships = useCallback((e: React.MouseEvent) => {
-    if (modelRef) {
-      e.stopPropagation()
-      openOverlay({ relationshipsOf: modelRef })
-    }
-  }, [openOverlay, modelRef])
 
   return (
     <>
@@ -268,36 +179,18 @@ export const ElementNodeMemo = memo<ElementNodeProps>(function ElementNode({
           </Box>
         </Box>
         {/* {isHovercards && element.links && <ElementLink element={element} />} */}
-        <BottomButtons
-          keyPrefix={`${viewId}:element:${id}:`}
-          onNavigateTo={isNavigable && onNavigateTo}
-          onOpenRelationships={enableRelationshipBrowser && !!modelRef && onOpenRelationships}
-          {...isInteractive && animateHandlers}
-        />
+        <Box className={clsx(nodeCss.bottomBtnContainer)}>
+          <ActionButtonBar shiftY='bottom' {...isInteractive && animateHandlers} >
+            {isNavigable && !!modelRef && (<NavigateToButton fqn={modelRef} />)}
+            {enableRelationshipBrowser && !!modelRef && (<BrowseRelationshipsButton fqn={modelRef} />)}
+          </ActionButtonBar>
+        </Box>
         {enableElementDetails && !!modelRef && (
-          <Tooltip
-            fz="xs"
-            color="dark"
-            label="Open details"
-            withinPortal={false}
-            offset={2}
-            openDelay={600}>
-            <ActionIcon
-              key="details"
-              component={m.div}
-              variants={VariantsDetailsBtn}
-              data-animate-target="details"
-              className={clsx('nodrag nopan', css.detailsBtn)}
-              radius="md"
-              style={{ zIndex: 100 }}
-              role="button"
-              onClick={onOpenDetails}
-              onDoubleClick={stopPropagation}
-              {...isInteractive && animateHandlers}
-            >
-              <IconId stroke={1.8} style={{ width: '75%' }} />
-            </ActionIcon>
-          </Tooltip>
+          <Box className={clsx(nodeCss.topRightBtnContainer)}>
+            <ActionButtonBar shiftX='right' {...isInteractive && animateHandlers} >
+              <OpenDetailsButton fqn={element.id} />
+            </ActionButtonBar>
+          </Box>
         )}
       </Box>
       <Handle type="target" position={Position.Top} className={css.handleCenter} />
@@ -305,70 +198,3 @@ export const ElementNodeMemo = memo<ElementNodeProps>(function ElementNode({
     </>
   )
 }, isEqualProps)
-
-type BottomButtonsProps = PropsWithoutRef<
-  ActionIconProps & HTMLMotionProps<'div'> & {
-    keyPrefix: string
-    onNavigateTo: ((e: React.MouseEvent) => void) | false
-    onOpenRelationships: ((e: React.MouseEvent) => void) | false
-  }
->
-const BottomButtons = ({
-  keyPrefix,
-  onNavigateTo,
-  onOpenRelationships,
-  ...props
-}: BottomButtonsProps) => {
-  const enableRelationships = !!onOpenRelationships
-  const enableNavigate = !!onNavigateTo
-
-  if (!enableRelationships && !enableNavigate) {
-    return null
-  }
-
-  return (
-    <Box className={css.bottomButtonsContainer}>
-      {enableNavigate && (
-        <ActionIcon
-          {...props}
-          key={`${keyPrefix}navigate`}
-          data-animate-target="navigate"
-          component={m.div}
-          // Weird, but dts-bundle-generator fails on "enableRelationships && 'left'"
-          variants={variantsBottomButton('navigate', enableRelationships ? 'left' : false)}
-          className={clsx('nodrag nopan', css.navigateBtn)}
-          radius="md"
-          role="button"
-          onClick={onNavigateTo}
-          onDoubleClick={stopPropagation}
-        >
-          <IconZoomScan
-            style={{
-              width: '70%',
-              transform: 'var(--icon-scale)'
-            }} />
-        </ActionIcon>
-      )}
-      {enableRelationships && (
-        <ActionIcon
-          {...props}
-          key={`${keyPrefix}relationships`}
-          data-animate-target="relationships"
-          component={m.div}
-          variants={variantsBottomButton('relationships', enableNavigate ? 'right' : false)}
-          className={clsx('nodrag nopan', css.navigateBtn)}
-          radius="md"
-          role="button"
-          onClick={onOpenRelationships}
-          onDoubleClick={stopPropagation}
-        >
-          <IconTransform
-            style={{
-              width: '70%',
-              transform: 'var(--icon-scale)'
-            }} />
-        </ActionIcon>
-      )}
-    </Box>
-  )
-}

--- a/packages/diagram/src/xyflow/nodes/element/element.css.ts
+++ b/packages/diagram/src/xyflow/nodes/element/element.css.ts
@@ -46,16 +46,6 @@ export const containerAnimated = style({
   willChange: 'transform'
 })
 
-export const dimmed = style({})
-
-globalStyle(`.react-flow__node-element:has(${dimmed})`, {
-  opacity: 0.25,
-  transition: 'opacity 400ms ease-in-out, filter 500ms ease-in-out',
-  transitionDelay: '50ms',
-  filter: `grayscale(0.85) ${fallbackVar(vars.safariAnimationHook, 'blur(2px)')}`,
-  willChange: 'opacity, filter'
-})
-
 const indicatorKeyframes = keyframes({
   'from': {
     strokeOpacity: 0.8
@@ -103,10 +93,6 @@ export const indicator = style({
       vars: {
         [indicatorStroke]: `color-mix(in srgb, ${vars.element.fill} 50%, #3c3c3c)`
       }
-    },
-    [`${dimmed} &`]: {
-      visibility: 'hidden',
-      display: 'none'
     }
   }
 })

--- a/packages/diagram/src/xyflow/nodes/element/element.css.ts
+++ b/packages/diagram/src/xyflow/nodes/element/element.css.ts
@@ -367,39 +367,3 @@ export const bottomButtonsContainer = style({
 //   transitionDelay: '20ms',
 //   gap: 16
 // })
-
-const btn = style({
-  pointerEvents: 'all',
-  color: vars.element.loContrast,
-  cursor: 'pointer',
-  backgroundColor: 'var(--ai-bg)',
-  'vars': {
-    '--ai-bg-idle': `color-mix(in srgb , ${vars.element.fill},  transparent 99%)`,
-    '--ai-bg': `var(--ai-bg-idle)`,
-    '--ai-bg-hover': `color-mix(in srgb , ${vars.element.fill} 65%, ${vars.element.stroke})`,
-    '--ai-hover': `color-mix(in srgb , ${vars.element.fill} 50%, ${vars.element.stroke})`
-  },
-  ':hover': {
-    boxShadow: mantine.shadows.md
-  }
-})
-
-export const navigateBtn = style([btn, {}])
-
-export const detailsBtn = style([btn, {
-  position: 'absolute',
-  top: 2,
-  right: 2,
-  selectors: {
-    [`:where([data-likec4-shape='browser']) &`]: {
-      right: 5
-    },
-    ':where([data-likec4-shape="cylinder"], [data-likec4-shape="storage"]) &': {
-      top: 14
-    },
-    ':where([data-likec4-shape="queue"]) &': {
-      top: 1,
-      right: 12
-    }
-  }
-}])

--- a/packages/diagram/src/xyflow/nodes/element/element.css.ts
+++ b/packages/diagram/src/xyflow/nodes/element/element.css.ts
@@ -21,9 +21,6 @@ export const container = style({
   selectors: {
     ':where(.react-flow__node.selected) &': {
       willChange: 'transform'
-    },
-    '&[data-hovered="true"]': {
-      willChange: 'transform'
     }
   },
   // Catch pointer below the element
@@ -302,10 +299,6 @@ export const shapeSvgMultiple = style({
     },
     ':where([data-likec4-shape="queue"]) &': {
       transform: 'translate(-10px,8px)'
-    },
-    ':where([data-hovered="true"]) &': {
-      transition: 'opacity 300ms ease-in',
-      opacity: 0.2
     }
   }
 })

--- a/packages/diagram/src/xyflow/types.ts
+++ b/packages/diagram/src/xyflow/types.ts
@@ -1,60 +1,57 @@
-import type { BBox, DiagramEdge, DiagramNode, Fqn, XYPoint } from '@likec4/core'
-import type { Edge, InternalNode, Node as ReactFlowNode, ReactFlowInstance, ReactFlowState } from '@xyflow/react'
-import { isNode as isXYFlowNode } from '@xyflow/react'
-import { isTruthy } from 'remeda'
-import type { Simplify } from 'type-fest'
+import type { BBox, DiagramEdge, DiagramNode, XYPoint } from '@likec4/core'
+import type { Edge as ReactFlowEdge, InternalNode as ReactFlowInternalNode, Node as ReactFlowNode, ReactFlowInstance, ReactFlowState } from '@xyflow/react'
+import type { SetRequired, Simplify } from 'type-fest'
+import type { SharedFlowTypes } from '../overlays/shared/xyflow/_types'
 
-export type ElementXYFlowNode = ReactFlowNode<{
-  fqn: Fqn
-  element: DiagramNode
-}, 'element'>
+export namespace DiagramFlowTypes {
 
-export type CompoundXYFlowNode = ReactFlowNode<{
-  fqn: Fqn
-  isViewGroup: boolean
-  element: DiagramNode
-}, 'compound'>
-
-export type XYFlowNode = ElementXYFlowNode | CompoundXYFlowNode
-
-export type InternalXYFlowNode = InternalNode<XYFlowNode>
-
-export namespace XYFlowNode {
-  export function isCompound(node: unknown): node is CompoundXYFlowNode {
-    return isXYFlowNode(node) && node.type === 'compound'
-  }
-  export function isElement(node: ReactFlowNode): node is ElementXYFlowNode {
-    return isXYFlowNode(node) && node.type === 'element'
+  export type NodeData = {
+    /**
+     * The DiagramNode backing this node.
+     */
+    element: DiagramNode
   }
 
-  export const is = (node: ReactFlowNode): node is XYFlowNode => isCompound(node) || isElement(node)
+  export type CompoundNodeData = NodeData & {
+    /**
+     * Whether this node is a view group.
+     */
+    isViewGroup: boolean
+  }
+
+  export type ElementNode = SetRequired<ReactFlowNode<
+      SharedFlowTypes.NonEmptyNodeData & NodeData,
+      'element'>,
+    'type'>
+
+  export type CompoundNode = SetRequired<ReactFlowNode<
+      SharedFlowTypes.NonEmptyNodeData & CompoundNodeData,
+      'compound'>,
+    'type'>
+
+  export type Node = ElementNode | CompoundNode
+
+  export type InternalNode = ReactFlowInternalNode<Node>
+
+  export type XYFlowInstance = ReactFlowInstance<Node, Edge>
+
+  export type XYFlowState = ReactFlowState<Node, Edge>
+
+  export type DiagramEdgeData = {
+    edge: DiagramEdge
+    // if set - edge was changed by user
+    controlPoints: XYPoint[] | null
+    label: null | {
+      bbox: BBox
+      text: string
+    }
+  }
+
+  export type Edge = Simplify<
+    ReactFlowEdge<DiagramEdgeData, 'relationship'> & {
+      type: 'relationship'
+      // Make field required
+      data: DiagramEdgeData
+    }
+  >
 }
-
-export type RelationshipData = {
-  edge: DiagramEdge
-  // if set - edge was changed by user
-  controlPoints: XYPoint[] | null
-  label: null | {
-    bbox: BBox
-    text: string
-  }
-}
-
-export type RelationshipEdge = Simplify<
-  Edge<RelationshipData, 'relationship'> & {
-    type: 'relationship'
-    // Make field required
-    data: RelationshipData
-  }
->
-
-export type XYFlowEdge = RelationshipEdge
-
-export namespace XYFlowEdge {
-  export type Data = RelationshipData
-
-  export const isRelationship = (e: Edge): e is RelationshipEdge => e.type === 'relationship' && isTruthy(e.data)
-}
-
-export type XYFlowInstance = ReactFlowInstance<XYFlowNode, XYFlowEdge>
-export type XYFlowState = ReactFlowState<XYFlowNode, XYFlowEdge>

--- a/packages/diagram/src/xyflow/types.ts
+++ b/packages/diagram/src/xyflow/types.ts
@@ -1,15 +1,15 @@
 import type { BBox, DiagramEdge, DiagramNode, Fqn, XYPoint } from '@likec4/core'
-import type { Edge, InternalNode, Node, ReactFlowInstance, ReactFlowState } from '@xyflow/react'
-import { isNode } from '@xyflow/react'
+import type { Edge, InternalNode, Node as ReactFlowNode, ReactFlowInstance, ReactFlowState } from '@xyflow/react'
+import { isNode as isXYFlowNode } from '@xyflow/react'
 import { isTruthy } from 'remeda'
 import type { Simplify } from 'type-fest'
 
-export type ElementXYFlowNode = Node<{
+export type ElementXYFlowNode = ReactFlowNode<{
   fqn: Fqn
   element: DiagramNode
 }, 'element'>
 
-export type CompoundXYFlowNode = Node<{
+export type CompoundXYFlowNode = ReactFlowNode<{
   fqn: Fqn
   isViewGroup: boolean
   element: DiagramNode
@@ -21,13 +21,13 @@ export type InternalXYFlowNode = InternalNode<XYFlowNode>
 
 export namespace XYFlowNode {
   export function isCompound(node: unknown): node is CompoundXYFlowNode {
-    return isNode(node) && node.type === 'compound'
+    return isXYFlowNode(node) && node.type === 'compound'
   }
-  export function isElement(node: Node): node is ElementXYFlowNode {
-    return isNode(node) && node.type === 'element'
+  export function isElement(node: ReactFlowNode): node is ElementXYFlowNode {
+    return isXYFlowNode(node) && node.type === 'element'
   }
 
-  export const is = (node: Node): node is XYFlowNode => isCompound(node) || isElement(node)
+  export const is = (node: ReactFlowNode): node is XYFlowNode => isCompound(node) || isElement(node)
 }
 
 export type RelationshipData = {

--- a/packages/diagram/src/xyflow/useLayoutConstraints.ts
+++ b/packages/diagram/src/xyflow/useLayoutConstraints.ts
@@ -1,11 +1,11 @@
 import { type NodeId, type NonEmptyArray, nonNullable } from '@likec4/core'
-import type { InternalNode, NodeChange, ReactFlowProps, XYPosition } from '@xyflow/react'
+import type { NodeChange, ReactFlowProps, XYPosition } from '@xyflow/react'
 import { getNodeDimensions } from '@xyflow/system'
 import { useMemo, useRef } from 'react'
 import { filter, hasAtLeast, isNullish, map, pipe } from 'remeda'
 import { useDiagramStoreApi } from '../hooks'
 import { type XYStoreApi } from '../hooks/useXYFlow'
-import type { XYFlowNode } from './types'
+import type { DiagramFlowTypes } from './types'
 
 abstract class Rect {
   static readonly LeftPadding = 40
@@ -60,7 +60,7 @@ class Compound extends Rect {
   public readonly children = [] as Rect[]
 
   constructor(
-    xynode: InternalNode<XYFlowNode>,
+    xynode: DiagramFlowTypes.InternalNode,
     protected readonly parent: Compound | null = null
   ) {
     super()
@@ -74,7 +74,7 @@ class Compound extends Rect {
 
 class Leaf extends Rect {
   constructor(
-    xynode: InternalNode<XYFlowNode>,
+    xynode: DiagramFlowTypes.InternalNode,
     public readonly parent: Compound | null = null
   ) {
     super()
@@ -94,7 +94,7 @@ class Leaf extends Rect {
 }
 
 type NodePositionUpdater = (
-  nodes: Array<{ rect: Rect | Compound; node: InternalNode<XYFlowNode> }>
+  nodes: Array<{ rect: Rect | Compound; node: DiagramFlowTypes.InternalNode }>
 ) => void
 
 export function createLayoutConstraints(
@@ -108,7 +108,7 @@ export function createLayoutConstraints(
     const ancestors = [] as string[]
     const xynode = nodeLookup.get(nodeId)
     let parent = xynode?.parentId
-    let parentNode: InternalNode<XYFlowNode> | undefined
+    let parentNode: DiagramFlowTypes.InternalNode | undefined
     while (parent && (parentNode = nodeLookup.get(parent))) {
       ancestors.push(parentNode.id as NodeId)
       parent = parentNode.parentId
@@ -120,7 +120,7 @@ export function createLayoutConstraints(
     editingNodeIds.flatMap(ancestorsOf)
   )
 
-  const traverse = new Array<{ xynode: InternalNode<XYFlowNode>; parent: Compound | null }>()
+  const traverse = new Array<{ xynode: DiagramFlowTypes.InternalNode; parent: Compound | null }>()
 
   for (const [, xynode] of nodeLookup) {
     if (isNullish(xynode.parentId)) {
@@ -200,7 +200,7 @@ export function createLayoutConstraints(
           })
         }
         return acc
-      }, [] as NodeChange<XYFlowNode>[])
+      }, [] as NodeChange<DiagramFlowTypes.Node>[])
     )
   }
 
@@ -234,7 +234,7 @@ export function createLayoutConstraints(
   }
 }
 
-type LayoutConstraints = Required<Pick<ReactFlowProps<XYFlowNode>, 'onNodeDragStart' | 'onNodeDrag' | 'onNodeDragStop'>>
+type LayoutConstraints = Required<Pick<ReactFlowProps<DiagramFlowTypes.Node>, 'onNodeDragStart' | 'onNodeDrag' | 'onNodeDragStop'>>
 /**
  * Keeps the layout constraints (parent nodes and children) when dragging a node
  */

--- a/packages/diagram/src/xyflow/useXYFlowEvents.ts
+++ b/packages/diagram/src/xyflow/useXYFlowEvents.ts
@@ -4,12 +4,12 @@ import { useMemo, useRef } from 'react'
 import { first, isNonNullish, isTruthy } from 'remeda'
 import type { Simplify } from 'type-fest'
 import { useDiagramStoreApi } from '../hooks/useDiagramState'
-import type { XYFlowEdge, XYFlowNode } from './types'
+import type { DiagramFlowTypes } from './types'
 
 export type XYFlowEventHandlers = Simplify<
   Required<
     Pick<
-      ReactFlowProps<XYFlowNode, XYFlowEdge>,
+      ReactFlowProps<DiagramFlowTypes.Node, DiagramFlowTypes.Edge>,
       | 'onDoubleClick'
       | 'onPaneClick'
       | 'onNodeClick'

--- a/packages/diagram/src/xyflow/useXYFlowEvents.ts
+++ b/packages/diagram/src/xyflow/useXYFlowEvents.ts
@@ -20,8 +20,6 @@ export type XYFlowEventHandlers = Simplify<
       | 'onNodeContextMenu'
       | 'onEdgeContextMenu'
       | 'onPaneContextMenu'
-      | 'onNodeMouseEnter'
-      | 'onNodeMouseLeave'
       | 'onEdgeMouseEnter'
       | 'onEdgeMouseLeave'
     >
@@ -34,10 +32,6 @@ export function useXYFlowEvents() {
   const lastClickTimestamp = useRef<number>()
 
   const dblclickTimeout = useRef<number>()
-
-  // If we are in focused mode, on edge enter we want to "highlight" the other node
-  // This ref contains the id of this node
-  const hoveredNodeFromOnEdgeEnterRef = useRef('')
 
   return useMemo(() => {
     const dbclickLock = () => {
@@ -306,33 +300,15 @@ export function useXYFlowEvents() {
           diagramApi.setState({ viewportChanged }, false, `viewport-changed: ${viewportChanged}`)
         }
       },
-      onNodeMouseEnter: (_event, xynode) => {
-        hoveredNodeFromOnEdgeEnterRef.current = ''
-        diagramApi.getState().setHoveredNode(xynode.id)
-      },
-      onNodeMouseLeave: (_event, xynode) => {
-        const { hoveredNodeId, setHoveredNode } = diagramApi.getState()
-        if (hoveredNodeId === xynode.id) {
-          setHoveredNode(null)
-        }
-      },
-      onEdgeMouseEnter: (_event, { id, source, target }) => {
-        const { hoveredNodeId, focusedNodeId, setHoveredEdge, setHoveredNode } = diagramApi.getState()
+      onEdgeMouseEnter: (_event, { id }) => {
+        const { setHoveredEdge } = diagramApi.getState()
         setHoveredEdge(id)
-        if ((focusedNodeId === source || focusedNodeId === target) && focusedNodeId !== hoveredNodeId) {
-          const next = hoveredNodeFromOnEdgeEnterRef.current = source === focusedNodeId ? target : source
-          setHoveredNode(next)
-        }
       },
       onEdgeMouseLeave: (_event, xyedge) => {
-        const { hoveredEdgeId, setHoveredEdge, hoveredNodeId, setHoveredNode } = diagramApi.getState()
+        const { hoveredEdgeId, setHoveredEdge } = diagramApi.getState()
         if (hoveredEdgeId === xyedge.id) {
           setHoveredEdge(null)
         }
-        if (hoveredNodeId === hoveredNodeFromOnEdgeEnterRef.current) {
-          setHoveredNode(null)
-        }
-        hoveredNodeFromOnEdgeEnterRef.current = ''
       }
     }) satisfies XYFlowEventHandlers
   }, [diagramApi])

--- a/packages/diagram/src/xyflow/utils.ts
+++ b/packages/diagram/src/xyflow/utils.ts
@@ -4,7 +4,7 @@ import type { InternalNode, Rect, XYPosition } from '@xyflow/react'
 import { getNodeDimensions } from '@xyflow/system'
 import { Bezier } from 'bezier-js'
 import { isArray } from 'remeda'
-import type { InternalXYFlowNode } from './types'
+import type { DiagramFlowTypes } from './types'
 
 export function toDomPrecision(v: number | null) {
   if (v === null) {
@@ -17,7 +17,7 @@ export function distance(a: XYPosition, b: XYPosition) {
   return Math.sqrt(Math.pow(b.x - a.x, 2) + Math.pow(b.y - a.y, 2))
 }
 
-export const nodeToRect = (nd: InternalXYFlowNode): Rect => ({
+export const nodeToRect = (nd: DiagramFlowTypes.InternalNode): Rect => ({
   x: nd.internals.positionAbsolute.x,
   y: nd.internals.positionAbsolute.y,
   width: nd.measured.width ?? nd.width ?? nd.data.element.width,


### PR DESCRIPTION
This is the **third** of a series of PRs aimed at deduplicating stuff between the diagram and overlays.

1. https://github.com/likec4/likec4/pull/1347
2. https://github.com/likec4/likec4/pull/1372
3. **→** https://github.com/likec4/likec4/pull/1375
4. https://github.com/likec4/likec4/pull/1376

The buttons for navigating to views, browsing relationships, viewing details and navigating to source are almost identical. This PR extracts `ActionButton` and `ActionButtonBar` as standalone components. It makes use of these components in the diagram's `ElementNode` and `CompoundNode`, but does not use them in the overlays' nodes yet. Within the diagram, all buttons should behave exactly the same way as they did before. I compared the before and after in two windows side by side and did not notice any differences.

Secondly, the commit https://github.com/likec4/likec4/pull/1375/commits/d2f4a6221b6a300af8a1719856a835684b955831 extracts control `Text` from the various nodes. This is a tiny change, thus I don't think it warrants its own PR.