### PR TITLE
Fix styles of compound node header in light theme

### DIFF
--- a/packages/diagram/src/base/primitives/compound/CompoundTitle.css.ts
+++ b/packages/diagram/src/base/primitives/compound/CompoundTitle.css.ts
@@ -35,11 +35,6 @@ export const title = style({
   // paddingBottom: 6,
   // minHeight: 20,
   mixBlendMode: 'screen',
-  selectors: {
-    [`${whereLight} &`]: {
-      mixBlendMode: 'darken',
-    },
-  },
 })
 
 const iconSize = '20px'


### PR DESCRIPTION
With value 'darken' text gets the same color as the background when node has opacity 100%.

Value screen works well with opacity values 0%-60% and 100%. At 80%-90% text is barely readable. Checked other values (lighten, plus-lighter) result mostly the same but barely readable range shifts to the 70%-80%.

Closes #1590 