### PR TITLE
fix: problems when exporting to PNG

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -80,6 +80,7 @@
     {
       enabled: false,
       matchPackageNames: [
+        'html-to-image',
         '/^monaco/',
         '/^@monaco/',
         '/^@codingame/',

--- a/packages/likec4/package.json
+++ b/packages/likec4/package.json
@@ -181,7 +181,7 @@
     "fast-equals": "catalog:utils",
     "fdir": "catalog:utils",
     "get-port": "^7.1.0",
-    "html-to-image": "^1.11.13",
+    "html-to-image": "1.11.11",
     "is-inside-container": "^1.0.0",
     "json5": "catalog:utils",
     "ky": "^1.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1352,8 +1352,8 @@ importers:
         specifier: ^7.1.0
         version: 7.1.0
       html-to-image:
-        specifier: ^1.11.13
-        version: 1.11.13
+        specifier: 1.11.11
+        version: 1.11.11
       is-inside-container:
         specifier: ^1.0.0
         version: 1.0.0
@@ -5551,8 +5551,8 @@ packages:
   html-escaper@3.0.3:
     resolution: {integrity: sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==}
 
-  html-to-image@1.11.13:
-    resolution: {integrity: sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==}
+  html-to-image@1.11.11:
+    resolution: {integrity: sha512-9gux8QhvjRO/erSnDPv28noDZcPZmYE7e1vFsBLKLlRlKDSqNJYebj6Qz1TGd5lsRV+X+xYyjCKjuZdABinWjA==}
 
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
@@ -13941,7 +13941,7 @@ snapshots:
 
   html-escaper@3.0.3: {}
 
-  html-to-image@1.11.13: {}
+  html-to-image@1.11.11: {}
 
   html-void-elements@3.0.0: {}
 


### PR DESCRIPTION
Caused by https://github.com/bubkoo/html-to-image/issues/506
Downgrade `html-to-image` to `1.11.11`

Fixes #1211
