### PR TITLE
fix(vscode): multi-projects on windows

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 nodejs 20.19.3
 dprint 0.50.1
-pnpm 10.14.0
+pnpm 10.15.0

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "license": "MIT",
   "type": "module",
-  "packageManager": "pnpm@10.14.0",
+  "packageManager": "pnpm@10.15.0",
   "scripts": {
     "install:chromium": "playwright install chromium",
     "generate:png": "likec4 export png -o ./generated/images --flat",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.38.0",
   "private": true,
   "license": "MIT",
-  "packageManager": "pnpm@10.14.0",
+  "packageManager": "pnpm@10.15.0",
   "type": "module",
   "workspaces": [
     "apps/*",

--- a/packages/core/src/utils/compare-natural.spec.ts
+++ b/packages/core/src/utils/compare-natural.spec.ts
@@ -182,4 +182,57 @@ describe('compareNaturalHierarchically', () => {
       'a',
     ])
   })
+
+  it('should sort deeper paths first when deepestFirst=true', () => {
+    const sortDeepFirst = (array: Array<string | undefined>, separator = '.') =>
+      remedaSort(array, compareNaturalHierarchically(separator, true))
+
+    expect(
+      sortDeepFirst([
+        'a',
+        'a.b',
+        'a.b.c',
+        'a.a',
+      ]),
+    ).toEqual([
+      'a.a',
+      'a.b.c',
+      'a.b',
+      'a',
+    ])
+
+    // Ensure deeper comes first within same prefix and preserves natural order for differing segments
+    expect(
+      sortDeepFirst([
+        'x.2',
+        'x.10',
+        'x',
+        'x.1',
+      ]),
+    ).toEqual([
+      'x.1',
+      'x.2',
+      'x.10',
+      'x',
+    ])
+  })
+
+  it('should sort deeper paths first with a custom separator', () => {
+    const sortDeepFirst = (array: Array<string | undefined>, separator = '/') =>
+      remedaSort(array, compareNaturalHierarchically(separator, true))
+
+    expect(
+      sortDeepFirst([
+        'a/b/c',
+        'a',
+        'a/b',
+        'a/a',
+      ]),
+    ).toEqual([
+      'a/a',
+      'a/b/c',
+      'a/b',
+      'a',
+    ])
+  })
 })

--- a/packages/core/src/utils/compare-natural.ts
+++ b/packages/core/src/utils/compare-natural.ts
@@ -31,6 +31,7 @@ export function compareNatural(a: string | undefined, b: string | undefined): -1
  */
 export function compareNaturalHierarchically(
   separator = '.',
+  deepestFirst = false,
 ): (a: string | undefined, b: string | undefined) => number {
   return (a, b) => {
     if (a === b) return 0
@@ -52,7 +53,8 @@ export function compareNaturalHierarchically(
       }
     }
 
-    // If all common segments are equal, shorter paths come first
-    return aParts.length - bParts.length
+    // If all common segments are equal, shorter paths come first (if deepestFirst is false)
+    const diff = aParts.length - bParts.length
+    return deepestFirst ? -1 * diff : diff
   }
 }

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -93,7 +93,7 @@
     "build": "unbuild",
     "pack": "pnpm pack",
     "postpack": "cp likec4-language-server-$npm_package_version.tgz package.tgz || true",
-    "pregenerate": "rm -f src/generated/*",
+    "pregenerate": "rm -f src/generated/* || true",
     "watch:langium": "langium generate --watch",
     "watch:ts": "tsc --watch",
     "generate": "langium generate && tsx scripts/generate-icons.ts",

--- a/packages/language-server/src/LikeC4LanguageServices.ts
+++ b/packages/language-server/src/LikeC4LanguageServices.ts
@@ -65,6 +65,7 @@ export interface LikeC4LanguageServices {
 
   /**
    * Notifies the language server about changes in the workspace
+   * @deprecated use watcher instead
    */
   notifyUpdate(update: { changed?: string; removed?: string }): Promise<boolean>
 

--- a/packages/language-server/src/Rpc.ts
+++ b/packages/language-server/src/Rpc.ts
@@ -76,8 +76,10 @@ export class Rpc extends ADisposable {
       connection.onRequest(FetchComputedModel.req, async ({ projectId, cleanCaches }, cancelToken) => {
         logger.debug`received request ${'fetchComputedModel'} for project ${projectId}`
         if (cleanCaches) {
-          const docs = projectId ? LangiumDocuments.projectDocuments(projectId as ProjectId) : LangiumDocuments.all
-          const uris = docs.map(d => d.uri).toArray()
+          const docs = projectId
+            ? LangiumDocuments.projectDocuments(projectId as ProjectId)
+            : LangiumDocuments.allExcludingBuiltin
+          const uris = docs.toArray().map(d => d.uri)
           await DocumentBuilder.update(uris, [], cancelToken)
         }
         const likec4model = await modelBuilder.buildLikeC4Model(projectId as ProjectId, cancelToken)

--- a/packages/language-server/src/model/builder/MergedSpecification.ts
+++ b/packages/language-server/src/model/builder/MergedSpecification.ts
@@ -44,7 +44,7 @@ export class MergedSpecification {
 
   public readonly imports: MultiMap<c4.ProjectId, c4.Fqn, Set<c4.Fqn>> = new MultiMap(Set)
 
-  constructor(docs: ParsedLikeC4LangiumDocument[]) {
+  constructor(docs: ReadonlyArray<ParsedLikeC4LangiumDocument>) {
     const tags = {} as ParsedAstSpecification['tags']
     for (const doc of docs) {
       const {

--- a/packages/language-server/src/model/builder/buildModel.ts
+++ b/packages/language-server/src/model/builder/buildModel.ts
@@ -53,7 +53,7 @@ export function buildModelData(
     folderUri: URI
     config: Readonly<ProjectConfig>
   },
-  docs: ParsedLikeC4LangiumDocument[],
+  docs: ReadonlyArray<ParsedLikeC4LangiumDocument>,
 ): BuildModelData {
   const c4Specification = new MergedSpecification(docs)
 

--- a/packages/language-server/src/workspace/LangiumDocuments.ts
+++ b/packages/language-server/src/workspace/LangiumDocuments.ts
@@ -1,13 +1,36 @@
 import type { NonEmptyArray, ProjectId } from '@likec4/core'
-import { type Stream, DefaultLangiumDocuments } from 'langium'
+import { compareNaturalHierarchically } from '@likec4/core/utils'
+import type { LangiumDocument, Stream } from 'langium'
+import { DefaultLangiumDocuments } from 'langium'
 import { groupBy, prop } from 'remeda'
 import { type LikeC4LangiumDocument, isLikeC4LangiumDocument } from '../ast'
 import { isLikeC4Builtin } from '../likec4lib'
 import type { LikeC4SharedServices } from '../module'
 
+/**
+ * Compare function for document paths to ensure consistent order
+ */
+const compare = compareNaturalHierarchically('/', true)
+const ensureOrder = (a: LangiumDocument, b: LangiumDocument) => compare(a.uri.path, b.uri.path)
+
 export class LangiumDocuments extends DefaultLangiumDocuments {
+  protected compare = compareNaturalHierarchically('/', true)
+
   constructor(protected services: LikeC4SharedServices) {
     super(services)
+  }
+
+  override addDocument(document: LangiumDocument): void {
+    const uriString = document.uri.toString()
+    if (this.documentMap.has(uriString)) {
+      throw new Error(`A document with the URI '${uriString}' is already present.`)
+    }
+    const docs = [...this.documentMap.values(), document].sort(ensureOrder)
+    // Clear and re-add documents to ensure consistent order
+    this.documentMap.clear()
+    for (const doc of docs) {
+      this.documentMap.set(doc.uri.toString(), doc)
+    }
   }
 
   /**

--- a/packages/language-server/src/workspace/ProjectsManager.spec.ts
+++ b/packages/language-server/src/workspace/ProjectsManager.spec.ts
@@ -1,7 +1,8 @@
 import type { ProjectId } from '@likec4/core'
-import { describe, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { URI } from 'vscode-uri'
 import { createMultiProjectTestServices } from '../test'
+import { ProjectFolder } from './ProjectsManager'
 
 describe.concurrent('ProjectsManager', () => {
   it('should assign likec4ProjectId to docs', async ({ expect }) => {
@@ -274,65 +275,33 @@ describe.concurrent('ProjectsManager', () => {
         'default',
       ])
     })
-
-    it('should handle folder URIs with and without protocol', async ({ expect }) => {
-      const { projectsManager } = await createMultiProjectTestServices({})
-
-      const config = {
-        name: 'test-project',
-      }
-      const folderUri1 = URI.parse('file:///test/workspace/src/test-project-1')
-      const folderUri2 = '/test/workspace/src/test-project-2'
-
-      await projectsManager.registerProject({
-        config,
-        folderUri: folderUri1,
-      })
-      await projectsManager.registerProject({
-        config,
-        folderUri: folderUri2,
-      })
-
-      expect(projectsManager.all).toContain('test-project')
-      expect(projectsManager.all).toContain('test-project-1')
-      expect(projectsManager.getProject('test-project' as ProjectId).folderUri.toString()).toBe(
-        'file:///test/workspace/src/test-project-1/',
-      )
-      expect(projectsManager.getProject('test-project-1' as ProjectId).folderUri.toString()).toBe(
-        'file:///test/workspace/src/test-project-2/',
-      )
-    })
   })
 
-  it('should handle folder URIs with special characters', async ({ expect }) => {
+  it('should handle folder URIs with and without protocol', async ({ expect }) => {
     const { projectsManager } = await createMultiProjectTestServices({})
 
-    const folderUri1 = 'c:\\my\\files'
-    const folderUri2 = 'c:\\my\\files-ext'
-    const folderUri3 = '/coding/c#/project1'
+    const config = {
+      name: 'test-project',
+    }
+    const folderUri1 = URI.parse('file:///test/workspace/src/test-project-1')
+    const folderUri2 = '/test/workspace/src/test-project-2'
 
     await projectsManager.registerProject({
-      config: { name: 'test1' },
+      config,
       folderUri: folderUri1,
     })
     await projectsManager.registerProject({
-      config: { name: 'test2' },
+      config,
       folderUri: folderUri2,
     })
-    await projectsManager.registerProject({
-      config: { name: 'test3' },
-      folderUri: folderUri3,
-    })
 
-    expect.soft(projectsManager.all).to.include.members(['test1', 'test2', 'test3'])
-    expect.soft(projectsManager.getProject('test1' as ProjectId).folderUri.toString()).toBe(
-      'file://c:/my/files/',
+    expect(projectsManager.all).toContain('test-project')
+    expect(projectsManager.all).toContain('test-project-1')
+    expect(projectsManager.getProject('test-project' as ProjectId).folderUri.toString()).toBe(
+      'file:///test/workspace/src/test-project-1/',
     )
-    expect.soft(projectsManager.getProject('test2' as ProjectId).folderUri.toString()).toBe(
-      'file://c:/my/files-ext/',
-    )
-    expect(projectsManager.getProject('test3' as ProjectId).folderUri.toString()).toBe(
-      'file:///coding/c#/project1/',
+    expect(projectsManager.getProject('test-project-1' as ProjectId).folderUri.toString()).toBe(
+      'file:///test/workspace/src/test-project-2/',
     )
   })
 
@@ -373,5 +342,85 @@ describe.concurrent('ProjectsManager', () => {
     expect(pm.belongsTo('file:///test/project1/sub1-doc.likec4')).toEqual('project1')
     expect(pm.belongsTo('file:///test/qwe/doc.likec4')).toEqual('qwe')
     expect(pm.belongsTo('file:///test/qwe-qwe/doc.likec4')).toEqual('qwe-qwe')
+  })
+
+  describe.runIf(process.platform === 'win32')('On Windows', () => {
+    it('should handle folder URIs', async ({ expect }) => {
+      const { projectsManager } = await createMultiProjectTestServices({})
+
+      const folderUri1 = 'c:\\my\\files'
+      const folderUri2 = 'c:\\my\\files-ext'
+
+      await projectsManager.registerProject({
+        config: { name: 'test1' },
+        folderUri: folderUri1,
+      })
+      await projectsManager.registerProject({
+        config: { name: 'test2' },
+        folderUri: folderUri2,
+      })
+
+      expect.soft(projectsManager.all).to.include.members(['test1', 'test2'])
+      expect.soft(projectsManager.getProject('test1' as ProjectId).folderUri.toString()).toBe(
+        'file:///c%3A/my/files/',
+      )
+      expect.soft(projectsManager.getProject('test2' as ProjectId).folderUri.toString()).toBe(
+        'file:///c%3A/my/files-ext/',
+      )
+    })
+
+    it('should exclude node_modules', async ({ expect }) => {
+      const { projectsManager: pm } = await createMultiProjectTestServices({})
+
+      await pm.registerProject({
+        config: {
+          name: 'test1',
+          exclude: ['**/node_modules/**'],
+        },
+        folderUri: 'c:\\my\\files',
+      })
+      expect(pm.checkIfExcluded('c:\\my\\files\\doc.likec4')).toEqual(false)
+      expect(pm.checkIfExcluded('c:\\my\\files\\node_modules\\doc.likec4')).toEqual(true)
+    })
+
+    it('should correctly return project for documents', async ({ expect }) => {
+      const { projectsManager: pm } = await createMultiProjectTestServices({})
+
+      const projects = [
+        'project1',
+        'project1\\sub1',
+        'qwe',
+        'qwe-qwe', // https://github.com/likec4/likec4/issues/2099
+      ]
+      for (const project of projects) {
+        await pm.registerProject({
+          config: { name: project },
+          folderUri: `c:\\my\\files\\${project}`,
+        })
+      }
+
+      expect(pm.belongsTo('file:///test/outside/doc.likec4')).toEqual('default')
+      expect(pm.belongsTo('c:\\my\\files\\project1\\doc.likec4')).toEqual('project1')
+      expect(pm.belongsTo('c:\\my\\files\\project1\\sub1\\doc.likec4')).toEqual('project1\\sub1')
+      expect(pm.belongsTo('c:\\my\\files\\project1\\sub1\\f1\\doc.likec4')).toEqual('project1\\sub1')
+      expect(pm.belongsTo('c:\\my\\files\\project1\\sub1-doc.likec4')).toEqual('project1')
+      expect(pm.belongsTo('c:\\my\\files\\qwe\\doc.likec4')).toEqual('qwe')
+      expect(pm.belongsTo('c:\\my\\files\\qwe-qwe\\doc.likec4')).toEqual('qwe-qwe')
+    })
+  })
+})
+
+describe('ProjectFolder', () => {
+  it.each([
+    ['file:///test/project1', 'file:///test/project1/'],
+    ['/test/project1', 'file:///test/project1/'],
+    ['file:///test/project1/', 'file:///test/project1/'],
+    ['/test/project1/', 'file:///test/project1/'],
+    ['file:///test/project1/sub1', 'file:///test/project1/sub1/'],
+    ['file:///test/project1/sub1/', 'file:///test/project1/sub1/'],
+    [URI.parse('file:///test/project1'), 'file:///test/project1/'],
+    [URI.file('/test/project1'), 'file:///test/project1/'],
+  ])('convert %s -> %s', (input, expected) => {
+    expect(ProjectFolder(input)).toEqual(expected)
   })
 })

--- a/packages/language-server/src/workspace/ProjectsManager.ts
+++ b/packages/language-server/src/workspace/ProjectsManager.ts
@@ -10,18 +10,14 @@ import {
   URI,
   WorkspaceCache,
 } from 'langium'
-import { UriUtils } from 'langium'
 import PQueue from 'p-queue'
 import picomatch from 'picomatch'
 import { hasAtLeast, isNullish, isTruthy, map, pickBy, pipe, prop, sortBy } from 'remeda'
 import type { Tagged } from 'type-fest'
 import {
-  hasProtocol,
   joinRelativeURL,
-  normalizeURL,
   parseFilename,
   withoutProtocol,
-  withProtocol,
   withTrailingSlash,
 } from 'ufo'
 import { parseConfigJson, ProjectConfig, validateConfig } from '../config'
@@ -30,19 +26,25 @@ import type { LikeC4SharedServices } from '../module'
 
 const logger = mainLogger.getChild('ProjectsManager')
 
+function normalizeUri(uri: LangiumDocument | string | URI): string {
+  if (URI.isUri(uri)) {
+    return uri.toString()
+  } else if (typeof uri === 'string') {
+    // TODO: handle non-file URIs, i.e. vscode-remote://
+    return uri.startsWith('file://') ? uri : URI.file(uri).toString()
+  } else {
+    return uri.uri.toString()
+  }
+}
+
 /**
  * A tagged string that represents a project folder URI
  * Always has trailing slash.
  */
 export type ProjectFolder = Tagged<string, 'ProjectFolder'>
 export function ProjectFolder(folder: URI | string): ProjectFolder {
-  if (!URI.isUri(folder)) {
-    //   folder = folder.toString()
-    // } else {
-    // folder = folder.startsWith('file://') ? folder : URI.file(folder).toString()
-    folder = URI.file(folder).toString()
-  }
-  return withTrailingSlash(UriUtils.normalize(folder)) as ProjectFolder
+  folder = normalizeUri(folder)
+  return withTrailingSlash(folder) as ProjectFolder
 }
 
 interface ProjectData {
@@ -175,7 +177,7 @@ export class ProjectsManager {
 
   checkIfExcluded(document: LangiumDocument | URI | string): boolean {
     if (typeof document === 'string' || URI.isUri(document)) {
-      let docUriAsString = typeof document === 'string' ? document : document.toString()
+      let docUriAsString = normalizeUri(document)
       const project = this.findProjectForDocument(docUriAsString)
       return project.exclude ? project.exclude(withoutProtocol(docUriAsString)) : false
     }
@@ -305,14 +307,7 @@ export class ProjectsManager {
   }
 
   belongsTo(document: LangiumDocument | URI | string): ProjectId {
-    let documentUri: string
-    if (typeof document === 'string') {
-      documentUri = hasProtocol(document) ? document : withProtocol(document, 'file://')
-    } else if (URI.isUri(document)) {
-      documentUri = document.toString()
-    } else {
-      documentUri = document.uri.toString()
-    }
+    const documentUri = normalizeUri(document)
     return this.findProjectForDocument(documentUri).id
   }
 

--- a/packages/likec4/src/LikeC4.spec.ts
+++ b/packages/likec4/src/LikeC4.spec.ts
@@ -1,4 +1,6 @@
+import { UriUtils } from 'langium'
 import path from 'path'
+import { map, mapToObj, pipe } from 'remeda'
 import { describe, it } from 'vitest'
 import { LikeC4 } from './LikeC4'
 
@@ -157,37 +159,73 @@ describe.concurrent('LikeC4', () => {
     })
     expect(likec4.hasErrors()).toBe(false)
 
-    const projects = likec4.languageServices.projects().map(p => ({
-      id: p.id,
-      folder: p.folder.toString(),
-    }))
+    const projects = pipe(
+      likec4.languageServices.projects(),
+      mapToObj(p => [p.id, {
+        folder: UriUtils.basename(p.folder),
+        documents: map(p.documents, d => UriUtils.relative(p.folder, d)),
+      }]),
+    )
     expect(projects).toMatchInlineSnapshot(`
-      [
-        {
-          "folder": "file:///Users/davydkov/Projects/like-c4/likec4/examples/failed/",
-          "id": "failed",
+      {
+        "boutique": {
+          "documents": [
+            "_spec.c4",
+            "deployment/deployment.c4",
+            "deployment/deployment.development.c4",
+            "deployment/deployment.production.c4",
+            "model.c4",
+            "model.views.c4",
+            "use-cases/usecase.order-fullfillment.c4",
+            "use-cases/usecase.place-order.c4",
+          ],
+          "folder": "boutique",
         },
-        {
-          "folder": "file:///Users/davydkov/Projects/like-c4/likec4/examples/cloud-system/",
-          "id": "cloud-system",
+        "cloud-system": {
+          "documents": [
+            "_spec.c4",
+            "cloud/legacy.c4",
+            "cloud/next.c4",
+            "cloud/ui.c4",
+            "deployment.acc.c4",
+            "deployment.c4",
+            "externals.c4",
+            "model.c4",
+            "views.c4",
+          ],
+          "folder": "cloud-system",
         },
-        {
-          "folder": "file:///Users/davydkov/Projects/like-c4/likec4/examples/issue-1624/",
-          "id": "issue-1624",
+        "diagrams-dev": {
+          "documents": [
+            "_spec.c4",
+            "amazon.c4",
+            "model.c4",
+            "relationships/colors.c4",
+            "theme/colors.c4",
+          ],
+          "folder": "likec4",
         },
-        {
-          "folder": "file:///Users/davydkov/Projects/like-c4/likec4/examples/multi-project/boutique/",
-          "id": "boutique",
+        "issue-1624": {
+          "documents": [
+            "model.c4",
+          ],
+          "folder": "issue-1624",
         },
-        {
-          "folder": "file:///Users/davydkov/Projects/like-c4/likec4/examples/diagrams-dev/likec4/",
-          "id": "diagrams-dev",
+        "projectA": {
+          "documents": [
+            "_spec.c4",
+            "cloud/legacy.c4",
+            "cloud/next.c4",
+            "cloud/ui.c4",
+            "deployment.acc.c4",
+            "deployment.c4",
+            "externals.c4",
+            "model.c4",
+            "views.c4",
+          ],
+          "folder": "projectA",
         },
-        {
-          "folder": "file:///Users/davydkov/Projects/like-c4/likec4/examples/multi-project/projectA/",
-          "id": "projectA",
-        },
-      ]
+      }
     `)
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -315,7 +315,7 @@ overrides:
   vscode-oniguruma: 2.0.1
   vscode-uri: 3.1.0
   type-fest: ^4.41.0
-  turbo: 2.5.5
+  turbo: 2.5.6
   sharp: 0.34.3
   mnemonist: 0.40.3
 
@@ -359,8 +359,8 @@ importers:
         specifier: 'catalog:'
         version: 4.20.3
       turbo:
-        specifier: 2.5.5
-        version: 2.5.5
+        specifier: 2.5.6
+        version: 2.5.6
       typescript:
         specifier: 'catalog:'
         version: 5.9.2
@@ -632,8 +632,8 @@ importers:
         specifier: 'catalog:'
         version: 4.20.3
       turbo:
-        specifier: 2.5.5
-        version: 2.5.5
+        specifier: 2.5.6
+        version: 2.5.6
       type-fest:
         specifier: ^4.41.0
         version: 4.41.0
@@ -795,8 +795,8 @@ importers:
         specifier: catalog:utils
         version: 2.23.1
       turbo:
-        specifier: 2.5.5
-        version: 2.5.5
+        specifier: 2.5.6
+        version: 2.5.6
       typescript:
         specifier: 'catalog:'
         version: 5.9.2
@@ -1113,8 +1113,8 @@ importers:
         specifier: 'catalog:'
         version: 4.20.3
       turbo:
-        specifier: 2.5.5
-        version: 2.5.5
+        specifier: 2.5.6
+        version: 2.5.6
       type-fest:
         specifier: ^4.41.0
         version: 4.41.0
@@ -1222,8 +1222,8 @@ importers:
         specifier: ^3.0.4
         version: 3.0.4
       turbo:
-        specifier: 2.5.5
-        version: 2.5.5
+        specifier: 2.5.6
+        version: 2.5.6
       typescript:
         specifier: 'catalog:'
         version: 5.9.2
@@ -1469,8 +1469,8 @@ importers:
         specifier: 'catalog:'
         version: 4.20.3
       turbo:
-        specifier: 2.5.5
-        version: 2.5.5
+        specifier: 2.5.6
+        version: 2.5.6
       typescript:
         specifier: 'catalog:'
         version: 5.9.2
@@ -1572,8 +1572,8 @@ importers:
         specifier: 'catalog:'
         version: 4.20.3
       turbo:
-        specifier: 2.5.5
-        version: 2.5.5
+        specifier: 2.5.6
+        version: 2.5.6
       typescript:
         specifier: 'catalog:'
         version: 5.9.2
@@ -1682,8 +1682,8 @@ importers:
         specifier: 'catalog:'
         version: 4.20.3
       turbo:
-        specifier: 2.5.5
-        version: 2.5.5
+        specifier: 2.5.6
+        version: 2.5.6
       type-fest:
         specifier: ^4.41.0
         version: 4.41.0
@@ -8153,38 +8153,38 @@ packages:
   tty-browserify@0.0.1:
     resolution: {integrity: sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==}
 
-  turbo-darwin-64@2.5.5:
-    resolution: {integrity: sha512-RYnTz49u4F5tDD2SUwwtlynABNBAfbyT2uU/brJcyh5k6lDLyNfYKdKmqd3K2ls4AaiALWrFKVSBsiVwhdFNzQ==}
+  turbo-darwin-64@2.5.6:
+    resolution: {integrity: sha512-3C1xEdo4aFwMJAPvtlPqz1Sw/+cddWIOmsalHFMrsqqydcptwBfu26WW2cDm3u93bUzMbBJ8k3zNKFqxJ9ei2A==}
     cpu: [x64]
     os: [darwin]
 
-  turbo-darwin-arm64@2.5.5:
-    resolution: {integrity: sha512-Tk+ZeSNdBobZiMw9aFypQt0DlLsWSFWu1ymqsAdJLuPoAH05qCfYtRxE1pJuYHcJB5pqI+/HOxtJoQ40726Btw==}
+  turbo-darwin-arm64@2.5.6:
+    resolution: {integrity: sha512-LyiG+rD7JhMfYwLqB6k3LZQtYn8CQQUePbpA8mF/hMLPAekXdJo1g0bUPw8RZLwQXUIU/3BU7tXENvhSGz5DPA==}
     cpu: [arm64]
     os: [darwin]
 
-  turbo-linux-64@2.5.5:
-    resolution: {integrity: sha512-2/XvMGykD7VgsvWesZZYIIVXMlgBcQy+ZAryjugoTcvJv8TZzSU/B1nShcA7IAjZ0q7OsZ45uP2cOb8EgKT30w==}
+  turbo-linux-64@2.5.6:
+    resolution: {integrity: sha512-GOcUTT0xiT/pSnHL4YD6Yr3HreUhU8pUcGqcI2ksIF9b2/r/kRHwGFcsHgpG3+vtZF/kwsP0MV8FTlTObxsYIA==}
     cpu: [x64]
     os: [linux]
 
-  turbo-linux-arm64@2.5.5:
-    resolution: {integrity: sha512-DW+8CjCjybu0d7TFm9dovTTVg1VRnlkZ1rceO4zqsaLrit3DgHnN4to4uwyuf9s2V/BwS3IYcRy+HG9BL596Iw==}
+  turbo-linux-arm64@2.5.6:
+    resolution: {integrity: sha512-10Tm15bruJEA3m0V7iZcnQBpObGBcOgUcO+sY7/2vk1bweW34LMhkWi8svjV9iDF68+KJDThnYDlYE/bc7/zzQ==}
     cpu: [arm64]
     os: [linux]
 
-  turbo-windows-64@2.5.5:
-    resolution: {integrity: sha512-q5p1BOy8ChtSZfULuF1BhFMYIx6bevXu4fJ+TE/hyNfyHJIfjl90Z6jWdqAlyaFLmn99X/uw+7d6T/Y/dr5JwQ==}
+  turbo-windows-64@2.5.6:
+    resolution: {integrity: sha512-FyRsVpgaj76It0ludwZsNN40ytHN+17E4PFJyeliBEbxrGTc5BexlXVpufB7XlAaoaZVxbS6KT8RofLfDRyEPg==}
     cpu: [x64]
     os: [win32]
 
-  turbo-windows-arm64@2.5.5:
-    resolution: {integrity: sha512-AXbF1KmpHUq3PKQwddMGoKMYhHsy5t1YBQO8HZ04HLMR0rWv9adYlQ8kaeQJTko1Ay1anOBFTqaxfVOOsu7+1Q==}
+  turbo-windows-arm64@2.5.6:
+    resolution: {integrity: sha512-j/tWu8cMeQ7HPpKri6jvKtyXg9K1gRyhdK4tKrrchH8GNHscPX/F71zax58yYtLRWTiK04zNzPcUJuoS0+v/+Q==}
     cpu: [arm64]
     os: [win32]
 
-  turbo@2.5.5:
-    resolution: {integrity: sha512-eZ7wI6KjtT1eBqCnh2JPXWNUAxtoxxfi6VdBdZFvil0ychCOTxbm7YLRBi1JSt7U3c+u3CLxpoPxLdvr/Npr3A==}
+  turbo@2.5.6:
+    resolution: {integrity: sha512-gxToHmi9oTBNB05UjUsrWf0OyN5ZXtD0apOarC1KIx232Vp3WimRNy3810QzeNSgyD5rsaIDXlxlbnOzlouo+w==}
     hasBin: true
 
   type-fest@4.41.0:
@@ -11850,6 +11850,14 @@ snapshots:
       '@vitest/utils': 3.2.4
       chai: 5.2.0
       tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(vite@6.3.5(@types/node@20.19.2)(jiti@2.4.2)(lightningcss@1.25.1)(sugarss@4.0.1(postcss@8.5.5))(terser@5.39.2)(tsx@4.20.3)(yaml@2.7.0))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      vite: 6.3.5(@types/node@20.19.2)(jiti@2.4.2)(lightningcss@1.25.1)(sugarss@4.0.1(postcss@8.5.5))(terser@5.39.2)(tsx@4.20.3)(yaml@2.7.0)
 
   '@vitest/mocker@3.2.4(vite@6.3.5(@types/node@22.15.31)(jiti@2.4.2)(lightningcss@1.25.1)(sugarss@4.0.1(postcss@8.5.5))(terser@5.39.2)(tsx@4.20.3)(yaml@2.7.0))':
     dependencies:
@@ -16985,32 +16993,32 @@ snapshots:
 
   tty-browserify@0.0.1: {}
 
-  turbo-darwin-64@2.5.5:
+  turbo-darwin-64@2.5.6:
     optional: true
 
-  turbo-darwin-arm64@2.5.5:
+  turbo-darwin-arm64@2.5.6:
     optional: true
 
-  turbo-linux-64@2.5.5:
+  turbo-linux-64@2.5.6:
     optional: true
 
-  turbo-linux-arm64@2.5.5:
+  turbo-linux-arm64@2.5.6:
     optional: true
 
-  turbo-windows-64@2.5.5:
+  turbo-windows-64@2.5.6:
     optional: true
 
-  turbo-windows-arm64@2.5.5:
+  turbo-windows-arm64@2.5.6:
     optional: true
 
-  turbo@2.5.5:
+  turbo@2.5.6:
     optionalDependencies:
-      turbo-darwin-64: 2.5.5
-      turbo-darwin-arm64: 2.5.5
-      turbo-linux-64: 2.5.5
-      turbo-linux-arm64: 2.5.5
-      turbo-windows-64: 2.5.5
-      turbo-windows-arm64: 2.5.5
+      turbo-darwin-64: 2.5.6
+      turbo-darwin-arm64: 2.5.6
+      turbo-linux-64: 2.5.6
+      turbo-linux-arm64: 2.5.6
+      turbo-windows-64: 2.5.6
+      turbo-windows-arm64: 2.5.6
 
   type-fest@4.41.0: {}
 
@@ -17481,7 +17489,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.3.5(@types/node@22.15.31)(jiti@2.4.2)(lightningcss@1.25.1)(sugarss@4.0.1(postcss@8.5.5))(terser@5.39.2)(tsx@4.20.3)(yaml@2.7.0))
+      '@vitest/mocker': 3.2.4(vite@6.3.5(@types/node@20.19.2)(jiti@2.4.2)(lightningcss@1.25.1)(sugarss@4.0.1(postcss@8.5.5))(terser@5.39.2)(tsx@4.20.3)(yaml@2.7.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,7 +8,7 @@ catalog:
   "@types/node": ~20.19.2
   playwright: 1.54.2
   tsx: 4.20.3
-  turbo: 2.5.5
+  turbo: 2.5.6
   typescript: 5.9.2
   unbuild: 3.5.0
   wireit: 0.14.12


### PR DESCRIPTION
- Use `URI.file` to correct platform-dependent path
- Ensure documents order by sorting by paths