### PR TITLE
Added an alias for ignore-layout option

### DIFF
--- a/packages/likec4/src/cli/validate/index.ts
+++ b/packages/likec4/src/cli/validate/index.ts
@@ -10,6 +10,7 @@ export const validateCmd = {
     yargs
       .positional('path', path)
       .option('ignore-layout', {
+        alias: ['skip-layout'],
         boolean: true,
         default: false,
         description: 'do not validate layout of views',


### PR DESCRIPTION
The problem described in #1638 was related to layout computation on workspace initialization. This was solved with https://github.com/likec4/likec4/commit/7b5c98511f1ff869362422192e33aed709bbe77d#diff-e6b879e84bd696db8051d5c7aa46c0b994961913fe99fab9506f783b20570453L60-L66

--ignore-layout option seems to work as expected, thus just an alias was added.

Closes #1641