### PR TITLE
Feat/1441 deployment element filter

### DIFF
--- a/apps/docs/src/content/docs/dsl/Deployment/views.mdx
+++ b/apps/docs/src/content/docs/dsl/Deployment/views.mdx
@@ -48,14 +48,13 @@ But they refer to deployment nodes and instances.
   The following features are not supported yet or do not work as expected:
  
   - `with` expressions
-  - `where` expressions on elements
   - Shared styles and predicates
   - Relationships browser, Element and Relationship Details popups (work with logical model)
 
   ```likec4
   deployment view prod {
     include *                                   // works
-    include * where tag is #next                // does not work
+    include * where tag is #next                // works (see details below)
     include * with { color: red }               // does not work
 
     include * -> *                              // works
@@ -68,9 +67,9 @@ But they refer to deployment nodes and instances.
   ```
 </Aside>
 
-### Relation filters
-Filtering of relations in deployment views use the same principles as in normal views but takes into account relations and tags defined in deployment model.
-When condition on relation participant is checked the following rules are applied:
+### Filtering
+Filtering in deployment views use the same principles as in normal views but takes into account deployment nodes, relations and tags defined in deployment model.
+When condition on element is checked the following rules are applied:
 - For a deployment instances tags are combined from tags defined in model and tags defined in deployment model
 - For a child of deployment instance the tags defined on child in model are used
 - For a deployment node the tags defined in deployment model are used

--- a/packages/core/src/builder/Builder.view-common.ts
+++ b/packages/core/src/builder/Builder.view-common.ts
@@ -67,6 +67,7 @@ export namespace ViewPredicate {
   export type WhereEq<Types extends AnyTypes> =
     | ViewPredicate.WhereTag<Types['Tag']>
     | ViewPredicate.WhereKind<Types['ElementKind']>
+    | ViewPredicate.WhereKind<Types['DeploymentKind']>
     | ViewPredicate.WhereParticipant<Types>
 
   export type WhereOperator<Types extends AnyTypes> = ViewPredicate.WhereEq<Types> | {

--- a/packages/core/src/compute-view/deployment-view/clean-connections.spec.ts
+++ b/packages/core/src/compute-view/deployment-view/clean-connections.spec.ts
@@ -133,8 +133,11 @@ describe('Clean Connections', () => {
 
     state.next($exclude('z1.s1.api'))
     t.expect(state).toHaveElements(
+      'z1.s1.ui',
       'z1.s2.ui',
       'z1.s2.api',
+      'z1.s2',
+      'z1.s1',
     )
     t.expect(state.memory.connections).toBeEmpty()
 

--- a/packages/core/src/compute-view/deployment-view/predicates/__test__/deploymentRef.filter.spec.ts
+++ b/packages/core/src/compute-view/deployment-view/predicates/__test__/deploymentRef.filter.spec.ts
@@ -1,0 +1,505 @@
+import { describe, expect, it } from 'vitest'
+import { Builder } from '../../../../builder'
+import { TestHelper } from '../../__test__/TestHelper'
+
+describe('DeploymentRef', () => {
+  const builder = Builder
+    .specification({
+      elements: {
+        el: {},
+        app: {},
+      },
+      tags: ['next', 'alpha', 'beta', 'omega'],
+      deployments: {
+        nd: {},
+        vm: {},
+      },
+    })
+    .model(({ el, app }, _) =>
+      _(
+        el('customer', { tags: ['next'] }),
+        el('cloud'),
+        el('cloud.ui'),
+        app('cloud.ui.app', { tags: ['next'] }),
+        el('cloud.backend'),
+        el('cloud.backend.api'),
+        el('cloud.backend.service'),
+        el('infra'),
+        el('infra.db'),
+        el('infra.email'),
+        el('integrators'),
+      )
+    )
+    .model(({ rel }, m) =>
+      m(
+        rel('customer', 'cloud'),
+        rel('customer', 'cloud.ui.app'),
+        rel('cloud.backend.api', 'cloud.backend.service'),
+        rel('cloud.backend.service', 'infra.db'),
+        rel('cloud.backend.service', 'infra.email'),
+        rel('cloud.ui.app', 'cloud.backend.api'),
+        rel('cloud', 'infra'),
+        rel('infra.email', 'customer'),
+        rel('integrators', 'cloud.backend.api'),
+        rel('infra.email', 'integrators'),
+      )
+    )
+
+  const { $include, $exclude } = TestHelper
+
+  const t = TestHelper.from(builder.deployment(({ nd, instanceOf, vm }, d) =>
+    d(
+      nd('customer').with(
+        instanceOf('customer'),
+      ),
+      nd('prod', { tags: ['alpha'] }),
+      nd('prod.z1').with(
+        instanceOf('cloud.ui.app'),
+        instanceOf('cloud.backend.api'),
+        instanceOf('cloud.backend.service'),
+      ),
+      nd('prod.infra', { tags: ['beta'] }).with(
+        instanceOf('infra.db'),
+        instanceOf('email', 'infra.email', { tags: ['alpha'] }),
+      ),
+      nd('global').with(
+        instanceOf('integrators'),
+      ),
+      vm('dev').with(
+        instanceOf('cloud.ui.app'),
+        instanceOf('cloud.backend.api'),
+        instanceOf('cloud.backend.service'),
+        instanceOf('infra.db'),
+        instanceOf('infra.email'),
+      ),
+    )
+  ))
+
+  describe('include', () => {
+    describe('instance where', () => {
+      describe('kind is', () => {
+        it('should include instance when model kind matches', () => {
+          t.expectComputedView(
+            $include('prod.z1.app', { where: 'kind is app' }),
+          ).toHaveNodes(
+            'prod.z1.app',
+          )
+        })
+        it('should not include instance when model kind does not match', () => {
+          t.expectComputedView(
+            $include('prod.z1.service', { where: 'kind is app' }),
+          ).toHaveNodes()
+        })
+      })
+
+      describe('tag is', () => {
+        it('should include instance when model tag matches', () => {
+          t.expectComputedView(
+            $include('prod.z1.app', { where: 'tag is #next' }),
+          ).toHaveNodes(
+            'prod.z1.app',
+          )
+        })
+        it('should include instance when deployment tag matches', () => {
+          t.expectComputedView(
+            $include('prod.infra.email', { where: 'tag is #alpha' }),
+          ).toHaveNodes(
+            'prod.infra.email',
+          )
+        })
+        it('should not include instance when neither model nor instance tag does not match', () => {
+          t.expectComputedView(
+            $include('prod.z1.app', { where: 'tag is #omega' }),
+          ).toHaveNodes()
+        })
+      })
+    })
+
+    describe('node where', () => {
+      describe('tag is', () => {
+        it('should include node when tag matches', () => {
+          t.expectComputedView(
+            $include('prod', { where: 'tag is #alpha' }),
+            $include('prod.infra', { where: 'tag is #beta' }),
+          ).toHaveNodes(
+            'prod',
+            'prod.infra',
+          )
+        })
+        it('should not include node when tag does not match', () => {
+          t.expectComputedView(
+            $include('prod', { where: 'tag is #omega' }),
+            $include('prod.infra', { where: 'tag is #omega' }),
+          ).toHaveNodes()
+        })
+      })
+    })
+
+    describe('node._ where', () => {
+      describe('tag is', () => {
+        it('should include child when model tag matches', () => {
+          t.expectComputedView(
+            $include('customer'),
+            $include('prod.z1._', { where: 'tag is #next' }),
+          ).toHaveNodes(
+            'customer',
+            'prod',
+            'prod.z1',
+            'prod.z1.app',
+          )
+        })
+        it('should include child when deployment tag matches', () => {
+          t.expectComputedView(
+            $include('customer'),
+            $include('prod.infra._', { where: 'tag is #alpha' }),
+          ).toHaveNodes(
+            'prod',
+            'prod.infra',
+            'prod.infra.email',
+            'customer',
+          )
+        })
+        it('should not include child when neither model nor deployment tag does not match', () => {
+          t.expectComputedView(
+            $include('customer'),
+            $include('prod.z1._', { where: 'tag is #omega' }),
+            $include('prod.infra._', { where: 'tag is #omega' }),
+          ).toHaveNodes(
+            'customer',
+            'prod',
+            'prod.z1',
+            'prod.infra',
+          )
+        })
+      })
+    })
+
+    describe('node.* where', () => {
+      describe('tag is', () => {
+        it('should include child when model tag matches', () => {
+          t.expectComputedView(
+            $include('customer'),
+            $include('prod.z1.*', { where: 'tag is #next' }),
+          ).toHaveNodes(
+            'customer',
+            'prod',
+            'prod.z1.app',
+          )
+        })
+        it('should include child when deployment tag matches', () => {
+          t.expectComputedView(
+            $include('customer'),
+            $include('prod.infra.*', { where: 'tag is #alpha' }),
+          ).toHaveNodes(
+            'prod',
+            'prod.infra.email',
+            'customer',
+          )
+        })
+        it('should not include child when neither model nor deployment tag does not match', () => {
+          t.expectComputedView(
+            $include('customer'),
+            $include('prod.z1.*', { where: 'tag is #omega' }),
+            $include('prod.infra.*', { where: 'tag is #omega' }),
+          ).toHaveNodes(
+            'customer',
+          )
+        })
+      })
+    })
+
+    describe('node.** where', () => {
+      describe('tag is', () => {
+        it('should include descendant instance when model tag matches', () => {
+          t.expectComputedView(
+            $include('customer'),
+            $include('prod.**', { where: 'tag is #next' }),
+          ).toHaveNodes(
+            'customer',
+            'prod',
+            'prod.z1.app',
+          )
+        })
+        it('should include descendant when deployment tag matches', () => {
+          t.expectComputedView(
+            $include('customer'),
+            $include('prod.**', { where: 'tag is #alpha' }),
+          ).toHaveNodes(
+            'prod',
+            'prod.infra.email',
+            'customer',
+          )
+        })
+        it('should not include descendant when neither model nor deployment tag does not match', () => {
+          t.expectComputedView(
+            $include('customer'),
+            $include('prod.**', { where: 'tag is #omega' }),
+          ).toHaveNodes(
+            'customer',
+          )
+        })
+      })
+    })
+  })
+
+  describe('exclude', () => {
+    describe('instance where', () => {
+      describe('tag is', () => {
+        it('should exclude instance when model tag matches', () => {
+          t.expectComputedView(
+            $include('customer'),
+            $include('prod.z1._'),
+            $exclude('prod.z1.app', { where: 'tag is #next' }),
+          ).toHaveNodes(
+            'customer',
+            'prod',
+            'prod.z1',
+            'prod.z1.api',
+            'prod.z1.service',
+          )
+        })
+        it('should exclude instance when deployment tag matches', () => {
+          t.expectComputedView(
+            $include('customer'),
+            $include('prod.infra._'),
+            $exclude('prod.infra.email', { where: 'tag is #alpha' }),
+          ).toHaveNodes(
+            'customer',
+            'prod',
+            'prod.infra',
+          )
+        })
+        it('should not exclude instance when neither model nor instance tag does not match', () => {
+          t.expectComputedView(
+            $include('customer'),
+            $include('prod.z1._'),
+            $exclude('prod.z1.app', { where: 'tag is #omega' }),
+          ).toHaveNodes(
+            'customer',
+            'prod',
+            'prod.z1',
+            'prod.z1.app',
+            'prod.z1.api',
+            'prod.z1.service',
+          )
+        })
+      })
+    })
+
+    describe('node where', () => {
+      describe('tag is', () => {
+        it('should exclude node when tag matches', () => {
+          t.expectComputedView(
+            $include('customer'),
+            $include('prod.z1._'),
+            $include('prod.infra._'),
+            $exclude('prod.infra', { where: 'tag is #beta' }),
+          ).toHaveNodes(
+            'customer',
+            'prod',
+            'prod.z1',
+            'prod.z1.app',
+            'prod.z1.api',
+            'prod.z1.service',
+            'prod.infra.db',
+            'prod.infra.email',
+          )
+        })
+        it('should not exclude node when tag does not match', () => {
+          t.expectComputedView(
+            $include('customer'),
+            $include('prod.z1._'),
+            $include('prod.infra._'),
+            $exclude('prod.infra', { where: 'tag is #omega' }),
+          ).toHaveNodes(
+            'customer',
+            'prod',
+            'prod.z1',
+            'prod.z1.app',
+            'prod.z1.api',
+            'prod.z1.service',
+            'prod.infra',
+            'prod.infra.db',
+            'prod.infra.email',
+          )
+        })
+      })
+    })
+
+    describe('node._ where', () => {
+      describe('tag is', () => {
+        it('should exclude child when model tag matches', () => {
+          t.expectComputedView(
+            $include('customer'),
+            $include('prod.z1._'),
+            $exclude('prod.z1._', { where: 'tag is #next' }),
+          ).toHaveNodes(
+            'customer',
+            'prod',
+            'prod.z1',
+            'prod.z1.api',
+            'prod.z1.service',
+          )
+        })
+        it('should exclude child when deployment tag matches', () => {
+          t.expectComputedView(
+            $include('customer'),
+            $include('prod.z1._'),
+            $include('prod.infra._'),
+            $exclude('prod.infra._', { where: 'tag is #alpha' }),
+          ).toHaveNodes(
+            'customer',
+            'prod',
+            'prod.z1',
+            'prod.z1.app',
+            'prod.z1.api',
+            'prod.z1.service',
+            'prod.infra',
+            'prod.infra.db',
+          )
+        })
+        it('should not exclude child when neither model nor deployment tag does not match', () => {
+          t.expectComputedView(
+            $include('customer'),
+            $include('prod.z1._'),
+            $include('prod.infra._'),
+            $exclude('prod.infra._', { where: 'tag is #omega' }),
+          ).toHaveNodes(
+            'customer',
+            'prod',
+            'prod.z1',
+            'prod.z1.app',
+            'prod.z1.api',
+            'prod.z1.service',
+            'prod.infra',
+            'prod.infra.db',
+            'prod.infra.email',
+          )
+        })
+      })
+    })
+
+    describe('node.* where', () => {
+      describe('tag is', () => {
+        it('should exclude child when model tag matches', () => {
+          t.expectComputedView(
+            $include('customer'),
+            $include('prod.z1._'),
+            $exclude('prod.z1.*', { where: 'tag is #next' }),
+          ).toHaveNodes(
+            'customer',
+            'prod',
+            'prod.z1',
+            'prod.z1.api',
+            'prod.z1.service',
+          )
+        })
+        it('should exclude child when deployment tag matches', () => {
+          t.expectComputedView(
+            $include('customer'),
+            $include('prod.z1._'),
+            $include('prod.infra._'),
+            $exclude('prod.infra.*', { where: 'tag is #alpha' }),
+          ).toHaveNodes(
+            'customer',
+            'prod',
+            'prod.z1',
+            'prod.z1.app',
+            'prod.z1.api',
+            'prod.z1.service',
+            'prod.infra',
+            'prod.infra.db',
+          )
+        })
+        it('should not exclude child when neither model nor deployment tag does not match', () => {
+          t.expectComputedView(
+            $include('customer'),
+            $include('prod.z1._'),
+            $include('prod.infra._'),
+            $exclude('prod.infra.*', { where: 'tag is #omega' }),
+          ).toHaveNodes(
+            'customer',
+            'prod',
+            'prod.z1',
+            'prod.z1.app',
+            'prod.z1.api',
+            'prod.z1.service',
+            'prod.infra',
+            'prod.infra.db',
+            'prod.infra.email',
+          )
+        })
+      })
+    })
+
+    describe('node.** where', () => {
+      describe('tag is', () => {
+        it('should exclude descendant when model tag matches', () => {
+          t.expectComputedView(
+            $include('customer'),
+            $include('prod.z1._'),
+            $exclude('prod.**', { where: 'tag is #next' }),
+          ).toHaveNodes(
+            'customer',
+            'prod',
+            'prod.z1',
+            'prod.z1.api',
+            'prod.z1.service',
+          )
+        })
+        it('should exclude descendant instances when deployment tag matches', () => {
+          t.expectComputedView(
+            $include('customer'),
+            $include('prod.z1._'),
+            $include('prod.infra._'),
+            $exclude('prod.**', { where: 'tag is #alpha' }),
+          ).toHaveNodes(
+            'customer',
+            'prod',
+            'prod.z1',
+            'prod.z1.app',
+            'prod.z1.api',
+            'prod.z1.service',
+            'prod.infra',
+            'prod.infra.db',
+          )
+        })
+        it('should exclude descendant nodes when deployment tag matches', () => {
+          t.expectComputedView(
+            $include('customer'),
+            $include('prod.z1._'),
+            $include('prod.infra._'),
+            $exclude('prod.**', { where: 'tag is #beta' }),
+          ).toHaveNodes(
+            'customer',
+            'prod',
+            'prod.z1',
+            'prod.z1.app',
+            'prod.z1.api',
+            'prod.z1.service',
+            'prod.infra.db',
+            'prod.infra.email',
+          )
+        })
+        it('should not exclude descendant when neither model nor deployment tag does not match', () => {
+          t.expectComputedView(
+            $include('customer'),
+            $include('prod.z1._'),
+            $include('prod.infra._'),
+            $exclude('prod.**', { where: 'tag is #omega' }),
+          ).toHaveNodes(
+            'customer',
+            'prod',
+            'prod.z1',
+            'prod.z1.app',
+            'prod.z1.api',
+            'prod.z1.service',
+            'prod.infra',
+            'prod.infra.db',
+            'prod.infra.email',
+          )
+        })
+      })
+    })
+  })
+})

--- a/packages/core/src/compute-view/deployment-view/predicates/__test__/deploymentRef.spec.ts
+++ b/packages/core/src/compute-view/deployment-view/predicates/__test__/deploymentRef.spec.ts
@@ -2,7 +2,7 @@ import { describe, it } from 'vitest'
 import { Builder } from '../../../../builder'
 import { TestHelper } from '../../__test__/TestHelper'
 
-describe('Wildcard', () => {
+describe('DeploymentRef', () => {
   const builder = Builder
     .specification({
       elements: {
@@ -43,7 +43,7 @@ describe('Wildcard', () => {
       )
     )
 
-  const { $include, $exclude } = TestHelper
+  const { $include } = TestHelper
 
   it('include *', () => {
     const t = TestHelper.from(builder.deployment(({ nd, instanceOf }, d) =>

--- a/packages/core/src/compute-view/deployment-view/predicates/__test__/relations.spec.ts
+++ b/packages/core/src/compute-view/deployment-view/predicates/__test__/relations.spec.ts
@@ -142,24 +142,4 @@ describe('RelationPredicate', () => {
       })
     })
   })
-
-  describe('exclude', () => {
-    describe('element -> *', () => {
-      const t = TestHelper.from(builder.deployment((_, deploymentModel) =>
-        deploymentModel(
-          _.node('a'),
-          _.node('a.b1'),
-          _.node('a.b1.c').with(
-            _.instanceOf('cloud.ui'),
-            _.instanceOf('cloud.backend.api'),
-          ),
-          _.node('a.b2'),
-          _.node('a.b2.c').with(
-            _.instanceOf('cloud.ui'),
-            _.instanceOf('cloud.backend.api'),
-          ),
-        )
-      ))
-    })
-  })
 })

--- a/packages/core/src/compute-view/deployment-view/predicates/__test__/relations.spec.ts
+++ b/packages/core/src/compute-view/deployment-view/predicates/__test__/relations.spec.ts
@@ -79,6 +79,49 @@ describe('RelationPredicate', () => {
           },
         )
       })
+
+      it('* -> instance where', () => {
+        t.expectComputedView(
+          $include('* -> a.b.d.api', { where: 'tag is #next' }),
+        ).toHave(
+          {
+            nodes: [
+              'a.b.c',
+              'a.b.d',
+              'a.b.d.api',
+            ],
+            edges: [
+              'a.b.c -> a.b.d.api',
+            ],
+          },
+        )
+
+        t.expectComputedView(
+          $include('* -> a.b.d.api', { where: 'tag is not #next' }),
+        ).toHave(
+          {
+            nodes: [],
+            edges: [],
+          },
+        )
+      })
+
+      it('* -> instance where participant is', () => {
+        t.expectComputedView(
+          $include('* -> a.b.d.api', { where: 'source.tag is #next' }),
+        ).toHave(
+          {
+            nodes: [
+              'a.b.c',
+              'a.b.d',
+              'a.b.d.api',
+            ],
+            edges: [
+              'a.b.c -> a.b.d.api',
+            ],
+          },
+        )
+      })
     })
 
     describe('element -> *', () => {
@@ -131,6 +174,145 @@ describe('RelationPredicate', () => {
           $include('a.b2.c.ui -> *'),
         )
         t.expect(view1).toHave({
+          nodes: [
+            'a.b2.c.ui',
+            'a.b2.c.api',
+          ],
+          edges: [
+            'a.b2.c.ui -> a.b2.c.api',
+          ],
+        })
+      })
+
+      it('node -> * where', () => {
+        t.expect(t.computeView(
+          $include('a.b2.c._ -> *', { where: 'tag is not #next' }),
+        )).toHave({
+          nodes: [],
+          edges: [],
+        })
+
+        t.expect(t.computeView(
+          $include('a.b2.c._ -> *', { where: 'tag is #next' }),
+        )).toHave({
+          nodes: [
+            'a.b2.c.ui',
+            'a.b2.c.api',
+          ],
+          edges: [
+            'a.b2.c.ui -> a.b2.c.api',
+          ],
+        })
+      })
+
+      it('node -> * where participant is', () => {
+        t.expect(t.computeView(
+          $include('a.b2.c._ -> *', {
+            where: 'source.tag is #next',
+          }),
+        )).toHave({
+          nodes: [
+            'a.b2.c.ui',
+            'a.b2.c.api',
+          ],
+          edges: [
+            'a.b2.c.ui -> a.b2.c.api',
+          ],
+        })
+
+        t.expect(t.computeView(
+          $include('a.b2.c._ -> *', {
+            where: 'source.tag is not #next',
+          }),
+        )).toHave({
+          nodes: [],
+          edges: [],
+        })
+      })
+
+      it('node -> node where', () => {
+        t.expect(t.computeView(
+          $include('a.b2.c._ -> a.b2.c._', { where: 'tag is not #next' }),
+        )).toHave({
+          nodes: [],
+          edges: [],
+        })
+
+        t.expect(t.computeView(
+          $include('a.b2.c._ -> a.b2.c._', { where: 'tag is #next' }),
+        )).toHave({
+          nodes: [
+            'a.b2.c.ui',
+            'a.b2.c.api',
+          ],
+          edges: [
+            'a.b2.c.ui -> a.b2.c.api',
+          ],
+        })
+      })
+
+      it('node -> instance where participant is', () => {
+        t.expect(t.computeView(
+          $include('a.b2.c._ -> a.b2.c.api', {
+            where: 'source.tag is #next',
+          }),
+        )).toHave({
+          nodes: [
+            'a.b2.c.ui',
+            'a.b2.c.api',
+          ],
+          edges: [
+            'a.b2.c.ui -> a.b2.c.api',
+          ],
+        })
+
+        t.expect(t.computeView(
+          $include('a.b2.c._ -> a.b2.c.api', {
+            where: 'source.tag is not #next',
+          }),
+        )).toHave({
+          nodes: [],
+          edges: [],
+        })
+      })
+    })
+  })
+
+  describe('exclude', () => {
+    describe('element -> *', () => {
+      const t = TestHelper.from(builder.deployment((_, deploymentModel) =>
+        deploymentModel(
+          _.node('a'),
+          _.node('a.b1'),
+          _.node('a.b1.c').with(
+            _.instanceOf('cloud.ui'),
+            _.instanceOf('cloud.backend.api'),
+          ),
+          _.node('a.b2'),
+          _.node('a.b2.c').with(
+            _.instanceOf('cloud.ui'),
+            _.instanceOf('cloud.backend.api'),
+          ),
+        )
+      ))
+
+      it('node -> * where', () => {
+        t.expect(t.computeView(
+          $include('a.b2.c.ui -> *'),
+          $exclude('a.b2.c._ -> *', {
+            where: 'source.tag is #next',
+          }),
+        )).toHave({
+          nodes: [],
+          edges: [],
+        })
+
+        t.expect(t.computeView(
+          $include('a.b2.c.ui -> *'),
+          $exclude('a.b2.c._ -> *', {
+            where: 'source.tag is not #next',
+          }),
+        )).toHave({
           nodes: [
             'a.b2.c.ui',
             'a.b2.c.api',

--- a/packages/core/src/compute-view/deployment-view/predicates/__test__/relations.spec.ts
+++ b/packages/core/src/compute-view/deployment-view/predicates/__test__/relations.spec.ts
@@ -79,49 +79,6 @@ describe('RelationPredicate', () => {
           },
         )
       })
-
-      it('* -> instance where', () => {
-        t.expectComputedView(
-          $include('* -> a.b.d.api', { where: 'tag is #next' }),
-        ).toHave(
-          {
-            nodes: [
-              'a.b.c',
-              'a.b.d',
-              'a.b.d.api',
-            ],
-            edges: [
-              'a.b.c -> a.b.d.api',
-            ],
-          },
-        )
-
-        t.expectComputedView(
-          $include('* -> a.b.d.api', { where: 'tag is not #next' }),
-        ).toHave(
-          {
-            nodes: [],
-            edges: [],
-          },
-        )
-      })
-
-      it('* -> instance where participant is', () => {
-        t.expectComputedView(
-          $include('* -> a.b.d.api', { where: 'source.tag is #next' }),
-        ).toHave(
-          {
-            nodes: [
-              'a.b.c',
-              'a.b.d',
-              'a.b.d.api',
-            ],
-            edges: [
-              'a.b.c -> a.b.d.api',
-            ],
-          },
-        )
-      })
     })
 
     describe('element -> *', () => {
@@ -183,98 +140,6 @@ describe('RelationPredicate', () => {
           ],
         })
       })
-
-      it('node -> * where', () => {
-        t.expect(t.computeView(
-          $include('a.b2.c._ -> *', { where: 'tag is not #next' }),
-        )).toHave({
-          nodes: [],
-          edges: [],
-        })
-
-        t.expect(t.computeView(
-          $include('a.b2.c._ -> *', { where: 'tag is #next' }),
-        )).toHave({
-          nodes: [
-            'a.b2.c.ui',
-            'a.b2.c.api',
-          ],
-          edges: [
-            'a.b2.c.ui -> a.b2.c.api',
-          ],
-        })
-      })
-
-      it('node -> * where participant is', () => {
-        t.expect(t.computeView(
-          $include('a.b2.c._ -> *', {
-            where: 'source.tag is #next',
-          }),
-        )).toHave({
-          nodes: [
-            'a.b2.c.ui',
-            'a.b2.c.api',
-          ],
-          edges: [
-            'a.b2.c.ui -> a.b2.c.api',
-          ],
-        })
-
-        t.expect(t.computeView(
-          $include('a.b2.c._ -> *', {
-            where: 'source.tag is not #next',
-          }),
-        )).toHave({
-          nodes: [],
-          edges: [],
-        })
-      })
-
-      it('node -> node where', () => {
-        t.expect(t.computeView(
-          $include('a.b2.c._ -> a.b2.c._', { where: 'tag is not #next' }),
-        )).toHave({
-          nodes: [],
-          edges: [],
-        })
-
-        t.expect(t.computeView(
-          $include('a.b2.c._ -> a.b2.c._', { where: 'tag is #next' }),
-        )).toHave({
-          nodes: [
-            'a.b2.c.ui',
-            'a.b2.c.api',
-          ],
-          edges: [
-            'a.b2.c.ui -> a.b2.c.api',
-          ],
-        })
-      })
-
-      it('node -> instance where participant is', () => {
-        t.expect(t.computeView(
-          $include('a.b2.c._ -> a.b2.c.api', {
-            where: 'source.tag is #next',
-          }),
-        )).toHave({
-          nodes: [
-            'a.b2.c.ui',
-            'a.b2.c.api',
-          ],
-          edges: [
-            'a.b2.c.ui -> a.b2.c.api',
-          ],
-        })
-
-        t.expect(t.computeView(
-          $include('a.b2.c._ -> a.b2.c.api', {
-            where: 'source.tag is not #next',
-          }),
-        )).toHave({
-          nodes: [],
-          edges: [],
-        })
-      })
     })
   })
 
@@ -295,33 +160,6 @@ describe('RelationPredicate', () => {
           ),
         )
       ))
-
-      it('node -> * where', () => {
-        t.expect(t.computeView(
-          $include('a.b2.c.ui -> *'),
-          $exclude('a.b2.c._ -> *', {
-            where: 'source.tag is #next',
-          }),
-        )).toHave({
-          nodes: [],
-          edges: [],
-        })
-
-        t.expect(t.computeView(
-          $include('a.b2.c.ui -> *'),
-          $exclude('a.b2.c._ -> *', {
-            where: 'source.tag is not #next',
-          }),
-        )).toHave({
-          nodes: [
-            'a.b2.c.ui',
-            'a.b2.c.api',
-          ],
-          edges: [
-            'a.b2.c.ui -> a.b2.c.api',
-          ],
-        })
-      })
     })
   })
 })

--- a/packages/core/src/compute-view/deployment-view/predicates/__test__/wildcard.filter.spec.ts
+++ b/packages/core/src/compute-view/deployment-view/predicates/__test__/wildcard.filter.spec.ts
@@ -1,0 +1,249 @@
+import { describe, it } from 'vitest'
+import { Builder } from '../../../../builder'
+import { TestHelper } from '../../__test__/TestHelper'
+
+describe('Wildcard', () => {
+  const builder = Builder
+    .specification({
+      elements: {
+        el: {},
+        app: {}
+      },
+      tags: ['next', 'alpha', 'beta', 'omega'],
+      deployments: {
+        nd: {},
+        vm: {},
+      },
+    })
+    .model(({ el, app }, _) =>
+      _(
+        el('customer', { tags: ['next'] }),
+        el('cloud'),
+        el('cloud.ui'),
+        app('cloud.ui.app', { tags: ['next'] }),
+        el('cloud.backend'),
+        el('cloud.backend.api'),
+        el('cloud.backend.service'),
+        el('infra'),
+        el('infra.db'),
+        el('infra.email'),
+        el('integrators'),
+      )
+    )
+    .model(({ rel }, m) =>
+      m(
+        rel('customer', 'cloud'),
+        rel('customer', 'cloud.ui.app'),
+        rel('cloud.backend.api', 'cloud.backend.service'),
+        rel('cloud.backend.service', 'infra.db'),
+        rel('cloud.backend.service', 'infra.email'),
+        rel('cloud.ui.app', 'cloud.backend.api'),
+        rel('cloud', 'infra'),
+        rel('infra.email', 'customer'),
+        rel('integrators', 'cloud.backend.api'),
+        rel('infra.email', 'integrators'),
+      )
+    )
+
+  const { $include, $exclude } = TestHelper
+
+  const t = TestHelper.from(builder.deployment(({ nd, instanceOf, vm }, d) =>
+    d(
+      nd('customer').with(
+        instanceOf('customer'),
+      ),
+      nd('prod', { tags: ['alpha'] }),
+      nd('prod.z1').with(
+        instanceOf('cloud.ui.app'),
+        instanceOf('cloud.backend.api'),
+        instanceOf('cloud.backend.service'),
+      ),
+      nd('prod.infra').with(
+        instanceOf('infra.db'),
+        instanceOf('email', 'infra.email', { tags: ['alpha'] }),
+      ),
+      nd('global').with(
+        instanceOf('integrators'),
+      ),
+      vm('dev').with(
+        instanceOf('cloud.ui.app'),
+        instanceOf('cloud.backend.api'),
+        instanceOf('cloud.backend.service'),
+        instanceOf('infra.db'),
+        instanceOf('infra.email'),
+      ),
+    )
+  ))
+
+  describe('include * where', () => {
+    describe('kind is', () => {
+      // Wildcard filters could not be applied to instances as instances are always wrapped into deployment node
+      // it('should include instance when model kind matches', () => {})
+      // it('should not include instance when model kind does not match', () => {})
+
+      it('should include node when node kind matches', () => {
+        t.expectComputedView(
+          $include('*', { where: 'kind is vm' }),
+        ).toHaveNodes(
+          'dev',
+          'dev.app',
+          'dev.api',
+          'dev.service',
+          'dev.db',
+          'dev.email',
+        )
+      })
+    })
+
+    describe('tag is', () => {
+      // Wildcard filters could not be applied to instances as instances are always wrapped into deployment node
+      // it('should include instance when model tag matches', () => {})
+      // it('should include instance when instance tag matches', () => {})
+      // it('should not include instance when neither model nor instance tag does not match', () => {})
+
+      it('should include node when tag matches', () => {
+        t.expectComputedView(
+          $include('*', { where: 'tag is #alpha' }),
+        ).toHaveNodes(
+          'prod',
+          'prod.z1',
+          'prod.infra',
+        )
+      })
+
+      it('should not include node when tag does not match', () => {
+        t.expectComputedView(
+          $include('*', { where: 'tag is #omega' }),
+        ).toHaveNodes()
+      })
+    })
+  })
+
+  describe('exclude *', () => {
+    describe('tag is', () => {
+      it('should exclude staged node when tag matches', () => {
+        t.expectComputedView(
+          $include('prod'),
+          $include('prod.**'),
+          $exclude('*', { where: 'tag is #alpha' }),
+        ).toHaveNodes(
+          'prod.z1',
+          'prod.z1.app',
+          'prod.z1.api',
+          'prod.z1.service',
+          'prod.infra',
+          'prod.infra.db',
+        )
+      })
+      it('should not exclude staged node when tag does not match', () => {
+        t.expectComputedView(
+          $include('customer'),
+          $include('dev'),
+          $include('dev._'),
+          $exclude('*', { where: 'tag is #alpha' }),
+        ).toHaveNodes(
+          'customer',
+          'dev',
+          'dev.app',
+          'dev.api',
+          'dev.service',
+          'dev.db',
+          'dev.email',
+        )
+      })
+      it('should exclude staged instance when model tag matches', () => {
+        t.expectComputedView(
+          $include('prod'),
+          $include('prod.**'),
+          $exclude('*', { where: 'tag is #next' }),
+        ).toHaveNodes(
+          'prod',
+          'prod.z1',
+          'prod.z1.api',
+          'prod.z1.service',
+          'prod.infra',
+          'prod.infra.db',
+          'prod.infra.email',
+        )
+      })
+      it('should exclude staged instance when deployment tag matches', () => {
+        t.expectComputedView(
+          $include('prod'),
+          $include('prod.**'),
+          $exclude('*', { where: 'tag is #alpha' }),
+        ).toHaveNodes(
+          'prod.z1',
+          'prod.z1.app',
+          'prod.z1.api',
+          'prod.z1.service',
+          'prod.infra',
+          'prod.infra.db',
+        )
+      })
+      it('should not exclude staged instance when neither model or deployment tag does not match', () => {
+        t.expectComputedView(
+          $include('prod'),
+          $include('prod.**'),
+          $exclude('*', { where: 'tag is #omega' }),
+        ).toHaveNodes(
+          'prod',
+          'prod.z1',
+          'prod.z1.app',
+          'prod.z1.api',
+          'prod.z1.service',
+          'prod.infra',
+          'prod.infra.db',
+          'prod.infra.email',
+        )
+      })
+    })
+
+    describe('kind is', () => {
+      it('should exclude staged node when kind matches', () => {
+        t.expectComputedView(
+          $include('dev'),
+          $include('dev.**'),
+          $exclude('*', { where: 'kind is vm' }),
+        ).toHaveNodes(
+          'dev.app',
+          'dev.api',
+          'dev.service',
+          'dev.db',
+          'dev.email',
+        )
+      })
+      it('should not exclude staged node when kind does not match', () => {
+        t.expectComputedView(
+          $include('prod'),
+          $include('prod.**'),
+          $exclude('*', { where: 'kind is vm' }),
+        ).toHaveNodes(
+          'prod',
+          'prod.z1',
+          'prod.z1.app',
+          'prod.z1.api',
+          'prod.z1.service',
+          'prod.infra',
+          'prod.infra.db',
+          'prod.infra.email',
+        )
+      })
+      it('should exclude staged instance when model kind matches', () => {
+        t.expectComputedView(
+          $include('prod'),
+          $include('prod.**'),
+          $exclude('*', { where: 'kind is app' }),
+        ).toHaveNodes(
+          'prod',
+          'prod.z1',
+          'prod.z1.api',
+          'prod.z1.service',
+          'prod.infra',
+          'prod.infra.db',
+          'prod.infra.email',
+        )
+      })
+      it('should not exclude staged instance when modelkind does not match', () => {})
+    })
+  })
+})

--- a/packages/core/src/compute-view/deployment-view/predicates/index.ts
+++ b/packages/core/src/compute-view/deployment-view/predicates/index.ts
@@ -1,4 +1,4 @@
-export * from './elements'
+export * from './deploymentRefs'
 export * from './relation-direct'
 export * from './relation-in-out'
 export * from './relation-incoming'

--- a/packages/core/src/compute-view/deployment-view/stages/stage-exclude.spec.ts
+++ b/packages/core/src/compute-view/deployment-view/stages/stage-exclude.spec.ts
@@ -279,6 +279,44 @@ describe('Stage', () => {
         ]
       `)
     })
+    
+    it('should keep explicit element explicit when neighbour is excluded', () => {
+      const model = createModel()
+      const zone1 = model.deployment.element('prod.eu.zone1')
+      const ui = model.deployment.element('prod.eu.zone1.ui')
+      const api = model.deployment.element('prod.eu.zone1.api')
+      const customer = model.deployment.element('customer')
+      const connection = findConnection(customer, ui)
+
+      const memory = Memory.empty().update({
+        elements: new Set([zone1, ui, api, customer]),
+        explicits: new Set([zone1, customer]),
+        final: new Set([zone1, ui, customer]),
+        connections: [...connection],
+      })
+      const stage = new StageExclude(memory, { wildcard: true })
+      stage.exclude(ui)
+
+      const result = omit(toReadableMemory(stage.commit()), ['connections'])
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "elements": [
+            "prod.eu.zone1",
+            "prod.eu.zone1.api",
+            "customer",
+          ],
+          "explicits": [
+            "prod.eu.zone1",
+            "customer",
+          ],
+          "final": [
+            "prod.eu.zone1",
+            "customer",
+          ],
+        }
+      `)
+    })
   })
 })
 

--- a/packages/core/src/compute-view/memory/AbstractStageExclude.ts
+++ b/packages/core/src/compute-view/memory/AbstractStageExclude.ts
@@ -209,7 +209,7 @@ export abstract class AbstractStageExclude<T extends AnyCtx> implements StageExc
       state = this.removeElements(state)
     }
 
-    state = this.moveDisconnectedExplicitsToImplicits(state)
+    //state = this.moveDisconnectedExplicitsToImplicits(state)
 
     return this.memory.update(this.postcommit(state))
   }

--- a/packages/language-server/src/__tests__/deployment-views.spec.ts
+++ b/packages/language-server/src/__tests__/deployment-views.spec.ts
@@ -169,7 +169,7 @@ describe.concurrent('Deployment views:', () => {
     `)
   })
 
-  it('valid rules', async ctx => {
+  it('valid relation rules', async ctx => {
     const { valid } = await mkTestServices(ctx)
 
     await valid(`
@@ -178,6 +178,20 @@ describe.concurrent('Deployment views:', () => {
       include * -> * where kind is https or tag is #next
       include * -> * where source.kind is zone
       include * -> * where source.kind is component
+    `)
+  })
+
+  it('valid element rules', async ctx => {
+    const { valid } = await mkTestServices(ctx)
+
+    await valid(`
+      include *
+      include *, user
+
+      include * where tag is #next
+      include * where kind is zone
+      include * where kind is component
+      include user, * where tag is #next
     `)
   })
 })

--- a/packages/language-server/src/like-c4.langium
+++ b/packages/language-server/src/like-c4.langium
@@ -369,7 +369,7 @@ WhereElementNegation:
 
 WhereElement:
   {infer WhereElementTag} 'tag' EqOperator value=[Tag:TagId]? |
-  {infer WhereElementKind} 'kind' EqOperator value=[ElementKind]?
+  {infer WhereElementKind} 'kind' EqOperator value=[DeploymentNodeOrElementKind]?
 ;
 
 ElementExpression:
@@ -634,7 +634,11 @@ DeploymentViewRulePredicateExpression:
 
 ExpressionV2:
   RelationPredicateOrWhereV2 |
-  FqnExpr
+  ElementPredicateOrWhereV2
+;
+
+ElementPredicateOrWhereV2:
+  FqnExpr ({infer ElementPredicateWhereV2.subject=current} 'where' where=WhereElementExpression?)?
 ;
 
 RelationPredicateOrWhereV2:

--- a/packages/language-server/src/model/parser/DeploymentViewParser.ts
+++ b/packages/language-server/src/model/parser/DeploymentViewParser.ts
@@ -84,6 +84,9 @@ export function DeploymentViewParser<TBase extends WithExpressionV2 & WithDeploy
               case ast.isFqnExpr(expr):
                 exprs.unshift(this.parseFqnExpr(expr))
                 break
+              case ast.isElementPredicateWhereV2(expr):
+                exprs.unshift(this.parseElementWhereExpr(expr))
+                break
               case ast.isRelationExpr(expr):
                 exprs.unshift(this.parseRelationExpr(expr))
                 break

--- a/packages/language-server/src/model/parser/FqnRefParser.ts
+++ b/packages/language-server/src/model/parser/FqnRefParser.ts
@@ -74,6 +74,17 @@ export function ExpressionV2Parser<TBase extends Base>(B: TBase) {
       }
     }
 
+    parseElementWhereExpr(astNode: ast.ElementPredicateWhereV2): c4.RelationExpr {
+      return {
+        where: {
+          expr: this.parseFqnExpr(astNode.subject as ast.FqnExpr),
+          condition: astNode.where ? parseWhereClause(astNode.where) : {
+            kind: { neq: '--always-true--' },
+          },
+        },
+      }
+    }
+
     parseFqnExpressions(astNode: ast.FqnExpressions): c4.FqnExpr[] {
       const exprs = [] as c4.FqnExpr[]
       let iter: ast.FqnExpressions['prev'] = astNode


### PR DESCRIPTION
Follow up #1430 
Closes #1441 

Hi, @davydkov 

One thing to mention is that I commented [this](https://github.com/likec4/likec4/blob/50288d53ed94e744fd57fda6deb98dc6e6274b17/packages/core/src/compute-view/memory/AbstractStageExclude.ts#L212C20-L212C56) line.
It was covered only by one [spec](https://github.com/likec4/likec4/blob/50288d53ed94e744fd57fda6deb98dc6e6274b17/packages/core/src/compute-view/deployment-view/clean-connections.spec.ts#L134):
Given the model
```
specification {
    element el
    deploymentNode node
}
model {
  el client 
  el cloud {
    el ui
    el backend{
      el api
    }
    el db
  }

  client -> cloud.ui
  cloud.ui -> cloud.backend.api
  cloud.backend.api -> cloud.db
}
deployment {
  node z1{
    node s1{
      instanceOf ui "ui (s1)"
      instanceOf api "api (s1)"
    }
    node s2{
      instanceOf ui "ui (s2)"
      instanceOf api "api (s2)"
    }
  }
}
views {
  deployment view some {
    include z1.**
    exclude -> z1.s2.api
    //exclude z1.s1.api
  }
}
```

commented line will convert 
![image](https://github.com/user-attachments/assets/a7fc27b6-fee6-4106-8281-bf68dd7675c8) into 
![image](https://github.com/user-attachments/assets/3edd119d-bfef-4f87-a594-ef08b597e42f)

This does not look correct. Both z1.s1.ui and z1.s2.ui don't have visible connections. They were added with the same predicate (z1.**). Thus, I expect they will behave identically. 
It also breaks the idea of explicit vs. implicit, where 'explicit' element is the one the user have explicitly added ('I want to see it on the diagram'). They must not be implicitly excluded.
