### PR TITLE
fix(vscode): Client LikeC4 Language Server: connection to server is erroring

### DIFF
--- a/packages/vscode/scripts/build.mts
+++ b/packages/vscode/scripts/build.mts
@@ -106,7 +106,7 @@ configs.push({
   target: 'es2022',
   platform: 'browser',
   plugins: [nodeModulesPolyfillPlugin()],
-  conditions: ['sources', 'browser'],
+  conditions: ['sources', 'worker', 'browser'],
 }, {
   ...base,
   sourcemap: isDev,
@@ -116,7 +116,7 @@ configs.push({
   target: 'es2022',
   platform: 'browser',
   plugins: [nodeModulesPolyfillPlugin()],
-  conditions: ['sources', 'browser'],
+  conditions: ['sources', 'worker', 'browser'],
 })
 
 let hasErrors = false


### PR DESCRIPTION
In web version:

```
Client LikeC4 Language Server: connection to server is erroring.
Writer received error. Reason: Uncaught NetworkError: Failed to execute 'importScripts' on 'WorkerGlobalScope': The script at 'https://likec4.vscode-unpkg.net/likec4/likec4-vscode/1.35.0/extension/dist/browser/language-server-worker.js' failed to load.
Shutting down server.
```