### PR TITLE
feat(cli): add PORT environment variable support for dev server

### DIFF
--- a/packages/likec4/src/cli/options.ts
+++ b/packages/likec4/src/cli/options.ts
@@ -88,6 +88,12 @@ export const listen = {
   nargs: 1,
 } as const satisfies Options
 
+export const port = {
+  type: 'number',
+  desc: 'port number for the dev server (default is 5173, or PORT environment variable)',
+  nargs: 1,
+} as const satisfies Options
+
 export const project = {
   alias: 'p',
   type: 'string',

--- a/packages/likec4/src/cli/serve/index.ts
+++ b/packages/likec4/src/cli/serve/index.ts
@@ -1,6 +1,6 @@
 import type * as yargs from 'yargs'
 import { ensureReact } from '../ensure-react'
-import { base, listen, path, title, useDotBin, useHashHistory, webcomponentPrefix } from '../options'
+import { base, listen, path, port, title, useDotBin, useHashHistory, webcomponentPrefix } from '../options'
 import { handler } from './serve'
 
 const serveCmd = (yargs: yargs.Argv) => {
@@ -19,6 +19,7 @@ const serveCmd = (yargs: yargs.Argv) => {
           // .option('use-overview', useOverview)
           .option('use-dot', useDotBin)
           .option('listen', listen)
+          .option('port', port)
           .options({
             'react-hmr': {
               type: 'boolean',
@@ -42,6 +43,7 @@ const serveCmd = (yargs: yargs.Argv) => {
           title: args['title'],
           useHashHistory: args['use-hash-history'],
           listen: args['listen'],
+          port: args['port'],
           enableHMR: args['react-hmr'],
           enableWebcomponent: args['build-webcomponent'],
         })

--- a/packages/likec4/src/cli/serve/serve.ts
+++ b/packages/likec4/src/cli/serve/serve.ts
@@ -43,6 +43,12 @@ type HandlerParams = {
   listen?: string | undefined
 
   /**
+   * port number for the dev server
+   * @default 5173
+   */
+  port?: number | undefined
+
+  /**
    * Enable webcomponent build
    * @default true
    */
@@ -66,6 +72,7 @@ export async function handler({
   enableHMR = true,
   base,
   listen,
+  port,
 }: HandlerParams) {
   // Explicitly set NODE_ENV to development
   if (enableHMR) {
@@ -91,6 +98,7 @@ export async function handler({
     useOverviewGraph: useOverview,
     likec4AssetsDir,
     listen,
+    port,
   })
 
   server.config.logger.clearScreen('info')

--- a/packages/likec4/src/vite/vite-dev.ts
+++ b/packages/likec4/src/vite/vite-dev.ts
@@ -6,6 +6,7 @@ import isInsideContainer from 'is-inside-container'
 import { mkdtemp } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { env } from 'std-env'
 import k from 'tinyrainbow'
 import type { SetOptional } from 'type-fest'
 import type { ViteDevServer } from 'vite'
@@ -17,6 +18,7 @@ type Config = SetOptional<LikeC4ViteConfig, 'likec4AssetsDir'> & {
   openBrowser?: boolean
   hmr?: boolean
   listen?: string | undefined
+  port?: number | undefined
 }
 
 export async function viteDev({
@@ -28,6 +30,7 @@ export async function viteDev({
   likec4AssetsDir,
   openBrowser,
   listen,
+  port,
   ...cfg
 }: Config): Promise<ViteDevServer> {
   likec4AssetsDir ??= await mkdtemp(join(tmpdir(), '.likec4-assets-'))
@@ -40,8 +43,8 @@ export async function viteDev({
     title,
   })
   const logger = config.customLogger
-  const preferredPort = process.env.PORT ? parseInt(process.env.PORT, 10) : 5173
-  const port = await getPort({
+  const preferredPort = port ?? (env.PORT ? parseInt(env.PORT, 10) : 5173)
+  const actualPort = await getPort({
     port: [
       preferredPort,
       ...portNumbers(61000, 61010),
@@ -81,7 +84,7 @@ export async function viteDev({
       // This is not recommended as it can be a security risk - https://vite.dev/config/server-options#server-allowedhosts
       // Enabled after request in discord support just to check if it solves the problem
       allowedHosts: true,
-      port,
+      port: actualPort,
       hmr: hmr && {
         overlay: true,
         // needed for hmr to work over network aka WSL2


### PR DESCRIPTION
## Summary
Adds support for setting a custom port via the PORT environment variable when running the dev server.

## Motivation
I'm building a (experimental) vibe code platform that provides preview functionality for various web servers. The platform requires all dev servers to support port configuration either via the PORT environment variable or as a CLI argument. This change allows LikeC4 to run seamlessly in preview mode within such environments, where multiple servers may need to run simultaneously on different ports. 

By the way, great work on LikeC4! I get a really nice workflow using AI agents write code autonomously but still have a clear overview of the system design. Planning to open-source my own platform once I've cleaned up the codebase a bit more...

## Checklist

- [x] I've thoroughly read the latest [contribution guidelines](https://github.com/likec4/likec4/blob/main/CONTRIBUTING.md).
- [x] I've rebased my branch onto `main` **before** creating this PR.
- [x] My commit messages follow [conventional spec](https://www.conventionalcommits.org/en/)
- [ ] I've added tests to cover my changes (not applicable).
- [x] I've verified that all new and existing tests have passed locally for mobile, tablet, and desktop screen sizes.
- [ ] My change requires documentation updates. (NO - standard convention)
- [ ] I've updated the documentation accordingly. 
