### PR TITLE
hotfix: downgrade wasm-graphviz

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,8 +149,8 @@ catalogs:
       version: 1.114.17
   utils:
     '@hpcc-js/wasm-graphviz':
-      specifier: 1.8.0
-      version: 1.8.0
+      specifier: 1.7.0
+      version: 1.7.0
     '@types/picomatch':
       specifier: ^4.0.0
       version: 4.0.0
@@ -440,7 +440,7 @@ importers:
         version: 0.5.2(hono@4.8.3)(valibot@1.1.0(typescript@5.8.3))
       '@hpcc-js/wasm-graphviz':
         specifier: catalog:utils
-        version: 1.8.0
+        version: 1.7.0
       '@likec4/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -947,7 +947,7 @@ importers:
     dependencies:
       '@hpcc-js/wasm-graphviz':
         specifier: catalog:utils
-        version: 1.8.0
+        version: 1.7.0
     devDependencies:
       '@likec4/core':
         specifier: workspace:*
@@ -1089,7 +1089,7 @@ importers:
     dependencies:
       '@hpcc-js/wasm-graphviz':
         specifier: catalog:utils
-        version: 1.8.0
+        version: 1.7.0
       '@likec4/core':
         specifier: workspace:*
         version: link:../core
@@ -1165,7 +1165,7 @@ importers:
     dependencies:
       '@hpcc-js/wasm-graphviz':
         specifier: catalog:utils
-        version: 1.8.0
+        version: 1.7.0
       '@likec4/core':
         specifier: workspace:*
         version: link:../core
@@ -1521,7 +1521,7 @@ importers:
     devDependencies:
       '@hpcc-js/wasm-graphviz':
         specifier: catalog:utils
-        version: 1.8.0
+        version: 1.7.0
       '@likec4/core':
         specifier: workspace:*
         version: link:../core
@@ -2791,8 +2791,8 @@ packages:
       hono: '>=3.9.0'
       valibot: ^1.0.0 || ^1.0.0-beta.4 || ^1.0.0-rc
 
-  '@hpcc-js/wasm-graphviz@1.8.0':
-    resolution: {integrity: sha512-aLQveMOReqKk0t1XLnQ0mhEuJiXInNwBVW4ASclpcETKlpvF+tIL2N+l8buQsoFEiyc5EYbNtedNX/Zk89fjjQ==}
+  '@hpcc-js/wasm-graphviz@1.7.0':
+    resolution: {integrity: sha512-/1XEmubfDz1UolKiVh6H4BrGX0DZwR39Y2h76LdqR17FZ3gCJoUs4jV7kUywedXerbwx1szhU3dBsNcvkEmjiQ==}
 
   '@hutson/parse-repository-url@3.0.2':
     resolution: {integrity: sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q==}
@@ -10424,7 +10424,7 @@ snapshots:
       hono: 4.8.3
       valibot: 1.1.0(typescript@5.8.3)
 
-  '@hpcc-js/wasm-graphviz@1.8.0': {}
+  '@hpcc-js/wasm-graphviz@1.7.0': {}
 
   '@hutson/parse-repository-url@3.0.2': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,7 +24,7 @@ catalogs:
     std-env: ^3.9.0
     consola: ^3.4.2
     chroma-js: ^3.1.2
-    "@hpcc-js/wasm-graphviz": 1.8.0
+    "@hpcc-js/wasm-graphviz": 1.7.0
     valibot: ^1.1.0
     "@valibot/to-json-schema": ^1.3.0
     esm-env: ^1.2.2


### PR DESCRIPTION
`@hpcc-js/wasm-graphviz 1.8.0` causes a error in vscode, revert to `1.7.0`

Fixes #2073