### PR TITLE
feat: add relationship metadata tooltip display

### DIFF
--- a/THIRD-PARTY-NOTICES.txt
+++ b/THIRD-PARTY-NOTICES.txt
@@ -1,0 +1,43 @@
+THIRD-PARTY SOFTWARE NOTICES AND INFORMATION
+
+This project includes modifications contributed by NVIDIA CORPORATION & AFFILIATES.
+
+================================================================================
+
+LikeC4
+https://github.com/likec4/likec4
+
+MIT License
+
+Copyright (c) 2023-2025 Denis Davydkov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+================================================================================
+
+NVIDIA CONTRIBUTIONS:
+
+Certain files in this repository have been modified by NVIDIA CORPORATION &
+AFFILIATES as indicated in the file headers. These modifications are also
+licensed under the MIT License as stated above.
+
+================================================================================
+
+For the complete original project license, see the LICENSE file in the root
+directory of this source tree.

--- a/examples/cloud-system/cloud/ui.c4
+++ b/examples/cloud-system/cloud/ui.c4
@@ -10,10 +10,25 @@ model {
       }
     }
 
-    dashboard -> cloud.graphql.myAccount "fetches via GraphQL"
-    dashboard -> cloud.graphql.updateAccount "mutates via GraphQL"
+    dashboard -> cloud.graphql.myAccount "fetches via GraphQL" {
+      metadata {
+        bandwith 'medium'
+        security 'approved'
+      }
+    }
+    dashboard -> cloud.graphql.updateAccount "mutates via GraphQL"{
+       metadata {
+        bandwith 'low'
+        security 'tbd'
+      }
+    }
 
     dashboard -> cloud.legacy.services "fetches via REST"
+    {
+      metadata {
+        bandwith 'high'
+      }
+    }
 
     mobile = mobileApp {
       title 'Customer Mobile App'

--- a/packages/diagram/src/likec4diagram/relationship-popover/RelationshipPopover.tsx
+++ b/packages/diagram/src/likec4diagram/relationship-popover/RelationshipPopover.tsx
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2025 Denis Davydkov
+// Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { autoPlacement, autoUpdate, computePosition, hide, offset, size } from '@floating-ui/dom'
 import { nameFromFqn } from '@likec4/core'
 import type { LikeC4Model } from '@likec4/core/model'
@@ -14,7 +21,7 @@ import {
   Tooltip as MantineTooltip,
   TooltipGroup,
 } from '@mantine/core'
-import { IconArrowRight, IconFileSymlink, IconZoomScan } from '@tabler/icons-react'
+import { IconArrowRight, IconFileSymlink, IconInfoCircle, IconZoomScan } from '@tabler/icons-react'
 import { useActorRef, useSelector } from '@xstate/react'
 import { shallowEqual } from 'fast-equals'
 import {
@@ -29,7 +36,7 @@ import {
   useRef,
   useState,
 } from 'react'
-import { clamp, filter, isEmpty, isTruthy, map, partition, pipe } from 'remeda'
+import { clamp, entries, filter, isEmpty, isTruthy, map, partition, pipe } from 'remeda'
 import { Markdown } from '../../base-primitives'
 import { Link } from '../../components/Link'
 import { PortalToContainer } from '../../components/PortalToContainer'
@@ -398,6 +405,59 @@ const Relationship = forwardRef<
   const navigateTo = onNavigateTo && r.navigateTo?.id !== viewId ? r.navigateTo?.id : undefined
   const links = r.links
 
+  // Build metadata tooltip content
+  const metadataEntries = r.hasMetadata()
+    ? entries(r.getMetadata()).sort(([a], [b]) => a.localeCompare(b))
+    : null
+
+  const metadataTooltipLabel = metadataEntries && (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
+      <div
+        style={{
+          fontWeight: 600,
+          fontSize: '10px',
+          color: '#868e96',
+          marginBottom: '2px',
+          letterSpacing: '0.5px',
+          textTransform: 'uppercase',
+        }}>
+        Metadata
+      </div>
+      <div
+        style={{
+          borderTop: '1px solid rgba(0, 0, 0, 0.1)',
+          paddingTop: '6px',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '6px',
+        }}>
+        {metadataEntries.map(([key, value]) => {
+          const displayValue = Array.isArray(value) ? value.join(', ') : value
+          return (
+            <div key={key} style={{ display: 'flex', gap: '12px', fontSize: '12px', lineHeight: '1.4' }}>
+              <span
+                style={{
+                  fontWeight: 600,
+                  minWidth: '110px',
+                  color: '#495057',
+                }}>
+                {key}:
+              </span>
+              <span
+                style={{
+                  color: '#212529',
+                  wordBreak: 'break-word',
+                  flex: 1,
+                }}>
+                {displayValue}
+              </span>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+
   return (
     <VStack
       ref={ref}
@@ -466,7 +526,36 @@ const Relationship = forwardRef<
           )}
         </TooltipGroup>
       </HStack>
-      <Box className={styles.title}>{r.title || 'untitled'}</Box>
+      <HStack gap={'xs'} alignItems="center">
+        <Box className={styles.title}>{r.title || 'untitled'}</Box>
+        {metadataTooltipLabel && (
+          <Tooltip
+            label={metadataTooltipLabel}
+            w={350}
+            position="right"
+            offset={10}
+            openDelay={300}
+            withArrow
+            bg="white"
+            c="dark"
+            withinPortal
+            styles={{
+              tooltip: {
+                boxShadow: '0 4px 12px rgba(0, 0, 0, 0.15)',
+                border: '1px solid #dee2e6',
+              },
+            }}
+          >
+            <Box display="inline-flex">
+              <IconInfoCircle
+                size={14}
+                opacity={0.5}
+                style={{ flexShrink: 0, cursor: 'help' }}
+              />
+            </Box>
+          </Tooltip>
+        )}
+      </HStack>
       {r.kind && (
         <HStack gap="2">
           <Label>kind</Label>


### PR DESCRIPTION
Added tooltip functionality to display relationship metadata in the relationship popover.

<img width="2371" height="1517" alt="image" src="https://github.com/user-attachments/assets/2fc1dae8-27ce-4a4d-9d5a-21791f82faca" />


This commit also includes NVIDIA copyright headers and THIRD-PARTY-NOTICES.txt as required by company policy for open source contributions.

Changes:
- Implemented relationship metadata tooltip display in RelationshipPopover component
- Added SPDX-License-Identifier and copyright headers to modified files
- Created THIRD-PARTY-NOTICES.txt documenting OSS attributions
- Maintains MIT License compatibility

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask, and propose improvements. We're here to help. -->

- [X] I've thoroughly read the latest [contribution guidelines](https://github.com/likec4/likec4/blob/main/CONTRIBUTING.md).
- [X] I've rebased my branch onto `main` **before** creating this PR.
- [X] My commit messages follow [conventional spec](https://www.conventionalcommits.org/en/)
- [NA] I've added tests to cover my changes (if applicable).
- [partially] I've verified that all new and existing tests have passed locally for mobile, tablet, and <ins>desktop screen sizes</ins>.
- [NA] My change requires documentation updates.
- [NA] I've updated the documentation accordingly.
