### PR TITLE
feat(dsl): add extend relation syntax

### DIFF
--- a/apps/docs/src/content/docs/dsl/extend.mdx
+++ b/apps/docs/src/content/docs/dsl/extend.mdx
@@ -1,6 +1,6 @@
 ---
 title: Extending model
-description: How to extend the model with additional elements and properties from other files
+description: How to extend the model with additional elements, relations and properties from other files
 sidebar: 
   label: Extending model
   order: 6
@@ -249,5 +249,106 @@ model {
   tags: ['backend', 'rest', 'microservice'],
   owner: 'team-a',
   regions: ['us', 'eu']
+}
+```
+
+## Extend relation
+
+Similar to extending elements, you can extend relations to add metadata, tags, and links from separate files.
+
+<Aside type='caution'>
+**Deployment model limitation**: Extending relations is currently only supported for the logical model. Deployment model relations cannot be extended at this time.
+</Aside>
+
+Relations are uniquely identified by:
+- Source element
+- Target element
+- Relationship kind (if specified)
+- Title (if specified)
+
+```likec4
+// base.c4
+specification {
+  element component
+  relationship sync
+}
+
+model {
+  component frontend
+  component api
+  
+  // Untyped relation with title
+  frontend -> api "Makes requests"
+  
+  // Typed relation with same title (different relation!)
+  frontend -[sync]-> api "Makes requests"
+}
+
+// extend-ops.c4
+model {
+  // Extend the untyped relation
+  extend frontend -> api "Makes requests" {
+    metadata {
+      latency_p95 '150ms'
+      rate_limit '1000req/s'
+    }
+  }
+  
+  // Extend the sync relation (different from above!)
+  extend frontend -[sync]-> api "Makes requests" {
+    metadata {
+      latency_p95 '80ms'
+      cache_enabled 'true'
+    }
+  }
+}
+```
+
+<Aside type='note'>
+**Title normalization**: Relations without a title and relations with an empty string title (`""`) are treated identically. Both are normalized to an empty string internally. This means `extend a -> b` will match both `a -> b` and `a -> b ""`.
+</Aside>
+
+### Metadata merging
+
+Relation extends follow the same metadata merging rules as element extends:
+- New keys are added
+- Duplicate keys with different values become arrays
+- Duplicate keys with the same value are de-duplicated
+
+```likec4
+// base.c4
+model {
+  api -> database "Queries data" {
+    metadata {
+      protocol 'TCP'
+    }
+  }
+}
+
+// extend-1.c4
+model {
+  extend api -> database "Queries data" {
+    metadata {
+      protocol 'SSL'        // Creates array
+      timeout '5s'          // New key
+    }
+  }
+}
+
+// extend-2.c4
+model {
+  extend api -> database "Queries data" {
+    metadata {
+      protocol 'TLS'        // Adds to array
+      retry_policy 'exponential'  // New key
+    }
+  }
+}
+
+// Result:
+{
+  protocol: ['TCP', 'SSL', 'TLS'],
+  timeout: '5s',
+  retry_policy: 'exponential'
 }
 ```

--- a/examples/multi-relation-extend/.likec4rc
+++ b/examples/multi-relation-extend/.likec4rc
@@ -1,0 +1,6 @@
+{
+  name: 'multi-relation-extend',
+  title: 'Multi Relation Extend',
+  description: 'Example demonstrating extend relation syntax'
+}
+

--- a/examples/multi-relation-extend/README.md
+++ b/examples/multi-relation-extend/README.md
@@ -1,0 +1,64 @@
+# Multi-Relation Extend Example
+
+This example demonstrates the `extend relation` feature in LikeC4, which allows you to add metadata, tags, and links to existing relations from separate files.
+
+## Files
+
+- **`base.c4`**: Defines the base model with elements and relations
+- **`extend-1.c4`**: Operations team adds monitoring/performance metadata
+- **`extend-2.c4`**: Security team adds security metadata
+
+## What This Example Tests
+
+### Test 1: Untyped Relation with Title
+
+**Base**: `frontend -> api "Makes requests"`
+
+- No relationship kind specified
+- Extended by both operations and security teams
+- Should receive metadata from both extend-1.c4 and extend-2.c4
+
+### Test 2: Typed Relation with Same Title
+
+**Base**: `frontend -[sync]-> api "Makes requests"`
+
+- Uses `sync` relationship kind
+- Has the SAME title as Test 1 but different kind
+- Should be treated as a DIFFERENT relation from Test 1
+- Only receives extends that explicitly match `[sync]` kind
+
+### Test 3: Typed Relation with Different Title
+
+**Base**: `frontend -[async]-> api "Sends analytics data"`
+
+- Uses `async` relationship kind with unique title
+- Should only receive extends that match both kind and title
+
+### Test 4: Empty Title Normalization
+
+**Base**:
+
+- `userDB -> authService` (no title)
+- `userDB -> authService ""` (empty string title)
+
+Both are normalized to empty string internally, so:
+
+- `extend userDB -> authService` matches BOTH base relations
+- `extend userDB -> authService ""` also matches BOTH base relations
+
+## Key Concepts Demonstrated
+
+1. **Relation Identity**: Relations are uniquely identified by:
+   - Source element
+   - Target element
+   - Relationship kind (or lack thereof)
+   - Title (or empty string)
+
+2. **Metadata Merging**:
+   - New keys are added
+   - Duplicate keys with different values become arrays
+   - Duplicate keys with same values are de-duplicated
+
+3. **Multi-Team Collaboration**: Different teams can extend the same relations with their specific metadata without modifying the base model.
+
+4. **Title Normalization**: Relations without a title and relations with an empty string title are treated identically.

--- a/examples/multi-relation-extend/base.c4
+++ b/examples/multi-relation-extend/base.c4
@@ -1,0 +1,91 @@
+specification {
+  element component
+  element service
+  element database
+  // Declare tags used across examples so tag references can resolve
+  tag ops
+  tag perf
+  tag security
+  tag compliance
+  tag gateway
+  tag db
+  tag readonly
+  tag internal
+  tag empty_title
+  tag analytics
+  tag baseTag
+  tag audit
+  relationship async {
+    technology "gRPC Streaming"
+  }
+  relationship sync {
+    technology "HTTP/REST"
+  }
+}
+
+model {
+  component api {
+    title "API Gateway"
+  }
+
+  component frontend {
+    title "Frontend Application"
+  }
+
+  service authService {
+    title "Authentication Service"
+  }
+
+  database userDB {
+    title "User Database"
+  }
+
+  // Define base relations
+  // Test 1: No kind, title "Makes requests" - tests default/untyped relation extension
+  frontend -> api "Makes requests"
+
+  // Test 2: kind=sync, SAME title "Makes requests" - tests that kind differentiates relations with same title
+  frontend -[sync]-> api "Makes requests" {
+    metadata {
+      format 'JSON'
+    }
+  }
+
+  // Test 3: kind=async, different title - tests async relation with unique title
+  frontend -[async]-> api "Sends analytics data" {
+    metadata {
+      protocol 'gRPC'
+      batch_size '100'
+    }
+  }
+
+  api -> authService "Validates tokens" {
+    metadata {
+      protocol 'REST'
+    }
+  }
+
+  authService -> userDB "Queries users" {
+    metadata {
+      connection_type 'connection_pool'
+    }
+  }
+
+  // Test 5: Relation with base tags in header; extends add overlapping tags
+  // Expect: tags merged and deduplicated -> baseTag, security, ops, compliance
+  api -> userDB "Stores data" #baseTag #security
+
+  // Test 4: Empty string title vs no title
+  // Test 4a: No title at all
+  userDB -> authService
+
+  // Test 4b: Empty string title - should match Test 4a (both normalized to empty string)
+  userDB -> authService ""
+}
+
+views {
+  view index {
+    title "System Overview"
+    include *
+  }
+}

--- a/examples/multi-relation-extend/extend-1.c4
+++ b/examples/multi-relation-extend/extend-1.c4
@@ -1,0 +1,74 @@
+// Operations team extends relations with monitoring and performance metadata
+model {
+  // Extend Test 1: No kind, "Makes requests" - should only extend the untyped relation
+  extend frontend -> api "Makes requests" {
+    #ops #perf                         // Tags: added by operations
+    metadata {
+      latency_p95 '150ms'              // New key
+      rate_limit '1000req/s'           // New key
+    }
+    link https://api.example.com/docs "API Documentation"
+    link https://api.example.com/docs "Developer Guide"
+  }
+
+  // Extend Test 2: kind=sync, "Makes requests" - should only extend the sync relation (NOT Test 1)
+  extend frontend -[sync]-> api "Makes requests" {
+    #ops                               // Tags: added by operations for sync path
+    metadata {
+      latency_p95 '80ms'               // Faster sync performance
+      cache_enabled 'true'             // New key
+    }
+  }
+
+  // Extend Test 3: kind=async, different title
+  extend frontend -[async]-> api "Sends analytics data" {
+    metadata {
+      latency_p95 '500ms'              // Different performance profile
+      compression 'gzip'               // New key
+    }
+  }
+
+  extend api -> authService "Validates tokens" {
+    #ops #gateway
+    metadata {
+      protocol ['REST', 'gRPC']        // Merges with 'REST' -> ['REST', 'gRPC']
+      timeout '5s'                     // New key
+      retry_policy 'exponential'       // New key
+    }
+  }
+
+  extend authService -> userDB "Queries users" {
+    #db #readonly
+    metadata {
+      connection_type 'connection_pool'  // Duplicate, will be de-duplicated to single string
+      max_connections '50'               // New key
+      query_timeout '3s'                 // New key
+    }
+  }
+
+  // Extend Test 4a: Extend relation with no title - matches 'userDB -> authService' with no title
+  extend userDB -> authService {
+    #db #internal
+    metadata {
+      response_time '20ms'               // New key
+      read_only 'true'                   // New key
+    }
+  }
+
+  // Extend Test 4b: Extend relation with empty title - should match 'userDB -> authService ""'
+  // This tests if empty string "" is treated the same as no title (they are)
+  extend userDB -> authService "" {
+    #empty_title #internal
+    metadata {
+      empty_title_test 'yes'             // New key
+      special_case 'empty_string'        // New key
+    }
+  }
+
+  // Extend Test 5 (part 1): Relation had base tags, we add overlapping tags (security) and new tag (ops)
+  // Expect final tags: baseTag, security, ops, compliance (after extend-2)
+  extend api -> userDB "Stores data" {
+    #ops #security
+  }
+}
+

--- a/examples/multi-relation-extend/extend-2.c4
+++ b/examples/multi-relation-extend/extend-2.c4
@@ -1,0 +1,56 @@
+// Security team extends relations with security metadata
+model {
+  // Extend Test 1: No kind, "Makes requests" - should only extend the untyped relation
+  extend frontend -> api "Makes requests" {
+    #security #compliance #ops         // Overlaps with ops/perf, adds security/compliance
+    metadata {
+      encryption 'TLS 1.3'             // New key
+      authentication 'OAuth2'          // New key
+    }
+    link https://api.example.com/docs "API Documentation"  // Duplicate title - should be deduplicated
+    link https://api.example.com/docs "Deployment Guide"   // Different title - should be kept
+    link https://security.example.com "Security Guidelines"
+  }
+
+  // Extend Test 2: kind=sync, "Makes requests" - should only extend the sync relation (NOT Test 1)
+  extend frontend -[sync]-> api "Makes requests" {
+    #security
+    metadata {
+      encryption 'TLS 1.2'             // Different encryption for sync
+      cors_enabled 'true'              // New key
+    }
+  }
+
+  // Extend Test 3: kind=async, different title
+  extend frontend -[async]-> api "Sends analytics data" {
+    #security #analytics
+    metadata {
+      encryption 'mTLS'                // Different security for analytics
+      data_classification 'internal'   // New key
+    }
+  }
+
+  extend api -> authService "Validates tokens" {
+    #security #gateway
+    metadata {
+      protocol 'MTLS'                  // Further extends protocol -> ['REST', 'gRPC', 'MTLS']
+      auth_method 'JWT'                // New key
+      rate_limit '500req/s'            // New key
+    }
+  }
+
+  extend authService -> userDB "Queries users" {
+    #db #audit
+    metadata {
+      encryption_at_rest 'AES-256'     // New key
+      access_control 'RBAC'            // New key
+      audit_logging 'enabled'          // New key
+    }
+  }
+
+  // Extend Test 5 (part 2): Add overlapping and new tags on the same relation
+  extend api -> userDB "Stores data" {
+    #baseTag #compliance
+  }
+}
+

--- a/packages/language-server/src/ast.ts
+++ b/packages/language-server/src/ast.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2025 Denis Davydkov
+// Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import type * as c4 from '@likec4/core'
 import { invariant, MultiMap, nonexhaustive } from '@likec4/core/utils'
 import type { AstNode, AstNodeDescription, DiagnosticInfo, LangiumDocument } from 'langium'
@@ -98,6 +105,14 @@ export interface ParsedAstElement {
 
 export interface ParsedAstExtend {
   id: c4.Fqn
+  astPath: string
+  tags?: c4.NonEmptyArray<c4.Tag> | null
+  links?: c4.NonEmptyArray<c4.Link> | null
+  metadata?: { [key: string]: string | string[] }
+}
+
+export interface ParsedAstExtendRelation {
+  id: c4.RelationId
   astPath: string
   tags?: c4.NonEmptyArray<c4.Tag> | null
   links?: c4.NonEmptyArray<c4.Link> | null
@@ -218,6 +233,7 @@ export interface LikeC4DocumentProps {
   c4Elements?: ParsedAstElement[]
   c4ExtendElements?: ParsedAstExtend[]
   c4ExtendDeployments?: ParsedAstExtend[]
+  c4ExtendRelations?: ParsedAstExtendRelation[]
   c4Relations?: ParsedAstRelation[]
   c4Globals?: ParsedAstGlobals
   c4Views?: ParsedAstView[]
@@ -253,6 +269,7 @@ export function isParsedLikeC4LangiumDocument(
     && !!doc.c4Elements
     && !!doc.c4ExtendElements
     && !!doc.c4ExtendDeployments
+    && !!doc.c4ExtendRelations
     && !!doc.c4Relations
     && !!doc.c4Views
     && !!doc.c4Deployments

--- a/packages/language-server/src/like-c4.langium
+++ b/packages/language-server/src/like-c4.langium
@@ -105,6 +105,7 @@ Model:
   name='model' '{'
     elements+=(
       ExtendElement |
+      ExtendRelation |
       Relation<true> |
       Element
     )*
@@ -162,6 +163,28 @@ ExtendElementBody:  '{'
 ;
 
 ExtendElementProperty:
+  LinkProperty |
+  MetadataProperty;
+
+ExtendRelation:
+  'extend' source=FqnRef
+  (
+    dotKind=RelationKindDotRef |
+    '-[' kind=[RelationshipKind] ']->' |
+    '->'
+  )
+  target=FqnRef
+  title=String?
+  body=ExtendRelationBody
+;
+
+ExtendRelationBody: '{'
+  tags=Tags?
+  props+=ExtendRelationProperty*
+'}'
+;
+
+ExtendRelationProperty:
   LinkProperty |
   MetadataProperty;
 

--- a/packages/language-server/src/lsp/DocumentSymbolProvider.ts
+++ b/packages/language-server/src/lsp/DocumentSymbolProvider.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2025 Denis Davydkov
+// Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { nonexhaustive } from '@likec4/core'
 import { type AstNode, type LangiumDocument, AstUtils, DocumentState, GrammarUtils } from 'langium'
 import type { DocumentSymbolProvider, NodeKindProvider } from 'langium/lsp'
@@ -129,7 +136,11 @@ export class LikeC4DocumentSymbolProvider implements DocumentSymbolProvider {
         name: astModel.name,
         range: cstModel.range,
         selectionRange: nameNode.range,
-        children: astModel.elements.flatMap(e => this.getElementsSymbol(e)),
+        children: astModel.elements.flatMap(e => {
+          // Skip ExtendRelation nodes as they don't need symbols
+          if (ast.isExtendRelation(e)) return []
+          return this.getElementsSymbol(e)
+        }),
       },
     ]
   }

--- a/packages/language-server/src/model/__tests__/model-builder-extend-relation.spec.ts
+++ b/packages/language-server/src/model/__tests__/model-builder-extend-relation.spec.ts
@@ -1,0 +1,166 @@
+import { values } from 'remeda'
+import { describe, it } from 'vitest'
+import { createTestServices } from '../../test'
+
+// NOTE: These unit tests verify the extend relation matching logic and edge cases.
+// For comprehensive end-to-end testing including metadata merging, tag deduplication,
+// and link deduplication, see:
+// - packages/likec4/src/LikeC4.relation-extend.integration.spec.ts
+// - examples/multi-relation-extend/
+
+describe('Model Builder - Extend Relation', () => {
+  it('does not extend relation when title does not match', async ({ expect }) => {
+    const { validate, buildLikeC4Model } = createTestServices()
+    await validate(`
+      specification {
+        element component
+      }
+      model {
+        component sourceNode
+        component targetNode
+        sourceNode -> targetNode "Makes requests"
+      }
+    `)
+    await validate(`
+      model {
+        // Wrong title - should not match
+        extend sourceNode -> targetNode "Different title" {
+          metadata {
+            protocol 'HTTP'
+          }
+        }
+      }
+    `)
+
+    const model = await buildLikeC4Model()
+    const relations = values(model.$data.relations)
+    expect(relations).toHaveLength(1)
+    const relation = relations[0]
+    // Should not have metadata from the extend
+    expect(relation?.metadata).toBeUndefined()
+  })
+
+  it('does not extend relation when kind does not match', async ({ expect }) => {
+    const { validate, buildLikeC4Model } = createTestServices()
+    await validate(`
+      specification {
+        element component
+        relationship sync
+        relationship async
+      }
+      model {
+        component sourceNode
+        component targetNode
+        sourceNode -[sync]-> targetNode
+      }
+    `)
+    await validate(`
+      model {
+        // Wrong kind - should not match
+        extend sourceNode -[async]-> targetNode {
+          metadata {
+            protocol 'HTTP'
+          }
+        }
+      }
+    `)
+
+    const model = await buildLikeC4Model()
+    const relations = values(model.$data.relations)
+    expect(relations).toHaveLength(1)
+    const relation = relations[0]
+    expect(relation?.kind).toBe('sync')
+    // Should not have metadata from the extend
+    expect(relation?.metadata).toBeUndefined()
+  })
+
+  it('deduplicates links with same URL and title from multiple extends', async ({ expect }) => {
+    const { validate, buildLikeC4Model } = createTestServices()
+    await validate(`
+      specification {
+        element component
+      }
+      model {
+        component sourceNode
+        component targetNode
+        sourceNode -> targetNode
+      }
+    `)
+    // First extend adds links
+    await validate(`
+      model {
+        extend sourceNode -> targetNode {
+          link https://example.com/docs "API Docs"
+          link https://example.com/docs "User Guide"
+        }
+      }
+    `)
+    // Second extend tries to add duplicate and new links
+    await validate(`
+      model {
+        extend sourceNode -> targetNode {
+          link https://example.com/docs "API Docs"  // Should be deduplicated
+          link https://example.com/docs "Admin Guide"  // Should be added
+          link https://security.example.com "Security"
+        }
+      }
+    `)
+
+    const model = await buildLikeC4Model()
+    const relations = values(model.$data.relations)
+    expect(relations).toHaveLength(1)
+    const relation = relations[0]
+    expect(relation?.links).toHaveLength(4) // Should have 4 unique links
+
+    const linkTitles = new Set(relation?.links?.map(l => l.title))
+    expect(linkTitles).toEqual(new Set(['API Docs', 'User Guide', 'Admin Guide', 'Security']))
+
+    // Verify that "API Docs" appears only once (was deduplicated)
+    const apiDocsCount = relation?.links?.filter(l => l.title === 'API Docs').length
+    expect(apiDocsCount).toBe(1)
+  })
+
+  it('merges and deduplicates tags from multiple extends', async ({ expect }) => {
+    const { validate, buildLikeC4Model } = createTestServices()
+    await validate(`
+      specification {
+        element component
+        tag alpha
+        tag beta
+        tag gamma
+      }
+      model {
+        component a
+        component b
+        a -> b
+      }
+    `)
+
+    // First extend adds tags alpha, beta
+    await validate(`
+      model {
+        extend a -> b {
+          #alpha #beta
+        }
+      }
+    `)
+    // Second extend adds beta (duplicate) and gamma
+    await validate(`
+      model {
+        extend a -> b {
+          #beta #gamma
+        }
+      }
+    `)
+
+    const model = await buildLikeC4Model()
+    const relations = values(model.$data.relations)
+    expect(relations).toHaveLength(1)
+    const relation = relations[0]
+    expect(relation?.tags).toBeDefined()
+    expect(relation?.tags).toEqual(expect.arrayContaining(['alpha', 'beta', 'gamma']))
+    // Ensure de-duplication (beta only once)
+    const unique = Array.from(new Set(relation?.tags))
+    expect(unique.length).toBe(3)
+  })
+})

--- a/packages/language-server/src/model/fqn-index.ts
+++ b/packages/language-server/src/model/fqn-index.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2025 Denis Davydkov
+// Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { invariant, nonNullable } from '@likec4/core'
 import { type ProjectId, Fqn } from '@likec4/core/types'
 import { ancestorsFqn, compareNatural, DefaultWeakMap, MultiMap, sortNaturalByFqn } from '@likec4/core/utils'
@@ -208,7 +215,7 @@ export class FqnIndex<AstNd = ast.Element> extends ADisposable {
       let _nested = [] as AstNodeDescriptionWithFqn[]
       if (isDefined(el.body) && !isEmpty(el.body.elements)) {
         for (const child of el.body.elements) {
-          if (!ast.isRelation(child)) {
+          if (!ast.isRelation(child) && !ast.isExtendRelation(child)) {
             try {
               _nested.push(...traverseNode(child, thisFqn))
             } catch (e) {
@@ -238,7 +245,7 @@ export class FqnIndex<AstNd = ast.Element> extends ADisposable {
 
     for (const node of rootElements) {
       try {
-        if (ast.isRelation(node)) {
+        if (ast.isRelation(node) || ast.isExtendRelation(node)) {
           continue
         }
         traverseNode(node, null)

--- a/packages/language-server/src/model/model-parser.ts
+++ b/packages/language-server/src/model/model-parser.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2025 Denis Davydkov
+// Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import type { ProjectId } from '@likec4/core'
 import { DefaultWeakMap, invariant, MultiMap } from '@likec4/core/utils'
 import { type LangiumDocument, type Stream, DocumentState, UriUtils } from 'langium'
@@ -131,6 +138,7 @@ export class LikeC4ModelParser {
       c4Elements: [],
       c4ExtendElements: [],
       c4ExtendDeployments: [],
+      c4ExtendRelations: [],
       c4Relations: [],
       c4Deployments: [],
       c4DeploymentRelations: [],

--- a/packages/language-server/src/validation/index.ts
+++ b/packages/language-server/src/validation/index.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2025 Denis Davydkov
+// Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { onNextTick } from '@likec4/core/utils'
 import { loggable } from '@likec4/log'
 import { type AstNode, DocumentState } from 'langium'
@@ -22,7 +29,7 @@ import {
   notesPropertyRuleChecks,
   opacityPropertyRuleChecks,
 } from './property-checks'
-import { checkRelationBody, relationChecks } from './relation'
+import { checkRelationBody, extendRelationChecks, relationChecks } from './relation'
 import {
   checkDeploymentNodeKind,
   checkElementKind,
@@ -95,6 +102,7 @@ const isValidatableAstNode = validatableAstNodeGuards([
   ast.isElementRef,
   ast.isExtendElement,
   ast.isExtendDeployment,
+  ast.isExtendRelation,
   ast.isSpecificationElementKind,
   ast.isSpecificationRelationshipKind,
   ast.isSpecificationDeploymentNodeKind,
@@ -149,6 +157,7 @@ export function registerValidationChecks(services: LikeC4Services) {
     DeploymentNode: deploymentNodeChecks(services),
     DeploymentRelation: deploymentRelationChecks(services),
     ExtendDeployment: extendDeploymentChecks(services),
+    ExtendRelation: extendRelationChecks(services),
     FqnRefExpr: checkFqnRefExpr(services),
     RelationExpr: checkRelationExpr(services),
     NotesProperty: notesPropertyRuleChecks(services),

--- a/packages/language-server/src/validation/relation.ts
+++ b/packages/language-server/src/validation/relation.ts
@@ -1,9 +1,41 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2025 Denis Davydkov
+// Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { FqnRef, isSameHierarchy } from '@likec4/core'
 import { type ValidationCheck, AstUtils } from 'langium'
-import { ast } from '../ast'
+import { type LikeC4LangiumDocument, ast, isParsedLikeC4LangiumDocument } from '../ast'
 import type { LikeC4Services } from '../module'
 import { safeCall } from '../utils'
+import { stringHash } from '../utils/stringHash'
 import { tryOrLog } from './_shared'
+
+// Cache of relation match keys to avoid recomputing for every extend validation
+let cachedRelationKeys: Set<string> | null = null
+let cachedDocsFingerprint: string | null = null
+
+const computeDocsFingerprint = (docs: LikeC4LangiumDocument[]): string => {
+  return docs
+    .map(doc => {
+      const relationHashes = (doc.c4Relations ?? [])
+        .map(rel =>
+          stringHash(
+            'extend-relation',
+            FqnRef.flatten(rel.source),
+            FqnRef.flatten(rel.target),
+            rel.kind ?? 'default',
+            rel.title ?? '',
+          )
+        )
+        .sort()
+        .join(',')
+      return `${doc.uri.toString()}:${relationHashes}`
+    })
+    .join('|')
+}
 
 export const relationChecks = (services: LikeC4Services): ValidationCheck<ast.Relation> => {
   const modelParser = services.likec4.ModelParser
@@ -55,6 +87,95 @@ export const checkRelationBody = (_services: LikeC4Services): ValidationCheck<as
     if (relation.tags?.values && body.tags?.values) {
       accept('error', 'Relation cannot have tags in both header and body', {
         node: body.tags,
+      })
+    }
+  })
+}
+
+export const extendRelationChecks = (services: LikeC4Services): ValidationCheck<ast.ExtendRelation> => {
+  const modelParser = services.likec4.ModelParser
+
+  return tryOrLog((el, accept) => {
+    const parser = modelParser.forDocument(AstUtils.getDocument(el))
+
+    const source = safeCall(() => parser.parseFqnRef(el.source))
+    if (!source) {
+      accept('error', 'Source not resolved', {
+        node: el,
+        property: 'source',
+      })
+      return
+    }
+    const target = safeCall(() => parser.parseFqnRef(el.target))
+    if (!target) {
+      accept('error', 'Target not resolved', {
+        node: el,
+        property: 'target',
+      })
+      return
+    }
+
+    if (!FqnRef.isModelRef(source) && !FqnRef.isImportRef(source)) {
+      accept('error', 'Source must reference a model element', {
+        node: el,
+        property: 'source',
+      })
+      return
+    }
+
+    if (!FqnRef.isModelRef(target) && !FqnRef.isImportRef(target)) {
+      accept('error', 'Target must reference a model element', {
+        node: el,
+        property: 'target',
+      })
+      return
+    }
+
+    // Warn if this extend does not match any relation in the workspace
+    // Build a match key identical to buildModel.ts
+    const kind = (el.kind ?? el.dotKind?.kind)?.ref?.name ?? 'default'
+    // Normalize title using the same parser helper
+    const { title = '' } = parser.parseBaseProps({}, { title: el.title })
+
+    const extendKey = stringHash(
+      'extend-relation',
+      FqnRef.flatten(source),
+      FqnRef.flatten(target),
+      kind,
+      title,
+    )
+
+    // Build (or reuse) a Set of all relation match keys across the workspace.
+    // This avoids O(E x D x R) scans on large workspaces.
+    const docs = services.shared.workspace.LangiumDocuments.all
+      .toArray()
+      .filter(isParsedLikeC4LangiumDocument)
+
+    const fingerprint = computeDocsFingerprint(docs)
+
+    if (fingerprint !== cachedDocsFingerprint) {
+      const keys = new Set<string>()
+      for (const d of docs) {
+        for (const rel of d.c4Relations ?? []) {
+          const key = stringHash(
+            'extend-relation',
+            FqnRef.flatten(rel.source),
+            FqnRef.flatten(rel.target),
+            rel.kind ?? 'default',
+            rel.title ?? '',
+          )
+          keys.add(key)
+        }
+      }
+      cachedRelationKeys = keys
+      cachedDocsFingerprint = fingerprint
+    }
+
+    const hasMatch = cachedRelationKeys?.has(extendKey) ?? false
+
+    if (!hasMatch) {
+      accept('warning', 'This extend does not match any relation (by source, kind, target, title)', {
+        node: el,
       })
     }
   })

--- a/packages/likec4/src/LikeC4.relation-extend.integration.spec.ts
+++ b/packages/likec4/src/LikeC4.relation-extend.integration.spec.ts
@@ -1,0 +1,177 @@
+import { resolve } from 'node:path'
+import { describe, it } from 'vitest'
+import { LikeC4 } from './LikeC4'
+
+function findRelations(model: any, filter: (r: any) => boolean) {
+  return Object.values(model.relations as Record<string, any>).filter(filter)
+}
+
+describe('Integration: relation extend in examples/multi-relation-extend', () => {
+  it('merges metadata correctly for untyped and sync relations with same title', async ({ expect }) => {
+    const workspace = resolve(__dirname, '../../../examples/multi-relation-extend')
+    const likec4 = await LikeC4.fromWorkspace(workspace, { throwIfInvalid: true, printErrors: false })
+
+    const model = likec4.computedModel()
+
+    // Untyped: frontend -> api "Makes requests"
+    const untyped = findRelations(
+      model.$data,
+      (r) => !r.kind && r.title === 'Makes requests' && r.source.model === 'frontend' && r.target.model === 'api',
+    )
+    expect(untyped).toHaveLength(1)
+    expect(untyped[0].metadata).toMatchObject({
+      latency_p95: '150ms',
+      rate_limit: '1000req/s',
+      encryption: 'TLS 1.3',
+      authentication: 'OAuth2',
+    })
+
+    // Sync: frontend -[sync]-> api "Makes requests"
+    const sync = findRelations(
+      model.$data,
+      (r) =>
+        r.kind === 'sync' && r.title === 'Makes requests' && r.source.model === 'frontend' && r.target.model === 'api',
+    )
+    expect(sync).toHaveLength(1)
+    expect(sync[0].metadata).toMatchObject({
+      format: 'JSON',
+      latency_p95: '80ms',
+      cache_enabled: 'true',
+      encryption: 'TLS 1.2',
+      cors_enabled: 'true',
+    })
+  })
+
+  it('correctly handles async relation with different title', async ({ expect }) => {
+    const workspace = resolve(__dirname, '../../../examples/multi-relation-extend')
+    const likec4 = await LikeC4.fromWorkspace(workspace, { throwIfInvalid: true, printErrors: false })
+
+    const model = likec4.computedModel()
+
+    // Async: frontend -[async]-> api "Sends analytics data"
+    const async = findRelations(
+      model.$data,
+      (r) =>
+        r.kind === 'async' &&
+        r.title === 'Sends analytics data' &&
+        r.source.model === 'frontend' &&
+        r.target.model === 'api',
+    )
+    expect(async).toHaveLength(1)
+    expect(async[0].metadata).toMatchObject({
+      protocol: 'gRPC',
+      batch_size: '100',
+      latency_p95: '500ms',
+      compression: 'gzip',
+    })
+  })
+
+  it('normalizes empty title correctly (no title and empty string are same)', async ({ expect }) => {
+    const workspace = resolve(__dirname, '../../../examples/multi-relation-extend')
+    const likec4 = await LikeC4.fromWorkspace(workspace, { throwIfInvalid: true, printErrors: false })
+
+    const model = likec4.computedModel()
+
+    // Both "userDB -> authService" and 'userDB -> authService ""' should be treated as same relation
+    const relations = findRelations(
+      model.$data,
+      (r) => r.source.model === 'userDB' && r.target.model === 'authService',
+    )
+
+    // Should have exactly 2 relations (one with no title, one with empty string, both get same extends)
+    expect(relations).toHaveLength(2)
+
+    // Both should have the same extends applied
+    for (const rel of relations) {
+      expect(rel.metadata).toMatchObject({
+        response_time: '20ms',
+        read_only: 'true',
+        empty_title_test: 'yes',
+        special_case: 'empty_string',
+      })
+      expect(rel.tags).toEqual(expect.arrayContaining(['db', 'internal', 'empty_title']))
+    }
+  })
+
+  it('merges metadata into arrays when values differ', async ({ expect }) => {
+    const workspace = resolve(__dirname, '../../../examples/multi-relation-extend')
+    const likec4 = await LikeC4.fromWorkspace(workspace, { throwIfInvalid: true, printErrors: false })
+
+    const model = likec4.computedModel()
+
+    // api -> authService "Validates tokens" has protocol merged from multiple extends
+    const relations = findRelations(
+      model.$data,
+      (r) => r.source.model === 'api' && r.target.model === 'authService' && r.title === 'Validates tokens',
+    )
+    expect(relations).toHaveLength(1)
+    const rel = relations[0]
+
+    // Protocol should be an array with merged values
+    expect(rel.metadata.protocol).toEqual(expect.arrayContaining(['REST', 'gRPC']))
+    expect(rel.metadata.timeout).toBe('5s')
+    expect(rel.metadata.retry_policy).toBe('exponential')
+  })
+
+  it('deduplicates metadata when values are same', async ({ expect }) => {
+    const workspace = resolve(__dirname, '../../../examples/multi-relation-extend')
+    const likec4 = await LikeC4.fromWorkspace(workspace, { throwIfInvalid: true, printErrors: false })
+
+    const model = likec4.computedModel()
+
+    // authService -> userDB "Queries users" has connection_type in base and extend (same value)
+    const relations = findRelations(
+      model.$data,
+      (r) => r.source.model === 'authService' && r.target.model === 'userDB' && r.title === 'Queries users',
+    )
+    expect(relations).toHaveLength(1)
+    const rel = relations[0]
+
+    // connection_type should be a single string (deduplicated), not an array
+    expect(rel.metadata.connection_type).toBe('connection_pool')
+    expect(Array.isArray(rel.metadata.connection_type)).toBe(false)
+    expect(rel.metadata.max_connections).toBe('50')
+    expect(rel.metadata.query_timeout).toBe('3s')
+  })
+
+  it('deduplicates and merges tags correctly', async ({ expect }) => {
+    const workspace = resolve(__dirname, '../../../examples/multi-relation-extend')
+    const likec4 = await LikeC4.fromWorkspace(workspace, { throwIfInvalid: true, printErrors: false })
+
+    const model = likec4.computedModel()
+
+    // api -> userDB "Stores data" has tags from base and extends
+    const relations = findRelations(
+      model.$data,
+      (r) => r.source.model === 'api' && r.target.model === 'userDB' && r.title === 'Stores data',
+    )
+    expect(relations).toHaveLength(1)
+    const rel = relations[0]
+
+    // Should have all unique tags from base and extends
+    expect(rel.tags).toEqual(expect.arrayContaining(['baseTag', 'security', 'ops', 'compliance']))
+    // Ensure no duplicates
+    const uniqueTags = new Set(rel.tags)
+    expect(uniqueTags.size).toBe(rel.tags?.length)
+  })
+
+  it('deduplicates links with same URL and title', async ({ expect }) => {
+    const workspace = resolve(__dirname, '../../../examples/multi-relation-extend')
+    const likec4 = await LikeC4.fromWorkspace(workspace, { throwIfInvalid: true, printErrors: false })
+
+    const model = likec4.computedModel()
+
+    // frontend -> api "Makes requests" (untyped) has duplicate links
+    const relations = findRelations(
+      model.$data,
+      (r) => !r.kind && r.title === 'Makes requests' && r.source.model === 'frontend' && r.target.model === 'api',
+    )
+    expect(relations).toHaveLength(1)
+    const rel = relations[0]
+
+    // Check that duplicate links are removed
+    const linkUrls = rel.links?.map((l: any) => ({ url: l.url, title: l.title })) || []
+    const uniqueLinks = Array.from(new Set(linkUrls.map((l: any) => `${l.url}|${l.title || ''}`)))
+    expect(uniqueLinks.length).toBe(rel.links?.length)
+  })
+})

--- a/packages/likec4/src/LikeC4.spec.ts
+++ b/packages/likec4/src/LikeC4.spec.ts
@@ -226,6 +226,14 @@ describe.concurrent('LikeC4', () => {
           ],
           "folder": "multi-metadata-extend",
         },
+        "multi-relation-extend": {
+          "documents": [
+            "base.c4",
+            "extend-1.c4",
+            "extend-2.c4",
+          ],
+          "folder": "multi-relation-extend",
+        },
         "projectA": {
           "documents": [
             "_spec.c4",

--- a/packages/vscode/data/likec4-snippets.json
+++ b/packages/vscode/data/likec4-snippets.json
@@ -7,50 +7,94 @@
   "model": {
     "prefix": ["m", "model"],
     "body": [
-			"model {",
-			"\t$0",
-			"}"
-		],
+      "model {",
+      "\t$0",
+      "}"
+    ],
     "description": "inserts model block"
   },
   "views": {
     "prefix": ["views"],
     "body": [
-			"views {",
-			"\t$0",
-			"}"
-		],
+      "views {",
+      "\t$0",
+      "}"
+    ],
     "description": "inserts views block"
   },
   "view": {
     "prefix": ["v", "view"],
     "body": [
-			"view ${2:view_${TM_FILENAME_BASE}_${CURRENT_SECOND}} of ${1:element} {",
-			"\ttitle '${3:Untitled}'",
-			"\t",
-			"\tinclude $0*",
-			"}"
-		],
+      "view ${2:view_${TM_FILENAME_BASE}_${CURRENT_SECOND}} of ${1:element} {",
+      "\ttitle '${3:Untitled}'",
+      "\t",
+      "\tinclude $0*",
+      "}"
+    ],
     "description": "inserts view block"
   },
   "dynamic view": {
     "prefix": ["dv", "dynamic"],
     "body": [
-			"dynamic view ${1:view_${TM_FILENAME_BASE}_${CURRENT_SECOND}} {",
-			"\ttitle '${2:Untitled}'",
-			"\t",
-			"\t$0",
-			"}"
-		],
+      "dynamic view ${1:view_${TM_FILENAME_BASE}_${CURRENT_SECOND}} {",
+      "\ttitle '${2:Untitled}'",
+      "\t",
+      "\t$0",
+      "}"
+    ],
     "description": "inserts dynamic view block"
   },
   "extend": {
     "prefix": ["ex", "extend"],
     "body": [
-			"extend ${1:element} {",
-			"\t$0",
-			"}"
-		],
+      "extend ${1:element} {",
+      "\t$0",
+      "}"
+    ],
     "description": "inserts extends block"
+  },
+  "extend relation": {
+    "prefix": ["exr", "extend-relation"],
+    "body": [
+      "extend ${1:source} -> ${2:target} \"${3:title}\" {",
+      "\tmetadata {",
+      "\t\t${4:key} '${5:value}'",
+      "\t}",
+      "}"
+    ],
+    "description": "inserts extend relation block"
+  },
+  "extend relation - no title": {
+    "prefix": ["exr-no-title", "extend-relation-no-title"],
+    "body": [
+      "extend ${1:source} -> ${2:target} {",
+      "\tmetadata {",
+      "\t\t${3:key} '${4:value}'",
+      "\t}",
+      "}"
+    ],
+    "description": "inserts extend relation block without a title"
+  },
+  "extend relation - with kind": {
+    "prefix": ["exr-kind", "extend-relation-kind"],
+    "body": [
+      "extend ${1:source} -[${2:kind}]-> ${3:target} \"${4:title}\" {",
+      "\tmetadata {",
+      "\t\t${5:key} '${6:value}'",
+      "\t}",
+      "}"
+    ],
+    "description": "inserts extend relation block with a relationship kind"
+  },
+  "extend relation - with kind, no title": {
+    "prefix": ["exr-kind-no-title", "extend-relation-kind-no-title"],
+    "body": [
+      "extend ${1:source} -[${2:kind}]-> ${3:target} {",
+      "\tmetadata {",
+      "\t\t${4:key} '${5:value}'",
+      "\t}",
+      "}"
+    ],
+    "description": "inserts extend relation block with a relationship kind and no title"
   }
 }


### PR DESCRIPTION
# feat(dsl): add extend relation syntax

## Summary

Adds `extend` syntax for relations, allowing metadata, tags, and links to be added to existing relations from separate files. Works similarly to element extends.

## Changes

- Added `ExtendRelation` grammar to `model` block
- Relations matched by source, target, kind, and title
- Metadata merging with deduplication
- Validation with warnings for unmatched extends
- Documentation and examples in `examples/multi-relation-extend/`
- 4 VSCode snippets added
- 11 new tests (all passing)

## Example

```likec4
// base.c4
model {
  frontend -> api "Makes requests"
}

// extend-ops.c4
model {
  extend frontend -> api "Makes requests" {
    metadata { latency_p95 '150ms' }
  }
}
```

## Limitations

- Deployment model relations not yet supported (documented)





## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask, and propose improvements. We're here to help. -->

- [X] I've thoroughly read the latest [contribution guidelines](https://github.com/likec4/likec4/blob/main/CONTRIBUTING.md).
- [X] I've rebased my branch onto `main` **before** creating this PR.
- [X] My commit messages follow [conventional spec](https://www.conventionalcommits.org/en/)
- [X] I've added tests to cover my changes (if applicable).
- [NA] I've verified that all new and existing tests have passed locally for mobile, tablet, and desktop screen sizes.
- [X] My change requires documentation updates.
- [X] I've updated the documentation accordingly.
