### PR TITLE
fix(lsp): do not resolve real filenames for symbolic links

### DIFF
--- a/packages/language-server/src/LikeC4FileSystem.ts
+++ b/packages/language-server/src/LikeC4FileSystem.ts
@@ -18,7 +18,7 @@ class SymLinkTraversingFileSystemProvider extends NodeFileSystemProvider {
     const entries = [] as FileSystemNode[]
     try {
       const crawled = await new fdir()
-        .withSymlinks()
+        .withSymlinks({resolvePaths: false})
         .withFullPaths()
         .filter(hasExtension)
         .crawl(folderPath.fsPath)


### PR DESCRIPTION
Fixes #1620

Update `SymLinkTraversingFileSystemProvider` to handle symbolic links without resolving paths.

* Modify `readDirectory` method to use `withSymlinks({resolvePaths: false})` option in `fdir` to prevent duplicate element names when reading files under symbolic links.