### PR TITLE
Fix relationship details popup being opened after control point is moved

### DIFF
--- a/packages/diagram/src/likec4diagram/custom/edges/RelationshipEdge.tsx
+++ b/packages/diagram/src/likec4diagram/custom/edges/RelationshipEdge.tsx
@@ -193,6 +193,10 @@ export const RelationshipEdge = customEdge<Types.RelationshipEdgeData>((props) =
       }
       setIsControlPointDragging(false)
     }
+    const onClick = (e: MouseEvent) => {
+      e.stopPropagation()
+      e.preventDefault()
+    }
 
     domNode.addEventListener('pointermove', onPointerMove, {
       capture: true,
@@ -200,6 +204,11 @@ export const RelationshipEdge = customEdge<Types.RelationshipEdgeData>((props) =
     domNode.addEventListener('pointerup', onPointerUp, {
       once: true,
       capture: true,
+    })
+    // Handle click to prevent it from being handled by the edge #1945
+    domNode.addEventListener('click', onClick, {
+      capture: true,
+      once: true,
     })
   }
 


### PR DESCRIPTION
Neither pointerdown nor pointerup events are able to prevent click event being fired on edge element. It seems that event handling in react is a bit different from how it works in 'plain' dom.
As a workaround I've added a click handler that catches click event prevents it's propagation.

Closes #1945

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask, and propose improvements. We're here to help. -->

- [x] I've thoroughly read the latest [contribution guidelines](https://github.com/likec4/likec4/blob/main/CONTRIBUTING.md).
- [x] I've rebased my branch onto `main` **before** creating this PR.
- [ ] I've added tests to cover my changes (if applicable).
- [x] I've verified that all new and existing tests have passed locally for mobile, tablet, and desktop screen sizes.
- [x] My commit messages follow [conventional spec](https://www.conventionalcommits.org/en/)
- [ ] My change requires documentation updates.
- [ ] I've updated the documentation accordingly.
- [x] My code follows existing patterns of this project and/or improves upon them.
