### PR TITLE
Workaround for incorrect value of node.internals.positionAbsolute in xyflow/react@12.4.2

### DIFF
--- a/packages/diagram/src/likec4diagram/useLayoutConstraints.ts
+++ b/packages/diagram/src/likec4diagram/useLayoutConstraints.ts
@@ -60,33 +60,17 @@ abstract class Rect {
     }
   }
   protected abstract parent: Compound | null
-}
-
-class Compound extends Rect {
-  public readonly children = [] as Rect[]
 
   constructor(
     xynode: InternalNode,
-    protected readonly parent: Compound | null = null,
+    parent: Compound | null = null,
   ) {
-    super()
     this.id = xynode.id
 
-    if (parent) {
-      parent.children.push(this)
+    this.positionAbsolute = !parent ? xynode.position : {
+      x: xynode.position.x + parent.minX,
+      y: xynode.position.y + parent.minY,
     }
-  }
-}
-
-class Leaf extends Rect {
-  constructor(
-    xynode: InternalNode,
-    public readonly parent: Compound | null = null,
-  ) {
-    super()
-    this.id = xynode.id
-
-    this.positionAbsolute = xynode.internals.positionAbsolute
 
     const { width, height } = getNodeDimensions(xynode)
 
@@ -96,6 +80,26 @@ class Leaf extends Rect {
     if (parent) {
       parent.children.push(this)
     }
+  }
+}
+
+class Compound extends Rect {
+  public readonly children = [] as Rect[]
+
+  constructor(
+    xynode: InternalNode,
+    public readonly parent: Compound | null = null,
+  ) {
+    super(xynode, parent)
+  }
+}
+
+class Leaf extends Rect {
+  constructor(
+    xynode: InternalNode,
+    public readonly parent: Compound | null = null,
+  ) {
+    super(xynode, parent)
   }
 }
 


### PR DESCRIPTION
The issue appeared after update xyflow/react. Works fine up to (including) the version 12.4.1.
In the version 12.4.2 the update mechanism for InternalNodes was refactored in order to make InternalNode immutable (https://github.com/xyflow/xyflow/commit/7cb9a8686ddf932c7fdbc36e919a78e25dee649b).

Workaround is based on assumption that value of node.internals.positionAbsolute the field is incorrect while node.position is correct. Therefore, absolute position of the node's rectangle is calculated from the position of its parent and node's relative coords.

Closes #1516