### PR TITLE
Added go-to-source button into nodes of the  relationship browser

### DIFF
--- a/packages/diagram/src/overlays/relationships-browser/custom/ElementActions.tsx
+++ b/packages/diagram/src/overlays/relationships-browser/custom/ElementActions.tsx
@@ -1,4 +1,4 @@
-import { IconTransform, IconZoomScan } from '@tabler/icons-react'
+import { IconFileSymlink, IconTransform, IconZoomScan } from '@tabler/icons-react'
 import { ElementActionButtons } from '../../../base/primitives'
 import type { NodeProps } from '../../../base/types'
 import { useEnabledFeature } from '../../../context/DiagramFeatures'
@@ -35,6 +35,14 @@ export const ElementActions = (props: ElementActionsProps) => {
       },
     })
   }
+  buttons.push({
+    key: 'goToSource',
+    icon: <IconFileSymlink />,
+    onClick: (e) => {
+      e.stopPropagation()
+      diagram.openSource({ element: fqn })
+    },
+  })
   return (
     <ElementActionButtons
       buttons={buttons}

--- a/packages/diagram/src/overlays/relationships-browser/custom/ElementActions.tsx
+++ b/packages/diagram/src/overlays/relationships-browser/custom/ElementActions.tsx
@@ -8,7 +8,7 @@ import { useRelationshipsBrowser } from '../hooks'
 
 type ElementActionsProps = NodeProps<Types.ElementNodeData>
 export const ElementActions = (props: ElementActionsProps) => {
-  const { enableNavigateTo } = useEnabledFeature('NavigateTo')
+  const { enableNavigateTo, enableVscode } = useEnabledFeature('NavigateTo', 'Vscode')
   const diagram = useDiagram()
   const browser = useRelationshipsBrowser()
 
@@ -35,14 +35,16 @@ export const ElementActions = (props: ElementActionsProps) => {
       },
     })
   }
-  buttons.push({
-    key: 'goToSource',
-    icon: <IconFileSymlink />,
-    onClick: (e) => {
-      e.stopPropagation()
-      diagram.openSource({ element: fqn })
-    },
-  })
+  if (enableVscode) {
+    buttons.push({
+      key: 'goToSource',
+      icon: <IconFileSymlink />,
+      onClick: (e) => {
+        e.stopPropagation()
+        diagram.openSource({ element: fqn })
+      },
+    })
+  }
   return (
     <ElementActionButtons
       buttons={buttons}


### PR DESCRIPTION
Relationship browser is an awesome tool to navigate the model! It is especially useful when altering relationships between elements. But this use case does not work without the ability to navigate to these relations or elements which are endpoints of these relationships.