### PR TITLE
feat: multi-metadata extends support

### DIFF
--- a/apps/docs/src/content/docs/dsl/extend.mdx
+++ b/apps/docs/src/content/docs/dsl/extend.mdx
@@ -143,3 +143,111 @@ model {
   }
 }
 ```
+
+#### Metadata merging
+
+When extending elements with metadata, duplicate keys from both the original element and the extension are merged into arrays:
+
+```likec4
+model {
+  component api {
+    metadata {
+      version '1.0.0'
+      tags 'backend'
+      regions 'us-east-1'
+    }
+  }
+}
+
+// In another file
+model {
+  extend api {
+    metadata {
+      tags 'microservice'        // Merges with existing 'backend'
+      regions ['eu-west-1']      // Merges with existing 'us-east-1'
+      owner 'platform-team'      // New key
+    }
+  }
+}
+
+// Result:
+{
+  version: '1.0.0',
+  tags: ['backend', 'microservice'],     // Merged and kept as array
+   regions: ['us-east-1', 'eu-west-1'],   // Merged and kept as array
+   owner: 'platform-team'
+}
+```
+
+**Merging behavior:**
+- Duplicate values are automatically de-duplicated
+- If after de-duplication there's only one unique value, it's stored as a string (not an array)
+- Arrays from both sides are merged and de-duplicated
+
+```likec4
+model {
+  component api {
+    metadata {
+      environment 'production'
+      tags ['backend', 'api']
+    }
+  }
+}
+
+model {
+  extend api {
+    metadata {
+      environment 'production'   // Duplicate value
+      tags ['api', 'critical']   // 'api' is duplicate
+    }
+  }
+}
+
+// Result:
+{
+  environment: 'production',           // Single value (de-duplicated)
+  tags: ['backend', 'api', 'critical'] // Merged and de-duplicated
+}
+```
+
+You can extend the same element multiple times across different files, and all metadata will be properly merged:
+
+```likec4
+// file1.c4
+model {
+  component api {
+    metadata {
+      version '2.0.0'
+      tags 'backend'
+    }
+  }
+}
+
+// file2.c4
+model {
+  extend api {
+    metadata {
+      tags 'rest'
+      owner 'team-a'
+    }
+  }
+}
+
+// file3.c4
+model {
+  extend api {
+    metadata {
+      tags 'microservice'
+      regions ['us', 'eu']
+    }
+  }
+}
+
+// Result:
+{
+  version: '2.0.0',
+  tags: ['backend', 'rest', 'microservice'],
+  owner: 'team-a',
+  regions: ['us', 'eu']
+}
+```

--- a/apps/docs/src/content/docs/tooling/model-api.mdx
+++ b/apps/docs/src/content/docs/tooling/model-api.mdx
@@ -412,6 +412,18 @@ for (const element of model.elements()) {
 console.log('All unique tags:', Array.from(allTags).sort())
 ```
 
+:::note[Metadata Merging with Extends]
+When using [`extend`](/dsl/extend/) to add metadata to elements, duplicate metadata keys are automatically merged:
+
+- String + String = Array (if different values)
+- String + Array = Array (merged)
+- Array + Array = Array (merged)
+- Duplicate values are automatically de-duplicated
+- Single-value arrays are converted back to strings
+
+This allows you to progressively build up metadata across multiple files. See the [extend documentation](/dsl/extend/#metadata-merging) for more details.
+:::
+
 ### LikeC4DeploymentModel
 
 API provides methods to query and traverse deployment model.

--- a/examples/multi-metadata-extend/base.c4
+++ b/examples/multi-metadata-extend/base.c4
@@ -1,0 +1,31 @@
+specification {
+  element component
+  element service
+  element database
+}
+
+model {
+  component api {
+    metadata {
+      version '2.0.0'
+      tags 'backend'
+      port '8080'
+    }
+  }
+
+  component frontend {
+    metadata {
+      version '1.5.0'
+      framework 'React'
+      deployment_target 'staging'
+    }
+  }
+
+  service database {
+    metadata {
+      engine 'PostgreSQL'
+      version '15.3'
+      replicas 'primary'
+    }
+  }
+}

--- a/examples/multi-metadata-extend/extend-1.c4
+++ b/examples/multi-metadata-extend/extend-1.c4
@@ -1,0 +1,24 @@
+model {
+  extend api {
+    metadata {
+      tags 'rest'                    // Merges with 'backend' -> ['backend', 'rest']
+      owner 'platform-team'          // New key
+      port '9090'                    // Merges with '8080' -> ['8080', '9090']
+    }
+  }
+
+  extend frontend {
+    metadata {
+      version '1.5.0'                // Duplicate value, will be de-duplicated to single string
+      deployment_target 'production' // Merges with 'staging' -> ['staging', 'production']
+      build_tool 'Vite'              // New key
+    }
+  }
+
+  extend database {
+    metadata {
+      replicas ['replica-1', 'replica-2']  // Merges with 'primary' -> ['primary', 'replica-1', 'replica-2']
+      backup_schedule 'daily'              // New key
+    }
+  }
+}

--- a/examples/multi-metadata-extend/extend-2.c4
+++ b/examples/multi-metadata-extend/extend-2.c4
@@ -1,0 +1,22 @@
+model {
+  extend api {
+    metadata {
+      tags 'microservice'            // Further extends tags -> ['backend', 'rest', 'microservice']
+      regions ['us-east-1', 'eu-west-1']  // New key with array
+    }
+  }
+
+  extend frontend {
+    metadata {
+      deployment_target 'preview'    // Further extends -> ['staging', 'production', 'preview']
+      cdn 'CloudFlare'               // New key
+    }
+  }
+
+  extend database {
+    metadata {
+      replicas 'replica-1'           // Duplicate value, already exists, no change
+      monitoring 'enabled'           // New key
+    }
+  }
+}

--- a/packages/language-server/src/model/__tests__/model-builder-extend-metadata.spec.ts
+++ b/packages/language-server/src/model/__tests__/model-builder-extend-metadata.spec.ts
@@ -1,0 +1,364 @@
+import { describe, it } from 'vitest'
+import { createTestServices } from '../../test'
+
+describe('LikeC4ModelBuilder - extend element with metadata', () => {
+  it('extends element with simple metadata', async ({ expect }) => {
+    const { validate, buildLikeC4Model } = createTestServices()
+    await validate(`
+      specification {
+        element component
+      }
+      model {
+        component system {
+          metadata {
+            version '1.0.0'
+          }
+        }
+      }
+    `)
+    await validate(`
+      model {
+        extend system {
+          metadata {
+            owner 'team-a'
+          }
+        }
+      }
+    `)
+
+    const model = await buildLikeC4Model()
+    const system = model.element('system')
+    expect(system.getMetadata()).toEqual({
+      version: '1.0.0',
+      owner: 'team-a',
+    })
+  })
+
+  it('merges duplicate metadata keys from extend', async ({ expect }) => {
+    const { validate, buildLikeC4Model } = createTestServices()
+    await validate(`
+      specification {
+        element component
+      }
+      model {
+        component system {
+          metadata {
+            tags 'backend'
+          }
+        }
+      }
+    `)
+    await validate(`
+      model {
+        extend system {
+          metadata {
+            tags 'api'
+          }
+        }
+      }
+    `)
+
+    const model = await buildLikeC4Model()
+    const system = model.element('system')
+    expect(system.getMetadata()).toEqual({
+      tags: ['backend', 'api'],
+    })
+  })
+
+  it('merges array metadata from extend', async ({ expect }) => {
+    const { validate, buildLikeC4Model } = createTestServices()
+    await validate(`
+      specification {
+        element component
+      }
+      model {
+        component system {
+          metadata {
+            regions ['us-east-1', 'us-west-2']
+          }
+        }
+      }
+    `)
+    await validate(`
+      model {
+        extend system {
+          metadata {
+            regions ['eu-west-1', 'ap-south-1']
+          }
+        }
+      }
+    `)
+
+    const model = await buildLikeC4Model()
+    const system = model.element('system')
+    expect(system.getMetadata()).toEqual({
+      regions: ['us-east-1', 'us-west-2', 'eu-west-1', 'ap-south-1'],
+    })
+  })
+
+  it('merges string and array metadata', async ({ expect }) => {
+    const { validate, buildLikeC4Model } = createTestServices()
+    await validate(`
+      specification {
+        element component
+      }
+      model {
+        component system {
+          metadata {
+            tags 'backend'
+          }
+        }
+      }
+    `)
+    await validate(`
+      model {
+        extend system {
+          metadata {
+            tags ['api', 'microservice']
+          }
+        }
+      }
+    `)
+
+    const model = await buildLikeC4Model()
+    const system = model.element('system')
+    expect(system.getMetadata()).toEqual({
+      tags: ['backend', 'api', 'microservice'],
+    })
+  })
+
+  it('deduplicates duplicate values in merged metadata', async ({ expect }) => {
+    const { validate, buildLikeC4Model } = createTestServices()
+    await validate(`
+      specification {
+        element component
+      }
+      model {
+        component system {
+          metadata {
+            tags ['backend', 'api']
+          }
+        }
+      }
+    `)
+    await validate(`
+      model {
+        extend system {
+          metadata {
+            tags ['api', 'microservice', 'backend']
+          }
+        }
+      }
+    `)
+
+    const model = await buildLikeC4Model()
+    const system = model.element('system')
+    expect(system.getMetadata()).toEqual({
+      tags: ['backend', 'api', 'microservice'],
+    })
+  })
+
+  it('converts single-value array to string after deduplication', async ({ expect }) => {
+    const { validate, buildLikeC4Model } = createTestServices()
+    await validate(`
+      specification {
+        element component
+      }
+      model {
+        component system {
+          metadata {
+            environment 'production'
+          }
+        }
+      }
+    `)
+    await validate(`
+      model {
+        extend system {
+          metadata {
+            environment 'production'
+          }
+        }
+      }
+    `)
+
+    const model = await buildLikeC4Model()
+    const system = model.element('system')
+    expect(system.getMetadata()).toEqual({
+      environment: 'production',
+    })
+  })
+
+  it('merges metadata from multiple extends', async ({ expect }) => {
+    const { validate, buildLikeC4Model } = createTestServices()
+    await validate(`
+      specification {
+        element component
+      }
+      model {
+        component system {
+          metadata {
+            version '1.0.0'
+            tags 'backend'
+          }
+        }
+      }
+    `)
+    await validate(`
+      model {
+        extend system {
+          metadata {
+            tags 'api'
+            owner 'team-a'
+          }
+        }
+      }
+    `)
+    await validate(`
+      model {
+        extend system {
+          metadata {
+            tags 'microservice'
+            regions 'us-east-1'
+          }
+        }
+      }
+    `)
+
+    const model = await buildLikeC4Model()
+    const system = model.element('system')
+    expect(system.getMetadata()).toEqual({
+      version: '1.0.0',
+      tags: ['backend', 'api', 'microservice'],
+      owner: 'team-a',
+      regions: 'us-east-1',
+    })
+  })
+
+  it('handles complex metadata merging with mixed types', async ({ expect }) => {
+    const { validate, buildLikeC4Model } = createTestServices()
+    await validate(`
+      specification {
+        element component
+      }
+      model {
+        component system {
+          metadata {
+            version '1.0.0'
+            tags ['backend', 'critical']
+            regions 'us-east-1'
+            ports ['8080']
+          }
+        }
+      }
+    `)
+    await validate(`
+      model {
+        extend system {
+          metadata {
+            tags 'api'
+            regions ['eu-west-1', 'ap-south-1']
+            ports ['9090', '3000']
+            owner 'team-a'
+          }
+        }
+      }
+    `)
+
+    const model = await buildLikeC4Model()
+    const system = model.element('system')
+    expect(system.getMetadata()).toEqual({
+      version: '1.0.0',
+      tags: ['backend', 'critical', 'api'],
+      regions: ['us-east-1', 'eu-west-1', 'ap-south-1'],
+      ports: ['8080', '9090', '3000'],
+      owner: 'team-a',
+    })
+  })
+
+  it('extends nested element with metadata', async ({ expect }) => {
+    const { validate, buildLikeC4Model } = createTestServices()
+    await validate(`
+      specification {
+        element component
+      }
+      model {
+        component cloud {
+          component api {
+            metadata {
+              version '1.0.0'
+            }
+          }
+        }
+      }
+    `)
+    await validate(`
+      model {
+        extend cloud.api {
+          metadata {
+            tags 'backend'
+          }
+        }
+      }
+    `)
+
+    const model = await buildLikeC4Model()
+    const api = model.element('cloud.api')
+    expect(api.getMetadata()).toEqual({
+      version: '1.0.0',
+      tags: 'backend',
+    })
+  })
+
+  it('merges metadata across multiple documents', async ({ expect }) => {
+    const { addDocument, buildLikeC4Model, validateAll } = createTestServices()
+
+    await addDocument(`
+      specification {
+        element component
+      }
+      model {
+        component api {
+          metadata {
+            version '2.0.0'
+            tags 'backend'
+          }
+        }
+      }
+    `)
+
+    await addDocument(`
+      model {
+        extend api {
+          metadata {
+            tags 'rest'
+            owner 'platform-team'
+          }
+        }
+      }
+    `)
+
+    await addDocument(`
+      model {
+        extend api {
+          metadata {
+            tags 'microservice'
+            regions ['us', 'eu']
+          }
+        }
+      }
+    `)
+
+    const { errors } = await validateAll()
+    expect(errors).toEqual([])
+
+    const model = await buildLikeC4Model()
+    const api = model.element('api')
+    expect(api.getMetadata()).toEqual({
+      version: '2.0.0',
+      tags: ['backend', 'rest', 'microservice'],
+      owner: 'platform-team',
+      regions: ['us', 'eu'],
+    })
+  })
+})

--- a/packages/language-server/src/model/builder/MergedExtends.ts
+++ b/packages/language-server/src/model/builder/MergedExtends.ts
@@ -15,6 +15,33 @@ export class MergedExtends {
     metadata: Record<string, string | string[]>
   }>()
 
+  private mergeMetadata(
+    existing: Record<string, string | string[]>,
+    incoming: Record<string, string | string[]>,
+  ): Record<string, string | string[]> {
+    const result: Record<string, string | string[]> = { ...existing }
+
+    for (const [key, incomingValue] of Object.entries(incoming)) {
+      const existingValue = result[key]
+
+      if (existingValue === undefined) {
+        result[key] = incomingValue
+        continue
+      }
+
+      // Convert both values to arrays to make merging easier.
+      const existingArray = Array.isArray(existingValue) ? existingValue : [existingValue]
+      const incomingArray = Array.isArray(incomingValue) ? incomingValue : [incomingValue]
+
+      // Merge and deduplicate based on value.
+      const merged = unique([...existingArray, ...incomingArray])
+
+      result[key] = merged.length === 1 ? merged[0]! : merged
+    }
+
+    return result
+  }
+
   merge(parsedExtends: ParsedAstExtend[]): void {
     for (const parsedExtend of parsedExtends) {
       const { id, links, tags, metadata } = parsedExtend
@@ -33,10 +60,7 @@ export class MergedExtends {
         ])
       }
       if (metadata) {
-        existing.metadata = {
-          ...existing.metadata,
-          ...metadata,
-        }
+        existing.metadata = this.mergeMetadata(existing.metadata, metadata)
       }
       this.mergedData.set(id, existing)
     }
@@ -73,14 +97,9 @@ export class MergedExtends {
 
     let metadata = extendData.metadata
     if (el.metadata) {
-      metadata = {
-        ...el.metadata,
-        ...extendData.metadata,
-      }
+      metadata = this.mergeMetadata(el.metadata, extendData.metadata)
     }
-    // const links = [...(el.links ?? []), ...extendData.links]
-    // const tags = unique([...(el.tags ?? []), ...extendData.tags)
-    // const metadata = { ...el.metadata, ...extendData.metadata }
+
     return {
       ...el,
       tags: hasAtLeast(tags, 1) ? tags : null,

--- a/packages/likec4/src/LikeC4.spec.ts
+++ b/packages/likec4/src/LikeC4.spec.ts
@@ -195,6 +195,14 @@ describe.concurrent('LikeC4', () => {
           ],
           "folder": "cloud-system",
         },
+        "default": {
+          "documents": [
+            "multi-metadata-extend/base.c4",
+            "multi-metadata-extend/extend-1.c4",
+            "multi-metadata-extend/extend-2.c4",
+          ],
+          "folder": "examples",
+        },
         "diagrams-dev": {
           "documents": [
             "_spec.c4",


### PR DESCRIPTION
Extending the multi-metadata support with support for the `extends` keyword.

## Checklist

- [x] I've thoroughly read the latest [contribution guidelines](https://github.com/likec4/likec4/blob/main/CONTRIBUTING.md).
- [x] I've rebased my branch onto `main` **before** creating this PR.
- [x] My commit messages follow [conventional spec](https://www.conventionalcommits.org/en/)
- [x] I've added tests to cover my changes (if applicable).
- [x] I've verified that all new and existing tests have passed locally for mobile, tablet, and desktop screen sizes.
- [x] My change requires documentation updates.
- [x] I've updated the documentation accordingly.
