### PR TITLE
Fixed nesting of the groups on 3+ level

### DIFF
--- a/packages/core/src/compute-view/element-view/__test__/groups.spec.ts
+++ b/packages/core/src/compute-view/element-view/__test__/groups.spec.ts
@@ -233,4 +233,36 @@ describe('groups', () => {
       }
     `)
   })
+
+  it('should work with deep nesting', () => {
+    const { nodeIds, nodes } = computeView([
+      $group([
+        $group([
+          $group([]),
+          $group([]),
+        ]),
+      ])
+    ])
+    expect.soft(nodeIds).toEqual([
+      '@gr1',
+      '@gr2',
+      '@gr3',
+      '@gr4',
+    ])
+    // parent of each node
+    expect(
+      pipe(
+        nodes,
+        indexBy(prop('id')),
+        mapValues(prop('parent')),
+      ),
+    ).toMatchInlineSnapshot(`
+      {
+        "@gr1": null,
+        "@gr2": "@gr1",
+        "@gr3": "@gr2",
+        "@gr4": "@gr2",
+      }
+    `)
+  })
 })

--- a/packages/core/src/compute-view/element-view/memory/memory.ts
+++ b/packages/core/src/compute-view/element-view/memory/memory.ts
@@ -111,7 +111,7 @@ export class ActiveGroupMemory extends Memory<ActiveGroupCtx> {
   ): ActiveGroupMemory {
     const groupId = `@gr${memory.groups.length + 1}` as NodeId
     if (memory instanceof ActiveGroupMemory) {
-      const stack = Stack.from(memory.stack)
+      const stack = Stack.from([...memory.stack].reverse())
       const state = memory.mutableState()
       state.groups.push(new NodesGroup(groupId, rule, memory.activeGroupId))
       stack.push(groupId)


### PR DESCRIPTION
Interestingly enough, Stack.from(stack) produces the reversed stack rather than copy of the original collection.
I suppose, it is because the original stack is being iterated from the topmost (newest) element to the oldest and new stack is filled by pushing items into it. Thus, the newest item in the original stack becomes the oldest in the new one.

Closes #1519 
