### PR TITLE
Feat(cli): Add --output-single-file flag to build give self-contained HTML file

### DIFF
--- a/apps/docs/src/content/docs/tooling/cli.mdx
+++ b/apps/docs/src/content/docs/tooling/cli.mdx
@@ -114,6 +114,7 @@ likec4 build -o ./dist
 | `--use-hash-history`    | Hash-based navigation, e.g. "/#/view" instead of "/view"                                              |
 | `--use-dot`             | Use local binaries of Graphviz ("dot") instead of bundled WASM                                        |
 | `--webcomponent-prefix` | Prefix for web components, e.g. "c4" generates `<c4-view ../>`                                        |
+| `--output-single-file`  | Generates a single self-contained HTML file                                                           |
 
 :::note
 Internally, CLI uses Vite to build the website, and `likec4 build` calls `vite build`.  

--- a/packages/likec4/package.json
+++ b/packages/likec4/package.json
@@ -186,6 +186,7 @@
     "vite-plugin-css-injected-by-js": "^3.5.2",
     "vite-plugin-dts": "^4.5.0",
     "vite-plugin-shadow-style": "^1.2.0",
+    "vite-plugin-singlefile": "^2.1.0",
     "vitest": "^2.1.8",
     "yargs": "17.7.2"
   },

--- a/packages/likec4/src/cli/build/build.ts
+++ b/packages/likec4/src/cli/build/build.ts
@@ -33,7 +33,9 @@ type HandlerParams = {
 
   useHashHistory: boolean | undefined
 
-  webcomponentPrefix: string
+  webcomponentPrefix: string,
+
+  outputSingleFile : boolean | undefined
 }
 
 export async function buildHandler({
@@ -43,6 +45,7 @@ export async function buildHandler({
   webcomponentPrefix,
   useOverview = false,
   output: outputDir,
+  outputSingleFile,
   base
 }: HandlerParams) {
   const logger = createLikeC4Logger('c4:build')
@@ -78,13 +81,14 @@ export async function buildHandler({
   }
   await viteBuild({
     base,
-    useHashHistory,
+    useHashHistory: outputSingleFile || useHashHistory,
     customLogger: logger,
     useOverviewGraph: useOverview,
     webcomponentPrefix,
     languageServices,
     likec4AssetsDir,
-    outputDir
+    outputDir,
+    outputSingleFile
   })
 
   if (useOverview) {

--- a/packages/likec4/src/cli/build/index.ts
+++ b/packages/likec4/src/cli/build/index.ts
@@ -2,7 +2,7 @@
 import { resolve } from 'node:path'
 import k from 'tinyrainbow'
 import type { CommandModule } from 'yargs'
-import { base, path, useDotBin, useHashHistory, useOverview, webcomponentPrefix } from '../options'
+import { base, path, useDotBin, useHashHistory, useOverview, webcomponentPrefix, outputSingleFile } from '../options'
 import { buildHandler as handler } from './build'
 
 export const buildCmd = {
@@ -24,6 +24,7 @@ export const buildCmd = {
       .option('use-dot', useDotBin)
       .option('webcomponent-prefix', webcomponentPrefix)
       .option('use-overview', useOverview)
+      .option('output-single-file', outputSingleFile)
       .example(
         `${k.green('$0 build -o ./build ./src')}`,
         k.gray('Search for likec4 files in \'src\' and output static site to \'build\'')
@@ -36,7 +37,8 @@ export const buildCmd = {
       useHashHistory: args['use-hash-history'],
       useDotBin: args['use-dot'],
       useOverview: args['use-overview'] ?? false,
-      webcomponentPrefix: args['webcomponent-prefix']
+      webcomponentPrefix: args['webcomponent-prefix'],
+      outputSingleFile: args['output-single-file'] ?? false
     })
   }
 } satisfies CommandModule<object, {

--- a/packages/likec4/src/cli/options.ts
+++ b/packages/likec4/src/cli/options.ts
@@ -50,3 +50,9 @@ export const useOverview = {
   desc: 'overview all diagrams as graph [experimental]',
   default: false
 } as const satisfies Options
+
+export const outputSingleFile = {
+  boolean: true,
+  type: 'boolean',
+  desc: 'outputs a single self-contained HTML file with all required resources inlined'
+} as const satisfies Options

--- a/packages/likec4/src/vite/config-app.prod.ts
+++ b/packages/likec4/src/vite/config-app.prod.ts
@@ -8,6 +8,7 @@ import type { LikeC4 } from '../LikeC4'
 import { type ViteLogger, createLikeC4Logger } from '../logger'
 import { likec4Plugin } from './plugin'
 import { chunkSizeWarningLimit, viteAppRoot } from './utils'
+import { viteSingleFile } from "vite-plugin-singlefile"
 
 export type LikeC4ViteConfig = {
   customLogger?: ViteLogger
@@ -17,10 +18,13 @@ export type LikeC4ViteConfig = {
   webcomponentPrefix?: string | undefined
   useHashHistory?: boolean | undefined
   useOverviewGraph?: boolean | undefined
-  likec4AssetsDir: string
+  likec4AssetsDir: string,
+  outputSingleFile?: boolean | undefined
+
 }
 
 export const viteConfig = async ({ languageServices, likec4AssetsDir, ...cfg }: LikeC4ViteConfig) => {
+
   const customLogger = cfg.customLogger ?? createLikeC4Logger('c4:vite')
   const root = viteAppRoot()
   const useOverviewGraph = cfg?.useOverviewGraph === true
@@ -110,7 +114,7 @@ export const viteConfig = async ({ languageServices, likec4AssetsDir, ...cfg }: 
       likec4Plugin({
         languageServices,
         useOverviewGraph,
-      }),
-    ],
+      })
+    ].concat(cfg.outputSingleFile ? [viteSingleFile()] : []),
   } satisfies InlineConfig & Omit<LikeC4ViteConfig, 'customLogger'> & { isDev: boolean }
 }

--- a/packages/likec4/src/vite/config-app.ts
+++ b/packages/likec4/src/vite/config-app.ts
@@ -15,6 +15,8 @@ import { createLikeC4Logger } from '../logger'
 import type { LikeC4ViteConfig } from './config-app.prod'
 import { likec4Plugin } from './plugin'
 import { chunkSizeWarningLimit } from './utils'
+import { viteSingleFile } from "vite-plugin-singlefile"
+import { outputSingleFile } from 'src/cli/options'
 
 export type { LikeC4ViteConfig }
 
@@ -63,7 +65,7 @@ export const viteConfig = async ({ languageServices, likec4AssetsDir, ...cfg }: 
       WEBCOMPONENT_PREFIX: JSON.stringify(webcomponentPrefix),
       __USE_STYLE_BUNDLE__: 'false',
       __USE_OVERVIEW_GRAPH__: useOverviewGraph ? 'true' : 'false',
-      __USE_HASH_HISTORY__: cfg?.useHashHistory === true ? 'true' : 'false',
+      __USE_HASH_HISTORY__:  cfg?.useHashHistory === true ? 'true' : 'false',
       'process.env.NODE_ENV': '"development"',
     },
     resolve: {
@@ -147,50 +149,49 @@ export const viteConfig = async ({ languageServices, likec4AssetsDir, ...cfg }: 
         quoteStyle: 'single',
       }),
       react(),
-      cssInjectedByJsPlugin({
-        injectionCodeFormat: 'esm',
-        injectCodeFunction: function(cssCode: string, options) {
-          try {
-            if (typeof document != 'undefined') {
-              const id = options.styleId ?? options.attributes?.['data-vite-dev-id']
-              if (!id) {
-                throw new Error('styleId or data-vite-dev-id is required')
-              }
-              // @ts-ignore
-              if (window.__likec4styles) {
-                // @ts-ignore
-                window.__likec4styles.set(id, cssCode)
-                return
-              }
-
-              var elementStyle = document.createElement('style')
-
-              // SET ALL ATTRIBUTES
-              for (const attribute in options.attributes) {
-                elementStyle.setAttribute(attribute, options.attributes[attribute]!)
-              }
-
-              elementStyle.appendChild(document.createTextNode(cssCode))
-              document.head.appendChild(elementStyle)
+    ].concat(cfg.outputSingleFile ? [viteSingleFile()] : [cssInjectedByJsPlugin({
+      injectionCodeFormat: 'esm',
+      injectCodeFunction: function(cssCode: string, options) {
+        try {
+          if (typeof document != 'undefined') {
+            const id = options.styleId ?? options.attributes?.['data-vite-dev-id']
+            if (!id) {
+              throw new Error('styleId or data-vite-dev-id is required')
             }
-          } catch (e) {
-            console.error('vite-plugin-css-injected-by-js', e)
-          }
-        },
-        dev: {
-          enableDev: true,
-          removeStyleCodeFunction: function(id) {
-            document.querySelectorAll(`[data-vite-dev-id="${id}"]`).forEach((el) => {
-              el.parentNode!.removeChild(el)
-            })
             // @ts-ignore
             if (window.__likec4styles) {
               // @ts-ignore
-              window.__likec4styles.set(id, '')
+              window.__likec4styles.set(id, cssCode)
+              return
             }
-          },
+
+            var elementStyle = document.createElement('style')
+
+            // SET ALL ATTRIBUTES
+            for (const attribute in options.attributes) {
+              elementStyle.setAttribute(attribute, options.attributes[attribute]!)
+            }
+
+            elementStyle.appendChild(document.createTextNode(cssCode))
+            document.head.appendChild(elementStyle)
+          }
+        } catch (e) {
+          console.error('vite-plugin-css-injected-by-js', e)
+        }
+      },
+      dev: {
+        enableDev: true,
+        removeStyleCodeFunction: function(id) {
+          document.querySelectorAll(`[data-vite-dev-id="${id}"]`).forEach((el) => {
+            el.parentNode!.removeChild(el)
+          })
+          // @ts-ignore
+          if (window.__likec4styles) {
+            // @ts-ignore
+            window.__likec4styles.set(id, '')
+          }
         },
-      }),
-    ],
+      },
+    })]),
   } satisfies InlineConfig & LikeC4ViteConfig & { isDev: boolean }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12662,6 +12662,7 @@ __metadata:
     turbo: "npm:^2.3.4"
     typescript: "npm:^5.7.3"
     vite: "npm:5.4.14"
+    vite-plugin-singlefile: "npm:^2.1.0"
     vitest: "npm:^2.1.8"
   languageName: unknown
   linkType: soft
@@ -14529,6 +14530,18 @@ __metadata:
   version: 1.2.0
   resolution: "vite-plugin-shadow-style@npm:1.2.0"
   checksum: 10c0/3721202ab6a702762dec10daf0ad46a617fb18fdd80bdde3dc86e60c6d9ce54e97ce24a9524c316f82b9b59c5f6b2645baf93d5b33c08df8f0a1ee3a2c92cb50
+  languageName: node
+  linkType: hard
+
+"vite-plugin-singlefile@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "vite-plugin-singlefile@npm:2.1.0"
+  dependencies:
+    micromatch: "npm:^4.0.8"
+  peerDependencies:
+    rollup: ^4.28.1
+    vite: ^5.4.11 || ^6.0.0
+  checksum: 10c0/04b41a05ad9228011ec81dc06426b93724adfe8d7b966aa8c6e28da746be3c1b20b17451201172514df84f60b71cd8fe2477d57cd0cc346727c27a41f19702d3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This feature allows output to be bundled into a single static HTML file which does not require a web server (or relative files to load from a web server). So this is useful for anywhere you can attach/send just a single HTML file - like email, wikis and bug tracking systems.
