### PR TITLE
refactor: move element style parsing and improve icon handling

### DIFF
--- a/packages/language-server/src/ast.ts
+++ b/packages/language-server/src/ast.ts
@@ -45,7 +45,7 @@ declare module './generated/ast' {
   }
 }
 
-type ParsedElementStyle = {
+export type ParsedElementStyle = {
   shape?: c4.ElementShape
   icon?: c4.IconUrl
   color?: c4.Color
@@ -277,75 +277,6 @@ export function parseAstSizeValue({ value }: { value: ast.SizeValue }): 'xs' | '
     default:
       nonexhaustive(value)
   }
-}
-
-export function toElementStyle(props: Array<ast.StyleProperty> | undefined, isValid: IsValidFn) {
-  const result = {} as ParsedElementStyle
-  if (!props || props.length === 0) {
-    return result
-  }
-  for (const prop of props) {
-    if (!isValid(prop)) {
-      continue
-    }
-    switch (true) {
-      case ast.isBorderProperty(prop): {
-        if (isTruthy(prop.value)) {
-          result.border = prop.value
-        }
-        break
-      }
-      case ast.isColorProperty(prop): {
-        const color = toColor(prop)
-        if (isTruthy(color)) {
-          result.color = color
-        }
-        break
-      }
-      case ast.isShapeProperty(prop): {
-        if (isTruthy(prop.value)) {
-          result.shape = prop.value
-        }
-        break
-      }
-      case ast.isIconProperty(prop): {
-        const icon = prop.libicon?.ref?.name ?? prop.value
-        if (isTruthy(icon)) {
-          result.icon = icon as c4.IconUrl
-        }
-        break
-      }
-      case ast.isOpacityProperty(prop): {
-        result.opacity = parseAstOpacityProperty(prop)
-        break
-      }
-      case ast.isMultipleProperty(prop): {
-        result.multiple = isBoolean(prop.value) ? prop.value : false
-        break
-      }
-      case ast.isShapeSizeProperty(prop): {
-        if (isTruthy(prop.value)) {
-          result.size = parseAstSizeValue(prop)
-        }
-        break
-      }
-      case ast.isPaddingSizeProperty(prop): {
-        if (isTruthy(prop.value)) {
-          result.padding = parseAstSizeValue(prop)
-        }
-        break
-      }
-      case ast.isTextSizeProperty(prop): {
-        if (isTruthy(prop.value)) {
-          result.textSize = parseAstSizeValue(prop)
-        }
-        break
-      }
-      default:
-        nonexhaustive(prop)
-    }
-  }
-  return result
 }
 
 export function toRelationshipStyle(props: ast.RelationshipStyleProperty[] | undefined, isValid: IsValidFn) {

--- a/packages/language-server/src/model/model-parser.spec.ts
+++ b/packages/language-server/src/model/model-parser.spec.ts
@@ -75,6 +75,51 @@ describe.concurrent('LikeC4ModelParser', () => {
         },
       ])
     })
+
+    it('parses relative icons', async ({ expect }) => {
+      const { validate, services } = createTestServices()
+      // vscode-vfs://host/virtual/src/somefolder/index.c4
+      const { document } = await validate(
+        `
+          specification {
+            element component
+          }
+          model {
+            component c1 {
+              style {
+                icon ./icon1.png
+              }
+            }
+            component c2 {
+              style {
+                icon ../icon1.png
+              }
+              icon ../icon2.png // override
+            }
+          }
+        `,
+        'somefolder/index.c4',
+      )
+      const doc = services.likec4.ModelParser.parse(document)
+      expect(doc.c4Elements).toMatchObject([
+        {
+          'id': 'c1',
+          'kind': 'component',
+          'style': {
+            'icon': 'file:///test/workspace/src/somefolder/icon1.png',
+          },
+          'title': 'c1',
+        },
+        {
+          'id': 'c2',
+          'kind': 'component',
+          'style': {
+            'icon': 'file:///test/workspace/src/icon2.png',
+          },
+          'title': 'c2',
+        },
+      ])
+    })
   })
 
   describe('parses relation predicate', () => {

--- a/packages/language-server/src/model/parser/Base.ts
+++ b/packages/language-server/src/model/parser/Base.ts
@@ -1,9 +1,30 @@
 import type * as c4 from '@likec4/core'
-import { isNonEmptyArray } from '@likec4/core'
-import type { AstNode } from 'langium'
-import { filter, flatMap, fromEntries, isEmpty, isNonNullish, isTruthy, map, pipe, unique } from 'remeda'
+import { isNonEmptyArray, nonexhaustive } from '@likec4/core'
+import type { AstNode, URI } from 'langium'
+import {
+  filter,
+  flatMap,
+  fromEntries,
+  isArray,
+  isBoolean,
+  isEmpty,
+  isNonNullish,
+  isTruthy,
+  map,
+  pipe,
+  unique,
+} from 'remeda'
 import stripIndent from 'strip-indent'
-import { type ParsedLikeC4LangiumDocument, ast } from '../../ast'
+import { hasLeadingSlash, hasProtocol, isRelative, joinRelativeURL, joinURL } from 'ufo'
+import {
+  type ParsedElementStyle,
+  type ParsedLikeC4LangiumDocument,
+  ast,
+  parseAstOpacityProperty,
+  parseAstSizeValue,
+  toColor,
+} from '../../ast'
+import type { ProjectConfig } from '../../config'
 import type { LikeC4Services } from '../../module'
 import { readStrictFqn } from '../../utils/elementRef'
 import { type IsValidFn, checksFromDiagnostics } from '../../validation'
@@ -30,6 +51,14 @@ export class BaseParser {
   ) {
     // do nothing
     this.isValid = checksFromDiagnostics(doc).isValid
+  }
+
+  get project(): {
+    id: c4.ProjectId
+    folder: URI
+    config: Readonly<ProjectConfig>
+  } {
+    return this.services.shared.workspace.ProjectsManager.getProject(this.doc)
   }
 
   resolveFqn(node: ast.FqnReferenceable): c4.Fqn {
@@ -115,5 +144,116 @@ export class BaseParser {
         return []
       }),
     )
+  }
+
+  parseIconProperty(prop: ast.IconProperty | undefined): c4.IconUrl | undefined {
+    if (!prop || !this.isValid(prop)) {
+      return undefined
+    }
+    const { libicon, value } = prop
+    switch (true) {
+      case !!libicon: {
+        return libicon.ref?.name as c4.IconUrl
+      }
+      case value && hasProtocol(value): {
+        return value as c4.IconUrl
+      }
+      case value && isRelative(value): {
+        return joinRelativeURL(this.doc.uri.toString(), '../', value) as c4.IconUrl
+      }
+      case value && hasLeadingSlash(value): {
+        return joinURL(this.project.folder.toString(), value) as c4.IconUrl
+      }
+      default: {
+        return undefined
+      }
+    }
+  }
+
+  parseElementStyle(
+    elementProps: Array<ast.ElementProperty> | ast.ElementStyleProperty | undefined,
+  ): ParsedElementStyle {
+    if (!elementProps) {
+      return {} as ParsedElementStyle
+    }
+    if (isArray(elementProps)) {
+      const style = this.parseStyleProps(elementProps?.find(ast.isElementStyleProperty)?.props)
+      // Property on element has higher priority than from style
+      const iconProp = this.parseIconProperty(elementProps?.find(ast.isIconProperty))
+      if (iconProp) {
+        style.icon = iconProp
+      }
+      return style
+    }
+    return this.parseStyleProps(elementProps.props)
+  }
+
+  parseStyleProps(styleProps: Array<ast.StyleProperty> | undefined): ParsedElementStyle {
+    const result = {} as ParsedElementStyle
+    if (!styleProps || styleProps.length === 0) {
+      return result
+    }
+    for (const prop of styleProps) {
+      if (!this.isValid(prop)) {
+        continue
+      }
+      switch (true) {
+        case ast.isBorderProperty(prop): {
+          if (isTruthy(prop.value)) {
+            result.border = prop.value
+          }
+          break
+        }
+        case ast.isColorProperty(prop): {
+          const color = toColor(prop)
+          if (isTruthy(color)) {
+            result.color = color
+          }
+          break
+        }
+        case ast.isShapeProperty(prop): {
+          if (isTruthy(prop.value)) {
+            result.shape = prop.value
+          }
+          break
+        }
+        case ast.isIconProperty(prop): {
+          const icon = this.parseIconProperty(prop)
+          if (isTruthy(icon)) {
+            result.icon = icon
+          }
+          break
+        }
+        case ast.isOpacityProperty(prop): {
+          result.opacity = parseAstOpacityProperty(prop)
+          break
+        }
+        case ast.isMultipleProperty(prop): {
+          result.multiple = isBoolean(prop.value) ? prop.value : false
+          break
+        }
+        case ast.isShapeSizeProperty(prop): {
+          if (isTruthy(prop.value)) {
+            result.size = parseAstSizeValue(prop)
+          }
+          break
+        }
+        case ast.isPaddingSizeProperty(prop): {
+          if (isTruthy(prop.value)) {
+            result.padding = parseAstSizeValue(prop)
+          }
+          break
+        }
+        case ast.isTextSizeProperty(prop): {
+          if (isTruthy(prop.value)) {
+            result.textSize = parseAstSizeValue(prop)
+          }
+          break
+        }
+        default:
+          nonexhaustive(prop)
+      }
+    }
+    return result
   }
 }

--- a/packages/language-server/src/model/parser/DeploymentModelParser.ts
+++ b/packages/language-server/src/model/parser/DeploymentModelParser.ts
@@ -7,7 +7,6 @@ import {
   type ParsedAstDeploymentRelation,
   type ParsedAstExtend,
   ast,
-  toElementStyle,
   toRelationshipStyleExcludeDefaults,
 } from '../../ast'
 import { logWarnError } from '../../logger'
@@ -85,8 +84,7 @@ export function DeploymentModelParser<TBase extends WithExpressionV2>(B: TBase) 
       const id = this.resolveFqn(astNode)
       const kind = nonNullable(astNode.kind.ref, 'DeploymentKind not resolved').name as c4.DeploymentNodeKind
       const tags = this.convertTags(astNode.body)
-      const stylePropsAst = astNode.body?.props.find(ast.isElementStyleProperty)?.props
-      const style = toElementStyle(stylePropsAst, isValid)
+      const style = this.parseElementStyle(astNode.body?.props)
       const metadata = this.getMetadata(astNode.body?.props.find(ast.isMetadataProperty))
 
       const bodyProps = pipe(
@@ -101,15 +99,6 @@ export function DeploymentModelParser<TBase extends WithExpressionV2>(B: TBase) 
       const technology = toSingleLine(bodyProps.technology)
 
       const links = this.convertLinks(astNode.body)
-
-      // Property has higher priority than from style
-      const iconProp = astNode.body?.props.find(ast.isIconProperty)
-      if (iconProp && isValid(iconProp)) {
-        const value = iconProp.libicon?.ref?.name ?? iconProp.value
-        if (isTruthy(value)) {
-          style.icon = value as c4.IconUrl
-        }
-      }
 
       return {
         id,
@@ -130,8 +119,7 @@ export function DeploymentModelParser<TBase extends WithExpressionV2>(B: TBase) 
       const element = this.resolveFqn(nonNullable(elementRef(astNode.element), 'DeployedInstance element not found'))
 
       const tags = this.convertTags(astNode.body)
-      const stylePropsAst = astNode.body?.props.find(ast.isElementStyleProperty)?.props
-      const style = toElementStyle(stylePropsAst, isValid)
+      const style = this.parseElementStyle(astNode.body?.props)
       const metadata = this.getMetadata(astNode.body?.props.find(ast.isMetadataProperty))
 
       const bodyProps = pipe(
@@ -146,15 +134,6 @@ export function DeploymentModelParser<TBase extends WithExpressionV2>(B: TBase) 
       const technology = toSingleLine(bodyProps.technology)
 
       const links = this.convertLinks(astNode.body)
-
-      // Property has higher priority than from style
-      const iconProp = astNode.body?.props.find(ast.isIconProperty)
-      if (iconProp && isValid(iconProp)) {
-        const value = iconProp.libicon?.ref?.name ?? iconProp.value
-        if (isTruthy(value)) {
-          style.icon = value as c4.IconUrl
-        }
-      }
 
       return {
         id,

--- a/packages/language-server/src/model/parser/DeploymentViewParser.ts
+++ b/packages/language-server/src/model/parser/DeploymentViewParser.ts
@@ -1,7 +1,7 @@
 import type * as c4 from '@likec4/core'
 import { invariant, isNonEmptyArray, nonexhaustive } from '@likec4/core'
 import { isNonNullish } from 'remeda'
-import { type ParsedAstDeploymentView, ast, toAutoLayout, toElementStyle, ViewOps } from '../../ast'
+import { type ParsedAstDeploymentView, ast, toAutoLayout, ViewOps } from '../../ast'
 import { logWarnError } from '../../logger'
 import { stringHash } from '../../utils'
 import { parseViewManualLayout } from '../../view-utils/manual-layout'
@@ -106,16 +106,13 @@ export function DeploymentViewParser<TBase extends WithExpressionV2 & WithDeploy
     }
 
     parseDeploymentViewRuleStyle(astRule: ast.DeploymentViewRuleStyle): c4.DeploymentViewRuleStyle {
-      const styleProps = astRule.props.filter(ast.isStyleProperty)
-      const notationProperty = astRule.props.find(ast.isNotationProperty)
-      const notation = removeIndent(notationProperty?.value)
+      const style = this.parseStyleProps(astRule.props.filter(ast.isStyleProperty))
+      const notation = removeIndent(astRule.props.find(ast.isNotationProperty)?.value)
       const targets = this.parseFqnExpressions(astRule.targets)
       return {
         targets,
+        style,
         ...(notation && { notation }),
-        style: {
-          ...toElementStyle(styleProps, this.isValid),
-        },
       }
     }
   }

--- a/packages/language-server/src/model/parser/ModelParser.ts
+++ b/packages/language-server/src/model/parser/ModelParser.ts
@@ -8,7 +8,6 @@ import {
   type ParsedAstExtend,
   type ParsedAstRelation,
   ast,
-  toElementStyle,
   toRelationshipStyleExcludeDefaults,
 } from '../../ast'
 import { logger as mainLogger } from '../../logger'
@@ -109,8 +108,7 @@ export function ModelParser<TBase extends Base>(B: TBase) {
       const id = this.resolveFqn(astNode)
       const kind = nonNullable(astNode.kind.ref, 'Element kind is not resolved').name as c4.ElementKind
       const tags = this.parseTags(astNode.body)
-      const stylePropsAst = astNode.body?.props.find(ast.isElementStyleProperty)?.props
-      const style = toElementStyle(stylePropsAst, isValid)
+      const style = this.parseElementStyle(astNode.body?.props)
       const metadata = this.getMetadata(astNode.body?.props.find(ast.isMetadataProperty))
       const astPath = this.getAstNodePath(astNode)
 
@@ -128,15 +126,6 @@ export function ModelParser<TBase extends Base>(B: TBase) {
       technology = toSingleLine(bodyProps.technology ?? technology)
 
       const links = this.parseLinks(astNode.body)
-
-      // Property has higher priority than from style
-      const iconProp = astNode.body?.props.find(ast.isIconProperty)
-      if (iconProp && isValid(iconProp)) {
-        const value = iconProp.libicon?.ref?.name ?? iconProp.value
-        if (isTruthy(value)) {
-          style.icon = value as c4.IconUrl
-        }
-      }
 
       return {
         id,

--- a/packages/language-server/src/model/parser/SpecificationParser.ts
+++ b/packages/language-server/src/model/parser/SpecificationParser.ts
@@ -1,7 +1,7 @@
 import type * as c4 from '@likec4/core'
 import type { HexColorLiteral } from '@likec4/core'
 import { filter, isNonNullish, isTruthy, mapToObj, pipe } from 'remeda'
-import { ast, toElementStyle, toRelationshipStyleExcludeDefaults } from '../../ast'
+import { ast, toRelationshipStyleExcludeDefaults } from '../../ast'
 import { logger, logWarnError } from '../../logger'
 import { type Base, removeIndent } from './Base'
 
@@ -11,10 +11,10 @@ export function SpecificationParser<TBase extends Base>(B: TBase) {
       const {
         parseResult: {
           value: {
-            specifications
-          }
+            specifications,
+          },
         },
-        c4Specification
+        c4Specification,
       } = this.doc
       const isValid = this.isValid
 
@@ -29,17 +29,15 @@ export function SpecificationParser<TBase extends Base>(B: TBase) {
             logger.warn(`Element kind "${kindName}" is already defined`)
             continue
           }
-          const style = props.find(ast.isElementStyleProperty)
+          const style = this.parseElementStyle(props.find(ast.isElementStyleProperty))
           const bodyProps = pipe(
             props.filter(ast.isSpecificationElementStringProperty) ?? [],
             filter(p => this.isValid(p) && isNonNullish(p.value)),
-            mapToObj(p => [p.key, removeIndent(p.value)] satisfies [string, string])
+            mapToObj(p => [p.key, removeIndent(p.value)] satisfies [string, string]),
           )
           c4Specification.elements[kindName] = {
             ...bodyProps,
-            style: {
-              ...toElementStyle(style?.props, this.isValid)
-            }
+            style,
           }
         } catch (e) {
           logWarnError(e)
@@ -60,11 +58,11 @@ export function SpecificationParser<TBase extends Base>(B: TBase) {
           const bodyProps = pipe(
             props.filter(ast.isSpecificationRelationshipStringProperty) ?? [],
             filter(p => this.isValid(p) && isNonNullish(p.value)),
-            mapToObj(p => [p.key, removeIndent(p.value)] satisfies [string, string])
+            mapToObj(p => [p.key, removeIndent(p.value)] satisfies [string, string]),
           )
           c4Specification.relationships[kindName] = {
             ...bodyProps,
-            ...toRelationshipStyleExcludeDefaults(props, this.isValid)
+            ...toRelationshipStyleExcludeDefaults(props, this.isValid),
           }
         } catch (e) {
           logWarnError(e)
@@ -98,7 +96,7 @@ export function SpecificationParser<TBase extends Base>(B: TBase) {
           }
 
           c4Specification.colors[colorName] = {
-            color: color as HexColorLiteral
+            color: color as HexColorLiteral,
           }
         } catch (e) {
           logWarnError(e)
@@ -107,26 +105,24 @@ export function SpecificationParser<TBase extends Base>(B: TBase) {
     }
 
     parseSpecificationDeploymentNodeKind(
-      { kind, props }: ast.SpecificationDeploymentNodeKind
+      { kind, props }: ast.SpecificationDeploymentNodeKind,
     ): { [key: c4.DeploymentNodeKind]: c4.DeploymentNodeKindSpecification } {
       const kindName = kind.name as c4.DeploymentNodeKind
       if (!isTruthy(kindName)) {
         throw new Error('DeploymentNodeKind name is not resolved')
       }
 
-      const style = props.find(ast.isElementStyleProperty)
+      const style = this.parseElementStyle(props.find(ast.isElementStyleProperty))
       const bodyProps = pipe(
         props.filter(ast.isSpecificationElementStringProperty) ?? [],
         filter(p => this.isValid(p) && isNonNullish(p.value)),
-        mapToObj(p => [p.key, removeIndent(p.value)] satisfies [string, string])
+        mapToObj(p => [p.key, removeIndent(p.value)] satisfies [string, string]),
       )
       return {
         [kindName]: {
           ...bodyProps,
-          style: {
-            ...toElementStyle(style?.props, this.isValid)
-          }
-        }
+          style,
+        },
       }
     }
   }

--- a/packages/language-server/src/model/parser/ViewsParser.ts
+++ b/packages/language-server/src/model/parser/ViewsParser.ts
@@ -3,13 +3,12 @@ import { invariant, isNonEmptyArray, nonexhaustive } from '@likec4/core'
 import { isArray, isDefined, isNonNullish, isTruthy } from 'remeda'
 import type { Writable } from 'type-fest'
 import {
-  ast,
   type ParsedAstDynamicView,
   type ParsedAstElementView,
+  ast,
   toAutoLayout,
   toColor,
-  toElementStyle,
-  ViewOps
+  ViewOps,
 } from '../../ast'
 import type { NotationProperty } from '../../generated/ast'
 import { logger, logWarnError } from '../../logger'
@@ -82,7 +81,7 @@ export function ViewsParser<TBase extends WithPredicates & WithDeploymentView>(B
         id = 'view_' + stringHash(
           this.doc.uri.toString(),
           astPath,
-          viewOf ?? ''
+          viewOf ?? '',
         ) as c4.ViewId
       }
 
@@ -111,10 +110,10 @@ export function ViewsParser<TBase extends WithPredicates & WithDeploymentView>(B
               logWarnError(e)
               return []
             }
-          })
+          }),
         ],
         ...(viewOf && { viewOf }),
-        ...(manualLayout && { manualLayout })
+        ...(manualLayout && { manualLayout }),
       }
       ViewOps.writeId(astNode, view.id)
 
@@ -122,7 +121,7 @@ export function ViewsParser<TBase extends WithPredicates & WithDeploymentView>(B
         const extendsView = astNode.extends.view.ref
         invariant(extendsView?.name, 'view extends is not resolved: ' + astNode.$cstNode?.text)
         return Object.assign(view, {
-          extends: extendsView.name as c4.ViewId
+          extends: extendsView.name as c4.ViewId,
         })
       }
 
@@ -169,10 +168,10 @@ export function ViewsParser<TBase extends WithPredicates & WithDeploymentView>(B
     }
 
     parseViewRuleGlobalPredicateRef(
-      astRule: ast.ViewRuleGlobalPredicateRef | ast.DynamicViewGlobalPredicateRef
+      astRule: ast.ViewRuleGlobalPredicateRef | ast.DynamicViewGlobalPredicateRef,
     ): c4.ViewRuleGlobalPredicateRef {
       return {
-        predicateId: astRule.predicate.$refText as c4.GlobalPredicateId
+        predicateId: astRule.predicate.$refText as c4.GlobalPredicateId,
       }
     }
 
@@ -209,7 +208,7 @@ export function ViewsParser<TBase extends WithPredicates & WithDeploymentView>(B
       return {
         title: toSingleLine(astNode.title) ?? null,
         groupRules,
-        ...toElementStyle(astNode.props, this.isValid)
+        ...this.parseStyleProps(astNode.props),
       }
     }
 
@@ -223,29 +222,29 @@ export function ViewsParser<TBase extends WithPredicates & WithDeploymentView>(B
     parseRuleStyle(
       styleProperties: ast.StyleProperty[],
       elementExpressionsIterator: ast.ElementExpressionsIterator,
-      notationProperty?: NotationProperty
+      notationProperty?: NotationProperty,
     ): c4.ViewRuleStyle {
-      const styleProps = toElementStyle(styleProperties, this.isValid)
+      const styleProps = this.parseStyleProps(styleProperties)
       const notation = removeIndent(notationProperty?.value)
       const targets = this.parseElementExpressionsIterator(elementExpressionsIterator)
       return {
         targets,
         ...(notation && { notation }),
         style: {
-          ...styleProps
-        }
+          ...styleProps,
+        },
       }
     }
 
     parseViewRuleGlobalStyle(astRule: ast.ViewRuleGlobalStyle): c4.ViewRuleGlobalStyle {
       return {
-        styleId: astRule.style.$refText as c4.GlobalStyleID
+        styleId: astRule.style.$refText as c4.GlobalStyleID,
       }
     }
 
     parseDynamicElementView(
       astNode: ast.DynamicView,
-      additionalStyles: c4.ViewRuleStyleOrGlobalRef[]
+      additionalStyles: c4.ViewRuleStyleOrGlobalRef[],
     ): ParsedAstDynamicView {
       const body = astNode.body
       invariant(body, 'DynamicElementView body is not defined')
@@ -258,7 +257,7 @@ export function ViewsParser<TBase extends WithPredicates & WithDeploymentView>(B
       if (!id) {
         id = 'dynamic_' + stringHash(
           this.doc.uri.toString(),
-          astPath
+          astPath,
         ) as c4.ViewId
       }
 
@@ -289,7 +288,7 @@ export function ViewsParser<TBase extends WithPredicates & WithDeploymentView>(B
               logWarnError(e)
               return []
             }
-          }, [] as Array<c4.DynamicViewRule>)
+          }, [] as Array<c4.DynamicViewRule>),
         ],
         steps: body.steps.reduce((acc, n) => {
           try {
@@ -305,7 +304,7 @@ export function ViewsParser<TBase extends WithPredicates & WithDeploymentView>(B
           }
           return acc
         }, [] as c4.DynamicViewStepOrParallel[]),
-        ...(manualLayout && { manualLayout })
+        ...(manualLayout && { manualLayout }),
       }
     }
 
@@ -344,7 +343,7 @@ export function ViewsParser<TBase extends WithPredicates & WithDeploymentView>(B
 
     parseDynamicParallelSteps(node: ast.DynamicViewParallelSteps): c4.DynamicViewParallelSteps {
       return {
-        __parallel: node.steps.map(step => this.parseDynamicStep(step))
+        __parallel: node.steps.map(step => this.parseDynamicStep(step)),
       }
     }
 
@@ -364,14 +363,14 @@ export function ViewsParser<TBase extends WithPredicates & WithDeploymentView>(B
       let step: Writable<c4.DynamicViewStep> = {
         source,
         target,
-        title
+        title,
       }
       if (node.isBackward) {
         step = {
           source: target,
           target: source,
           title,
-          isBackward: true
+          isBackward: true,
         }
       }
       if (!isArray(node.custom?.props)) {

--- a/packages/language-server/src/workspace/ProjectsManager.ts
+++ b/packages/language-server/src/workspace/ProjectsManager.ts
@@ -84,13 +84,16 @@ export class ProjectsManager {
     return [ProjectsManager.DefaultProjectId]
   }
 
-  getProject(projectId: ProjectId): {
+  getProject(arg: ProjectId | LangiumDocument): {
+    id: ProjectId
     folder: URI
     config: Readonly<ProjectConfig>
   } {
-    if (projectId === ProjectsManager.DefaultProjectId) {
+    const id = typeof arg === 'string' ? arg : (arg.likec4ProjectId || this.belongsTo(arg))
+    if (id === ProjectsManager.DefaultProjectId) {
       const folder = this.services.workspace.WorkspaceManager.workspaceUri
       return {
+        id,
         folder,
         config: this.defaultGlobalProject.config,
       }
@@ -98,8 +101,9 @@ export class ProjectsManager {
     const {
       config,
       folder,
-    } = nonNullable(this._projects.find(({ id }) => id === projectId), `Project "${projectId}" not found`)
+    } = nonNullable(this._projects.find(p => p.id === id), `Project "${id}" not found`)
     return {
+      id,
       folder: URI.parse(folder),
       config,
     }


### PR DESCRIPTION
- Exported `ParsedElementStyle` type for better accessibility.
- Replaced the `toElementStyle` function with a more integrated approach in various parsers to enhance style property handling.
- Added new methods for parsing icon properties and element styles directly within the `BaseParser` class.
- Updated multiple parser files to utilize the new style parsing methods, ensuring consistent handling of element styles across the codebase.