### PR TITLE
fix(vscode): VS Code plugin shows `[object Object]` for instanceOf target in hover tooltip

### DIFF
--- a/packages/language-server/src/lsp/HoverProvider.ts
+++ b/packages/language-server/src/lsp/HoverProvider.ts
@@ -49,7 +49,7 @@ export class LikeC4HoverProvider extends AstNodeHoverProvider {
         ? [instance.element.project, instance.element.model]
         : [doc.likec4ProjectId, instance.element.model]
       const el = projectId ? this.locator.getParsedElement(fqn, projectId) : this.locator.getParsedElement(fqn)
-      const lines = [instance.id + '  ', `instance of \`${instance.element}\``]
+      const lines = [instance.id + '  ', `instance of \`${FqnRef.toModelFqn(instance.element)}\``]
       if (el) {
         lines.push(`### ${el.title}`, 'element kind `' + el.kind + '` ')
       }


### PR DESCRIPTION
Fixes #1948
