### PR TITLE
docs: update spelling

### DIFF
--- a/apps/docs/src/content/docs/dsl/Deployment/model.mdx
+++ b/apps/docs/src/content/docs/dsl/Deployment/model.mdx
@@ -176,7 +176,7 @@ deployment {
 As you see, relationship is between same logical element, but different instances.  
 Assume, we don't need this relationship in our logical model, but it makes sense for deployment.
 
-Deployment relationships can be kinded, and have [same properties](/dsl/relationships/#relationship-properties) as logical ones:
+Deployment relationships can be "kinded", and have [same properties](/dsl/relationships/#relationship-properties) as logical ones:
 
 ```likec4
 deployment {
@@ -214,6 +214,6 @@ deployment {
 :::
 
 :::note
-Check this <a href="https://github.com/likec4/likec4/discussions/1269" target='_blank'>GitHub discussion</a> for futher development.  
+Check this <a href="https://github.com/likec4/likec4/discussions/1269" target='_blank'>GitHub discussion</a> for further development.  
 Feel free to share your ideas.
 :::

--- a/apps/docs/src/content/docs/dsl/dynamic-views.mdx
+++ b/apps/docs/src/content/docs/dsl/dynamic-views.mdx
@@ -96,7 +96,7 @@ views {
 ```
 
 :::note
-Check this <a href="https://github.com/likec4/likec4/discussions/816" target='_blank'>GitHub discussion</a> for futher development.  
+Check this <a href="https://github.com/likec4/likec4/discussions/816" target='_blank'>GitHub discussion</a> for further development.  
 Feel free to share your ideas.
 :::
 

--- a/apps/docs/src/content/docs/dsl/intro.mdx
+++ b/apps/docs/src/content/docs/dsl/intro.mdx
@@ -72,6 +72,6 @@ views {
 
 :::tip
 For example, `views` block allows _"local styles"_, that apply to the views in the same block.  
-This way you can group views that have same styles, and avoid boilterplate.  
+This way you can group views that have same styles, and avoid boilerplate.  
 Explained later in [Views](/dsl/views/#shared-local-styles).
 :::

--- a/apps/docs/src/content/docs/guides/deploy-github-pages.mdx
+++ b/apps/docs/src/content/docs/guides/deploy-github-pages.mdx
@@ -1,6 +1,6 @@
 ---
 title: Deploy to GitHub Pages
-description: How to deploy static website with your archirecture diagrams to GitHub Pages
+description: How to deploy static website with your architecture diagrams to GitHub Pages
 ---
 
 :::note

--- a/apps/docs/src/content/docs/tooling/Code generation/react.mdx
+++ b/apps/docs/src/content/docs/tooling/Code generation/react.mdx
@@ -1,6 +1,6 @@
 ---
 title: Generate React
-description: How to generate React components, Webcomponents, and TypeScript models from the LikeC4 DSL.
+description: How to generate React components, Web Components, and TypeScript models from the LikeC4 DSL.
 head:
   - tag: title
     content: React components | LikeC4

--- a/apps/docs/src/content/docs/tooling/Code generation/webcomponent.mdx
+++ b/apps/docs/src/content/docs/tooling/Code generation/webcomponent.mdx
@@ -1,11 +1,11 @@
 ---
-title: Generate Webcomponents
-description: How to generate React components, Webcomponents, and TypeScript models from the LikeC4 DSL.
+title: Generate Web Components
+description: How to generate React components, Web Components, and TypeScript models from the LikeC4 DSL.
 head:
   - tag: title
-    content: Webcomponents | LikeC4
+    content: Web Components | LikeC4
 sidebar:
-  label: Webcomponents
+  label: Web Components
   order: 7
 tableOfContents:
   # minHeadingLevel: 3
@@ -24,9 +24,9 @@ Ensure you have [`likec4`](https://www.npmjs.com/package/likec4) in your depende
 npm add likec4
 ```
 
-## Webcomponent
+## Web Component
 
-Generate javascript bundle with webcomponent:
+Generate javascript bundle with web component:
 
 ```sh
 npx likec4 codegen webcomponent -o ./src/likec4-webcomponent.js
@@ -39,7 +39,7 @@ Use it:
 <likec4-view view-id="index"></likec4-view>
 ```
 
-By default, cli generates a `likec4-view` webcomponent.  
+By default, cli generates a `likec4-view` web component.  
 You can change the `likec4` prefix by `-w, --webcomponent-prefix`.
 
 For example:
@@ -55,6 +55,6 @@ And in HTML:
 ```
 
 :::note
-CLI command [build](/tooling/cli/#build-static-website) always generates javascript with webcomponents.  
+CLI command [build](/tooling/cli/#build-static-website) always generates javascript with web components.  
 Check `Share` button on the top at <a href="https://template.likec4.dev/view/cloud" target="_blank">this example</a>
 :::

--- a/apps/docs/src/content/docs/tooling/cli.mdx
+++ b/apps/docs/src/content/docs/tooling/cli.mdx
@@ -26,7 +26,7 @@ The `likec4` CLI is a tool for various operations and automation, such as:
 - Export to PNG, Mermaid, Dot, D2
 - Generate [source code artifacts](/tooling/code-generation/react/):
   - React components
-  - Webcomponents
+  - Web Components
   - Typed data
 
 ## Install
@@ -171,7 +171,7 @@ likec4 gen d2
 
 <LinkCard
   title="Generate components"
-  description="Learn how to generate React and Webcomponents"
+  description="Learn how to generate React and Web Components"
   href="/tooling/code-generation/react/"
 />
 

--- a/apps/docs/src/content/docs/tooling/cli.mdx
+++ b/apps/docs/src/content/docs/tooling/cli.mdx
@@ -97,7 +97,7 @@ You can start the process in a separate terminal window and keep it running whil
 :::
 
 <Aside type="caution">
-By default the web server listening localhost (127.0.0.1). If you want it to listen on all newtwork interfaces add '--listen 0.0.0.0' to the serve command.
+By default the web server listening localhost (127.0.0.1). If you want it to listen on all network interfaces add '--listen 0.0.0.0' to the serve command.
 </Aside>
 
 ### Build static website

--- a/apps/docs/src/content/docs/tooling/vite-plugin.mdx
+++ b/apps/docs/src/content/docs/tooling/vite-plugin.mdx
@@ -55,7 +55,7 @@ This is useful for building documentation, tutorials, or any other application w
 
 4. ### Add LikeC4 model
 
-    Creat `src/tutorial.c4` and copy the following model from tutorial:
+    Create `src/tutorial.c4` and copy the following model from tutorial:
 
     ```likec4 showLineNumbers copy collapse={14-57}
     //src/tutorial.c4

--- a/apps/docs/src/content/docs/tooling/vite-plugin.mdx
+++ b/apps/docs/src/content/docs/tooling/vite-plugin.mdx
@@ -261,5 +261,5 @@ Then you can import this component in astro components or markdown files.
 :::tip
 You can use LikeC4 with other frameworks as well:
 - With Nextjs see [React code generation](/tooling/code-generation/react/)  
-- For non-react-based documentation tools like Docusaurus, see [Webcomponents](/tooling/code-generation/webcomponent/)
+- For non-react-based documentation tools like Docusaurus, see [Web Components](/tooling/code-generation/webcomponent/)
 :::


### PR DESCRIPTION
* Switch to "web components" consistently when used in prose. Aims to align with https://github.com/WICG/webcomponents
* Fixes a few small typos

Note: I used [cspell](https://cspell.org/) to surface these issues and then worked through the results. 