### PR TITLE
fix(lsp): Fixed lsp renaming for tags and relation kinds #1819

### DIFF
--- a/apps/docs/likec4.tmLanguage.json
+++ b/apps/docs/likec4.tmLanguage.json
@@ -79,6 +79,10 @@
       }
     },
     {
+      "match": "(#)([a-zA-Z0-9]+)",
+      "name": "entity.name.type.enum.likec4"
+    },
+    {
       "match": "\\b(opacity):?\\s+([^\\s]+)",
       "captures": {
         "1": {

--- a/apps/playground/likec4.tmLanguage.json
+++ b/apps/playground/likec4.tmLanguage.json
@@ -40,6 +40,10 @@
       }
     },
     {
+      "match": "(#)([a-zA-Z0-9]+)",
+      "name": "entity.name.type.enum.likec4"
+    },
+    {
       "match": "\\b(opacity):?\\s+([^\\s]+)",
       "captures": {
         "1": {

--- a/packages/language-server/src/formatting/LikeC4Formatter.ts
+++ b/packages/language-server/src/formatting/LikeC4Formatter.ts
@@ -167,13 +167,9 @@ export class LikeC4Formatter extends AbstractFormatter {
     this.on(node, ast.isDynamicViewStep, (n, f) => {
       f.keywords('->', '<-').surround(FormattingOptions.oneSpace)
 
-      const kind = GrammarUtils.findNodeForProperty(n.$cstNode, 'kind')
-      const dot = kind && CstUtils.getPreviousNode(kind)
-      if (dot?.text == '.') {
-        f.cst([dot])
-          .prepend(FormattingOptions.oneSpace)
-        f.cst([kind!]).append(FormattingOptions.oneSpace)
-      }
+      f.property('dotKind')
+        .prepend(FormattingOptions.oneSpace)
+        .append(FormattingOptions.oneSpace)
 
       f.keywords(']->')
         .prepend(FormattingOptions.noSpace)
@@ -623,13 +619,9 @@ export class LikeC4Formatter extends AbstractFormatter {
         .prepend(FormattingOptions.noSpace)
         .append(FormattingOptions.oneSpace)
 
-      const kind = GrammarUtils.findNodeForProperty(n.$cstNode, 'kind')
-      const dot = kind && CstUtils.getPreviousNode(kind)
-      if (dot?.text == '.') {
-        f.cst([dot])
-          .prepend(FormattingOptions.oneSpace)
-        f.cst([kind!]).append(FormattingOptions.oneSpace)
-      }
+      f.property('dotKind')
+        .prepend(FormattingOptions.oneSpace)
+        .append(FormattingOptions.oneSpace)
     })
     this.on(node, ast.isDirectedRelationExpr, (n, f) => {
       f.property('target').prepend(FormattingOptions.oneSpace)

--- a/packages/language-server/src/formatting/LikeC4Formatter.ts
+++ b/packages/language-server/src/formatting/LikeC4Formatter.ts
@@ -109,13 +109,11 @@ export class LikeC4Formatter extends AbstractFormatter {
 
   protected formatTags(node: AstNode) {
     this.on(node, ast.isTags, (n, f) => {
-      const tagNames = GrammarUtils.findNodesForProperty(n.$cstNode, 'values')
-      const hashes = tagNames
-        .map(x => CstUtils.getPreviousNode(x))
+      const tags = GrammarUtils.findNodesForProperty(n.$cstNode, 'values')
         .filter(x => x!!)
         .slice(1) as CstNode[]
 
-      f.cst(hashes)
+      f.cst(tags)
         .prepend(FormattingOptions.oneSpace)
 
       f.keywords(',')

--- a/packages/language-server/src/like-c4.langium
+++ b/packages/language-server/src/like-c4.langium
@@ -91,7 +91,7 @@ Imported:
 // Model -------------------------------------
 
 Tags:
-  (Hash values+=[Tag:Id])+ ({infer Tags.prev=current} ',' (Hash values+=[Tag:Id])*)* ';'?
+  (values+=TagRef)+ ({infer Tags.prev=current} ',' (values+=TagRef)*)* ';'?
 ;
 
 Model:
@@ -448,7 +448,7 @@ RelationExprOrWhere:
 FqnExpr:
   {infer WildcardExpression} isWildcard?='*' |
   // These are not valid in FqnExpr, but we keep for backward compatibility
-  {infer ElementTagExpression} 'element.tag' IsEqual Hash tag=[Tag:Id] |
+  {infer ElementTagExpression} 'element.tag' IsEqual tag=TagRef |
   {infer ElementKindExpression} 'element.kind' IsEqual kind=[ElementKind] |
   FqnRefExpr
 ;
@@ -502,7 +502,7 @@ WhereElementNegation:
   'not' value=WhereElementExpression;
 
 WhereElement:
-  {infer WhereElementTag} 'tag' EqOperator Hash value=[Tag:Id] |
+  {infer WhereElementTag} 'tag' EqOperator value=TagRef |
   {infer WhereElementKind} 'kind' EqOperator value=[DeploymentNodeOrElementKind]
 ;
 
@@ -527,9 +527,9 @@ WhereRelationNegation:
   'not' value=WhereRelationExpression;
 
 WhereRelation:
-  {infer WhereRelationTag} 'tag' EqOperator Hash value=[Tag:Id] |
+  {infer WhereRelationTag} 'tag' EqOperator value=TagRef |
   {infer WhereRelationKind} 'kind' EqOperator value=[RelationshipKind:Id] |
-  {infer WhereRelationParticipantTag} participant=Participant StickyDot 'tag' EqOperator Hash value=[Tag:Id] |
+  {infer WhereRelationParticipantTag} participant=Participant StickyDot 'tag' EqOperator value=TagRef |
   {infer WhereRelationParticipantKind} participant=Participant StickyDot 'kind' EqOperator value=[DeploymentNodeOrElementKind:Id]
 ;
 type DeploymentNodeOrElementKind = ElementKind | DeploymentNodeKind
@@ -765,6 +765,10 @@ ArrowProperty:
 
 RelationshipStyleProperty:
   ColorProperty | LineProperty | ArrowProperty;
+
+TagRef :
+  Hash tag=[Tag:Id]
+;
 
 Boolean returns boolean: 'true' | 'false';
 

--- a/packages/language-server/src/like-c4.langium
+++ b/packages/language-server/src/like-c4.langium
@@ -184,7 +184,7 @@ StrictFqnRef:
 Relation<isExplicit>:
   (<isExplicit> source=FqnRef | <!isExplicit> source=FqnRef?)
   (
-    Dot kind=[RelationshipKind:Id] |
+    dotKind=RelationKindDotRef |
     '-[' kind=[RelationshipKind] ']->' |
     '->'
   )
@@ -342,7 +342,7 @@ DynamicViewParallelSteps:
 
 DynamicViewStep:
   source=ElementRef
-  (isBackward?='<-' |  '->' | '-[' kind=[RelationshipKind] ']->' | Dot kind=[RelationshipKind:Id] )
+  (isBackward?='<-' |  '->' | '-[' kind=[RelationshipKind] ']->' | dotKind=RelationKindDotRef )
   target=ElementRef
   title=String?
   custom=CustomRelationProperties?
@@ -475,7 +475,7 @@ DirectedRelationExpr infers RelationExpr:
 
 OutgoingRelationExpr:
   from=FqnExpr
-  (isBidirectional?='<->' | '->' | '-[' kind=[RelationshipKind:Id] ']->' | Dot kind=[RelationshipKind:Id])
+  (isBidirectional?='<->' | '->' | '-[' kind=[RelationshipKind:Id] ']->' | dotKind=RelationKindDotRef)
 ;
 
 FqnExpressions:
@@ -606,7 +606,7 @@ ExtendDeploymentBody:  '{'
 
 DeploymentRelation<isExplicit>:
   (<isExplicit> source=FqnRef | <!isExplicit> source=FqnRef?)
-  ('->' | '-[' kind=[RelationshipKind:Id] ']->' | Dot kind=[RelationshipKind:Id])
+  ('->' | '-[' kind=[RelationshipKind:Id] ']->' | dotKind=RelationKindDotRef)
   target=FqnRef
   (
     title=String
@@ -768,6 +768,10 @@ RelationshipStyleProperty:
 
 TagRef :
   Hash tag=[Tag:Id]
+;
+
+RelationKindDotRef :
+  Dot kind=[RelationshipKind:Id]
 ;
 
 Boolean returns boolean: 'true' | 'false';

--- a/packages/language-server/src/like-c4.langium
+++ b/packages/language-server/src/like-c4.langium
@@ -91,7 +91,7 @@ Imported:
 // Model -------------------------------------
 
 Tags:
-  (values+=[Tag:TagId])+ ({infer Tags.prev=current} ',' (values+=[Tag:TagId])*)* ';'?
+  (Hash values+=[Tag:Id])+ ({infer Tags.prev=current} ',' (Hash values+=[Tag:Id])*)* ';'?
 ;
 
 Model:
@@ -184,7 +184,7 @@ StrictFqnRef:
 Relation<isExplicit>:
   (<isExplicit> source=FqnRef | <!isExplicit> source=FqnRef?)
   (
-    kind=[RelationshipKind:DotId] |
+    Dot kind=[RelationshipKind:Id] |
     '-[' kind=[RelationshipKind] ']->' |
     '->'
   )
@@ -342,7 +342,7 @@ DynamicViewParallelSteps:
 
 DynamicViewStep:
   source=ElementRef
-  (isBackward?='<-' |  '->' | '-[' kind=[RelationshipKind] ']->' | kind=[RelationshipKind:DotId] )
+  (isBackward?='<-' |  '->' | '-[' kind=[RelationshipKind] ']->' | Dot kind=[RelationshipKind:Id] )
   target=ElementRef
   title=String?
   custom=CustomRelationProperties?
@@ -448,8 +448,8 @@ RelationExprOrWhere:
 FqnExpr:
   {infer WildcardExpression} isWildcard?='*' |
   // These are not valid in FqnExpr, but we keep for backward compatibility
-  {infer ElementTagExpression} 'element.tag' IsEqual tag=[Tag:TagId]? |
-  {infer ElementKindExpression} 'element.kind' IsEqual kind=[ElementKind]? |
+  {infer ElementTagExpression} 'element.tag' IsEqual Hash tag=[Tag:Id] |
+  {infer ElementKindExpression} 'element.kind' IsEqual kind=[ElementKind] |
   FqnRefExpr
 ;
 
@@ -475,7 +475,7 @@ DirectedRelationExpr infers RelationExpr:
 
 OutgoingRelationExpr:
   from=FqnExpr
-  (isBidirectional?='<->' | '->' | '-[' kind=[RelationshipKind:Id] ']->' | kind=[RelationshipKind:DotId])
+  (isBidirectional?='<->' | '->' | '-[' kind=[RelationshipKind:Id] ']->' | Dot kind=[RelationshipKind:Id])
 ;
 
 FqnExpressions:
@@ -502,8 +502,8 @@ WhereElementNegation:
   'not' value=WhereElementExpression;
 
 WhereElement:
-  {infer WhereElementTag} 'tag' EqOperator value=[Tag:TagId]? |
-  {infer WhereElementKind} 'kind' EqOperator value=[DeploymentNodeOrElementKind]?
+  {infer WhereElementTag} 'tag' EqOperator Hash value=[Tag:Id] |
+  {infer WhereElementKind} 'kind' EqOperator value=[DeploymentNodeOrElementKind]
 ;
 
 WhereRelationExpression:
@@ -527,10 +527,10 @@ WhereRelationNegation:
   'not' value=WhereRelationExpression;
 
 WhereRelation:
-  {infer WhereRelationTag} 'tag' EqOperator value=[Tag:TagId]? |
-  {infer WhereRelationKind} 'kind' EqOperator value=[RelationshipKind:Id]? |
-  {infer WhereRelationParticipantTag} participant=Participant StickyDot 'tag' EqOperator value=[Tag:TagId]? |
-  {infer WhereRelationParticipantKind} participant=Participant StickyDot 'kind' EqOperator value=[DeploymentNodeOrElementKind:Id]?
+  {infer WhereRelationTag} 'tag' EqOperator Hash value=[Tag:Id] |
+  {infer WhereRelationKind} 'kind' EqOperator value=[RelationshipKind:Id] |
+  {infer WhereRelationParticipantTag} participant=Participant StickyDot 'tag' EqOperator Hash value=[Tag:Id] |
+  {infer WhereRelationParticipantKind} participant=Participant StickyDot 'kind' EqOperator value=[DeploymentNodeOrElementKind:Id]
 ;
 type DeploymentNodeOrElementKind = ElementKind | DeploymentNodeKind
 type WhereTagEqual = WhereElementTag | WhereRelationTag | WhereRelationParticipantTag;
@@ -606,7 +606,7 @@ ExtendDeploymentBody:  '{'
 
 DeploymentRelation<isExplicit>:
   (<isExplicit> source=FqnRef | <!isExplicit> source=FqnRef?)
-  ('->' | '-[' kind=[RelationshipKind:Id] ']->' | kind=[RelationshipKind:DotId])
+  ('->' | '-[' kind=[RelationshipKind:Id] ']->' | Dot kind=[RelationshipKind:Id])
   target=FqnRef
   (
     title=String
@@ -802,12 +802,6 @@ IconId returns string:
 
 Uri returns string:
   URI_WITH_SCHEMA | URI_RELATIVE;
-
-TagId returns string:
-  Hash Id;
-
-DotId returns string:
-  Dot Id;
 
 CustomColorId returns string:
   IdTerminal | ElementShape | ArrowType | LineOptions | 'element' | 'model';

--- a/packages/language-server/src/lsp/CompletionProvider.spec.ts
+++ b/packages/language-server/src/lsp/CompletionProvider.spec.ts
@@ -183,7 +183,7 @@ describe.concurrent('LikeC4CompletionProvider', () => {
       }
       model {
         actor customer {
-          <|>#tag1 #tag2 <|>
+          <|>#tag1 #tag2 #<|>tag3
         }
         <|>
       }
@@ -197,9 +197,6 @@ describe.concurrent('LikeC4CompletionProvider', () => {
         expect(completions.items).not.to.be.empty
         const labels = pluck('label', completions.items)
         expect(labels).to.include.members([
-          '#tag1',
-          '#tag2',
-          '#tag3',
           'title',
           'technology',
           'description',
@@ -219,9 +216,9 @@ describe.concurrent('LikeC4CompletionProvider', () => {
         expect(completions.items).not.to.be.empty
         const labels = pluck('label', completions.items)
         expect(labels).to.include.members([
-          '#tag1',
-          '#tag2',
-          '#tag3',
+          'tag1',
+          'tag2',
+          'tag3',
         ])
         expect(labels).not.to.include.members(['extend'])
       },
@@ -417,8 +414,8 @@ describe.concurrent('LikeC4CompletionProvider', () => {
           expect(completions.items).not.to.be.empty
           const first = take(completions.items, 2)
           expect(pluck('label', first)).toEqual([
-            '#tag1',
-            '#tag2',
+            'tag1',
+            'tag2',
           ])
         },
         disposeAfterCheck: true,
@@ -427,8 +424,8 @@ describe.concurrent('LikeC4CompletionProvider', () => {
         text,
         index: 1,
         expectedItems: [
-          '#tag1',
-          '#tag2',
+          'tag1',
+          'tag2',
         ],
         disposeAfterCheck: true,
       })
@@ -471,7 +468,7 @@ describe.concurrent('LikeC4CompletionProvider', () => {
           view {
             include
               * where (
-                tag == <|>#tag1 and
+                tag == #<|>tag1 and
                 tag is not #<|>tag2 or
                 kind != <|>service
               )
@@ -507,7 +504,7 @@ describe.concurrent('LikeC4CompletionProvider', () => {
             group {
               include
                 * where (
-                  tag == <|>#tag1 and
+                  tag == #<|>tag1 and
                   tag is not #<|>tag2 or
                   kind != <|>service
                 )
@@ -663,44 +660,30 @@ describe.concurrent('LikeC4CompletionProvider', () => {
       model {
         c1 = component
         c2 = component {
-          <|>#<|>deprecated
-          -> c1 <|>
+          #<|>deprecated
+          -> c1 #<|>
         }
       }
 
     `
     const completion = expectCompletion()
 
-    await completion({
-      text,
-      index: 0,
-      assert: completions => {
-        expect(completions.items).not.to.be.empty
-        const first = take(completions.items, 2)
-        expect(pluck('label', first)).toEqual([
-          '#deprecated',
-          '#experimental',
-        ])
-      },
-      disposeAfterCheck: true,
-    })
-
     // #<|>deprecated
     await completion({
       text,
-      index: 1,
-      expectedItems: ['#deprecated', '#experimental'],
+      index: 0,
+      expectedItems: ['deprecated', 'experimental'],
     })
     // > c1 <|>
     await completion({
       text,
-      index: 2,
+      index: 1,
       assert: completions => {
         expect(completions.items).not.to.be.empty
         const first = take(completions.items, 2)
         expect(pluck('label', first)).toEqual([
-          '#deprecated',
-          '#experimental',
+          'deprecated',
+          'experimental',
         ])
       },
       disposeAfterCheck: true,

--- a/packages/language-server/src/lsp/CompletionProvider.ts
+++ b/packages/language-server/src/lsp/CompletionProvider.ts
@@ -28,7 +28,7 @@ export class LikeC4CompletionProvider extends DefaultCompletionProvider {
   }
 
   override readonly completionOptions = {
-    triggerCharacters: ['.'],
+    triggerCharacters: ['.', '#'],
   } satisfies CompletionProviderOptions
 
   protected override completionForKeyword(

--- a/packages/language-server/src/model/model-parser-where.ts
+++ b/packages/language-server/src/model/model-parser-where.ts
@@ -31,7 +31,7 @@ function parseParticipant(astNode: ast.WhereExpression): ast.Participant | null 
 export function parseWhereClause(astNode: ast.WhereExpression): c4.WhereOperator<string, string> {
   switch (true) {
     case ast.isWhereTagEqual(astNode): {
-      const tag = astNode.value?.ref?.name
+      const tag = astNode.value.tag.ref?.name
       const participant = parseParticipant(astNode)
       invariant(tag, 'Expected tag name')
       const tagOperator = { tag: parseEquals(astNode, tag) }

--- a/packages/language-server/src/model/parser/Base.ts
+++ b/packages/language-server/src/model/parser/Base.ts
@@ -112,7 +112,7 @@ export class BaseParser {
     while (iter) {
       try {
         if (this.isValid(iter)) {
-          const values = iter.values.map(t => t.ref?.name).filter(isTruthy) as c4.Tag[]
+          const values = iter.values.map(t => t.tag.ref?.name).filter(isTruthy) as c4.Tag[]
           if (values.length > 0) {
             tags.push(...values)
           }

--- a/packages/language-server/src/model/parser/DeploymentModelParser.ts
+++ b/packages/language-server/src/model/parser/DeploymentModelParser.ts
@@ -188,7 +188,7 @@ export function DeploymentModelParser<TBase extends WithExpressionV2>(B: TBase) 
 
       const tags = this.convertTags(astNode) ?? this.convertTags(astNode.body)
       const links = this.convertLinks(astNode.body)
-      const kind = astNode.kind?.ref?.name as (c4.RelationshipKind | undefined)
+      const kind = (astNode.kind ?? astNode.dotKind?.kind)?.ref?.name as (c4.RelationshipKind | undefined)
       const metadata = this.getMetadata(astNode.body?.props.find(ast.isMetadataProperty))
 
       const bodyProps = mapToObj(

--- a/packages/language-server/src/model/parser/FqnRefParser.ts
+++ b/packages/language-server/src/model/parser/FqnRefParser.ts
@@ -208,11 +208,8 @@ export function ExpressionV2Parser<TBase extends Base>(B: TBase) {
         }
       }
       if (ast.isElementTagExpression(astNode)) {
-        invariant(astNode.tag?.ref, 'ElementTagExpr tag is not resolved: ' + astNode.$cstNode?.text)
-        let elementTag = astNode.tag.$refText
-        if (elementTag.startsWith('#')) {
-          elementTag = elementTag.slice(1)
-        }
+        invariant(astNode.tag.tag.ref, 'ElementTagExpr tag is not resolved: ' + astNode.$cstNode?.text)
+        let elementTag = astNode.tag.tag.$refText
         return {
           elementTag: elementTag as c4.Tag,
           isEqual: astNode.isEqual,

--- a/packages/language-server/src/model/parser/ModelParser.ts
+++ b/packages/language-server/src/model/parser/ModelParser.ts
@@ -158,7 +158,7 @@ export function ModelParser<TBase extends WithExpressionV2>(B: TBase) {
 
       const tags = this.parseTags(astNode) ?? this.parseTags(astNode.body)
       const links = this.parseLinks(astNode.body)
-      const kind = astNode.kind?.ref?.name as (c4.RelationshipKind | undefined)
+      const kind = (astNode.kind ?? astNode.dotKind?.kind)?.ref?.name as (c4.RelationshipKind | undefined)
       const metadata = this.getMetadata(astNode.body?.props.find(ast.isMetadataProperty))
       const astPath = this.getAstNodePath(astNode)
 

--- a/packages/language-server/src/references/scope-computation.ts
+++ b/packages/language-server/src/references/scope-computation.ts
@@ -190,7 +190,7 @@ export class LikeC4ScopeComputation extends DefaultScopeComputation {
           case ast.isSpecificationTag(spec): {
             if (isTruthy(spec.tag.name)) {
               docExports.push(
-                this.descriptions.createDescription(spec.tag, '#' + spec.tag.name, document),
+                this.descriptions.createDescription(spec.tag, spec.tag.name, document),
               )
             }
             continue
@@ -199,7 +199,6 @@ export class LikeC4ScopeComputation extends DefaultScopeComputation {
             if (isTruthy(spec.kind.name)) {
               docExports.push(
                 this.descriptions.createDescription(spec.kind, spec.kind.name, document),
-                this.descriptions.createDescription(spec.kind, '.' + spec.kind.name, document),
               )
             }
             continue

--- a/packages/language-server/src/validation/specification.ts
+++ b/packages/language-server/src/validation/specification.ts
@@ -112,7 +112,7 @@ export const checkDeploymentNodeKind = (services: LikeC4Services): ValidationChe
 export const checkTag = (services: LikeC4Services): ValidationCheck<ast.Tag> => {
   const index = services.shared.workspace.IndexManager
   return tryOrLog((node, accept) => {
-    const tagname = '#' + node.name
+    const tagname = node.name
     const projectId = projectIdFrom(node)
     const sameTag = index
       .projectElements(projectId, ast.Tag)

--- a/packages/vscode/likec4.tmLanguage.json
+++ b/packages/vscode/likec4.tmLanguage.json
@@ -44,6 +44,10 @@
       }
     },
     {
+      "match": "(#)([a-zA-Z0-9]+)",
+      "name": "entity.name.type.enum.likec4"
+    },
+    {
       "match": "\\b(opacity):?\\s+([^\\s]+)",
       "captures": {
         "1": {


### PR DESCRIPTION
Reference to tag was defined as Hash + Id. Thus, LSP replaces the whole reference with the new value.
Splitting TagId into two terminals solves the problem at a cost of more verbose grammar.
Side effect for user - suggestions on tags are shown only after the Hash is written, on the other hand it allows us to use hash as a trigger for autocompletion.

Also, I noticed that in WhereExpressions tag value was marked as 'optional' thus the following expressions were correct:
```
include * where tag is or kind is something
```
I was not able to find any reasons for 'optional tag value' and according to unit tests it is not necessary. I removed it. Probably, that was a workaround for some problem?

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask, and propose improvements. We're here to help. -->

- [x] I've thoroughly read the latest [contribution guidelines](https://github.com/likec4/likec4/blob/main/CONTRIBUTING.md).
- [x] I've rebased my branch onto `main` **before** creating this PR.
- [x] I've added tests to cover my changes (if applicable).
- [x] I've verified that all new and existing tests have passed locally for mobile, tablet, and desktop screen sizes.
- [x] My commit messages follow [conventional spec](https://www.conventionalcommits.org/en/)
- [ ] My change requires documentation updates.
- [ ] I've updated the documentation accordingly.
- [x] My code follows existing patterns of this project and/or improves upon them.

---

Closes #1819