### PR TITLE
feat(language-server/mcp): include links in read-element and read-dep…

### DIFF
--- a/packages/language-server/src/__tests__/mcp-server-links.int.spec.ts
+++ b/packages/language-server/src/__tests__/mcp-server-links.int.spec.ts
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2025 Denis Davydkov
+// Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
+import type { ProjectId } from '@likec4/core'
+import { describe, expect, it } from 'vitest'
+import { LikeC4MCPServerFactory } from '../mcp/MCPServerFactory'
+import { readDeployment } from '../mcp/tools/read-deployment'
+import { readElement } from '../mcp/tools/read-element'
+import { createTestServices } from '../test'
+
+describe('MCP server integration - tools expose links', () => {
+  it('read-element returns links when called via tool handler by name', async () => {
+    const { validate, buildLikeC4Model, services } = createTestServices()
+
+    await validate(`
+      specification {
+        element system
+      }
+      model {
+        cloud = system 'Cloud System' {
+          link https://likec4.dev/docs
+          link https://github.com/likec4/likec4 'repo'
+        }
+      }
+    `)
+
+    await buildLikeC4Model()
+
+    // Spin up MCP server (in-memory) to ensure registration works
+    const mcpFactory = new LikeC4MCPServerFactory({
+      likec4: { LanguageServices: services.likec4.LanguageServices } as any,
+      shared: { lsp: {} } as any,
+    } as any)
+    const _server = mcpFactory.create()
+
+    // Get the tool by name via the registration tuple
+    const [name, _cfg, handler] = readElement(services.likec4.LanguageServices)
+    expect(name).toBe('read-element')
+
+    const result = await handler({ id: 'cloud', project: 'default' as ProjectId } as any, {} as any)
+
+    expect(result.structuredContent).toBeDefined()
+    const links = result.structuredContent!['links'] as Array<{ url: string; title: string | null }>
+    expect(Array.isArray(links)).toBe(true)
+    expect(links.length).toBe(2)
+    expect(links[0]!.url).toBe('https://likec4.dev/docs')
+    expect(links[0]!.title).toBeNull()
+    expect(links[1]!.url).toBe('https://github.com/likec4/likec4')
+    expect(links[1]!.title).toBe('repo')
+  })
+
+  it('read-deployment returns links for deployment nodes', async () => {
+    const { validate, buildLikeC4Model, services } = createTestServices()
+
+    await validate(`
+      specification {
+        deploymentNode cluster
+      }
+      model {}
+      deployment {
+        dc = cluster 'DC' {
+          link https://status.example.com 'status'
+        }
+      }
+    `)
+
+    await buildLikeC4Model()
+
+    const mcpFactory = new LikeC4MCPServerFactory({
+      likec4: { LanguageServices: services.likec4.LanguageServices } as any,
+      shared: { lsp: {} } as any,
+    } as any)
+    const _server = mcpFactory.create()
+
+    const [name, _cfg, handler] = readDeployment(services.likec4.LanguageServices)
+    expect(name).toBe('read-deployment')
+
+    const result = await handler({ id: 'dc', project: 'default' as ProjectId } as any, {} as any)
+
+    expect(result.structuredContent).toBeDefined()
+    const links = result.structuredContent!['links'] as Array<{ url: string; title: string | null }>
+    expect(Array.isArray(links)).toBe(true)
+    expect(links.length).toBe(1)
+    expect(links[0]!.url).toBe('https://status.example.com')
+    expect(links[0]!.title).toBe('status')
+  })
+})

--- a/packages/language-server/src/__tests__/mcp-tools-links.spec.ts
+++ b/packages/language-server/src/__tests__/mcp-tools-links.spec.ts
@@ -1,0 +1,304 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2025 Denis Davydkov
+// Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
+import type { ProjectId } from '@likec4/core'
+import { describe, expect, it } from 'vitest'
+import { readDeployment } from '../mcp/tools/read-deployment'
+import { readElement } from '../mcp/tools/read-element'
+import { createTestServices } from '../test'
+
+describe('MCP Tools - Links', () => {
+  // These tests verify that MCP server tools correctly return link information
+  // in their structured content responses. The tools query the model and
+  // transform links to the expected format:
+  // { title: link.title ?? null, url: link.url, relative: link.relative ?? null }
+
+  describe('read-element tool', () => {
+    it('should include links in element response', async () => {
+      const { validate, buildLikeC4Model, services } = createTestServices()
+
+      await validate(`
+        specification {
+          element system
+          element container
+        }
+        model {
+          cloud = system 'Cloud System' {
+            link https://likec4.dev/docs/dsl/model/
+            link https://github.com/likec4/likec4 'GitHub Repository'
+
+            ui = container 'Frontend' {
+              link https://docs.example.com/frontend 'Documentation'
+              link ./README.md 'Local Docs'
+            }
+          }
+        }
+      `)
+
+      const likec4Model = await buildLikeC4Model()
+      const [_name, _config, readElementHandler] = readElement(services.likec4.LanguageServices)
+
+      const result = await readElementHandler({ id: 'cloud', project: 'default' as ProjectId }, {} as any)
+
+      expect(result.structuredContent).toBeDefined()
+      const links = result.structuredContent!['links'] as Array<{ url: string; title: string | null }>
+      expect(links).toBeDefined()
+      expect(links).toHaveLength(2)
+
+      // Verify MCP tool transforms links correctly
+      expect(links[0]!.url).toBe('https://likec4.dev/docs/dsl/model/')
+      expect(links[0]!.title).toBeNull() // MCP transforms undefined to null
+
+      expect(links[1]!.url).toBe('https://github.com/likec4/likec4')
+      expect(links[1]!.title).toBe('GitHub Repository')
+    })
+
+    it('should have empty links array for elements without links', async () => {
+      const { validate, buildLikeC4Model, services } = createTestServices()
+
+      await validate(`
+        specification {
+          element system
+        }
+        model {
+          cloud = system 'Cloud System'
+        }
+      `)
+
+      const likec4Model = await buildLikeC4Model()
+      const [_name, _config, readElementHandler] = readElement(services.likec4.LanguageServices)
+
+      const result = await readElementHandler({ id: 'cloud', project: 'default' as ProjectId }, {} as any)
+
+      expect(result.structuredContent).toBeDefined()
+      const links = result.structuredContent!['links'] as Array<{ url: string; title: string | null }>
+      expect(links).toBeDefined()
+      expect(links).toHaveLength(0)
+    })
+
+    it('should not crash when element.links is null/undefined', async () => {
+      const { validate, buildLikeC4Model, services } = createTestServices()
+
+      // Test with minimal element that has no links property
+      await validate(`
+        specification {
+          element component
+        }
+        model {
+          minimal = component 'Minimal'
+        }
+      `)
+
+      const likec4Model = await buildLikeC4Model()
+      const [_name, _config, readElementHandler] = readElement(services.likec4.LanguageServices)
+
+      // This should not throw even if element.links is null/undefined
+      const result = await readElementHandler({ id: 'minimal', project: 'default' as ProjectId }, {} as any)
+
+      expect(result.structuredContent).toBeDefined()
+      const links = result.structuredContent!['links'] as Array<{ url: string; title: string | null }>
+      expect(links).toBeDefined()
+      expect(Array.isArray(links)).toBe(true)
+      expect(links).toHaveLength(0)
+    })
+
+    it('should handle relative links correctly', async () => {
+      const { validate, buildLikeC4Model, services } = createTestServices()
+
+      await validate(`
+        specification {
+          element container
+        }
+        model {
+          ui = container 'Frontend' {
+            link ./docs/README.md 'Relative Documentation'
+            link ../CONTRIBUTING.md
+            link /absolute/path.md 'Absolute Path'
+          }
+        }
+      `)
+
+      const likec4Model = await buildLikeC4Model()
+      const [_name, _config, readElementHandler] = readElement(services.likec4.LanguageServices)
+
+      const result = await readElementHandler({ id: 'ui', project: 'default' as ProjectId }, {} as any)
+
+      expect(result.structuredContent).toBeDefined()
+      const links = result.structuredContent!['links'] as Array<{ url: string; title: string | null }>
+      expect(links).toBeDefined()
+      expect(links).toHaveLength(3)
+
+      // Verify MCP tool transforms all links correctly
+      expect(links[0]!.url).toBe('./docs/README.md')
+      expect(links[0]!.title).toBe('Relative Documentation')
+
+      expect(links[1]!.url).toBe('../CONTRIBUTING.md')
+      expect(links[1]!.title).toBeNull()
+
+      expect(links[2]!.url).toBe('/absolute/path.md')
+      expect(links[2]!.title).toBe('Absolute Path')
+    })
+
+    it('should preserve link order', async () => {
+      const { validate, buildLikeC4Model, services } = createTestServices()
+
+      await validate(`
+        specification {
+          element system
+        }
+        model {
+          cloud = system 'Cloud System' {
+            link https://first.com 'First'
+            link https://second.com 'Second'
+            link https://third.com 'Third'
+          }
+        }
+      `)
+
+      const likec4Model = await buildLikeC4Model()
+      const [_name, _config, readElementHandler] = readElement(services.likec4.LanguageServices)
+
+      const result = await readElementHandler({ id: 'cloud', project: 'default' as ProjectId }, {} as any)
+
+      const links = result.structuredContent!['links'] as Array<{ url: string; title: string | null }>
+      expect(links).toHaveLength(3)
+      expect(links[0]!.url).toBe('https://first.com')
+      expect(links[1]!.url).toBe('https://second.com')
+      expect(links[2]!.url).toBe('https://third.com')
+    })
+  })
+
+  describe('read-deployment tool', () => {
+    it('should include links in deployment nodes', async () => {
+      const { validate, buildLikeC4Model, services } = createTestServices()
+
+      await validate(`
+        specification {
+          deploymentNode cluster
+        }
+        model {}
+        deployment {
+          datacenter = cluster 'Data Center' {
+            link https://datacenter.example.com 'Monitoring Dashboard'
+            link https://status.example.com
+          }
+        }
+      `)
+
+      const likec4Model = await buildLikeC4Model()
+      const [_name, _config, readDeploymentHandler] = readDeployment(services.likec4.LanguageServices)
+
+      const result = await readDeploymentHandler({ id: 'datacenter', project: 'default' as ProjectId }, {} as any)
+
+      expect(result.structuredContent).toBeDefined()
+      const links = result.structuredContent!['links'] as Array<{ url: string; title: string | null }>
+      expect(links).toBeDefined()
+      expect(links).toHaveLength(2)
+
+      expect(links[0]!.url).toBe('https://datacenter.example.com')
+      expect(links[0]!.title).toBe('Monitoring Dashboard')
+
+      expect(links[1]!.url).toBe('https://status.example.com')
+      expect(links[1]!.title).toBeNull()
+    })
+
+    it('should have empty links array for deployment nodes without links', async () => {
+      const { validate, buildLikeC4Model, services } = createTestServices()
+
+      await validate(`
+        specification {
+          element system
+          deploymentNode cluster
+        }
+        model {
+          cloud = system 'Cloud System'
+        }
+        deployment {
+          datacenter = cluster 'Data Center'
+        }
+      `)
+
+      const likec4Model = await buildLikeC4Model()
+      const [_name, _config, readDeploymentHandler] = readDeployment(services.likec4.LanguageServices)
+
+      const result = await readDeploymentHandler({ id: 'datacenter', project: 'default' as ProjectId }, {} as any)
+
+      expect(result.structuredContent).toBeDefined()
+      const links = result.structuredContent!['links'] as Array<{ url: string; title: string | null }>
+      expect(links).toBeDefined()
+      expect(links).toHaveLength(0)
+    })
+
+    it('should not crash when deployment node links is null/undefined', async () => {
+      const { validate, buildLikeC4Model, services } = createTestServices()
+
+      // Test with minimal deployment node that has no links property
+      await validate(`
+        specification {
+          deploymentNode server
+        }
+        model {}
+        deployment {
+          minimal = server 'Minimal Server'
+        }
+      `)
+
+      const likec4Model = await buildLikeC4Model()
+      const [_name, _config, readDeploymentHandler] = readDeployment(services.likec4.LanguageServices)
+
+      // This should not throw even if element.links is null/undefined
+      const result = await readDeploymentHandler({ id: 'minimal', project: 'default' as ProjectId }, {} as any)
+
+      expect(result.structuredContent).toBeDefined()
+      const links = result.structuredContent!['links'] as Array<{ url: string; title: string | null }>
+      expect(links).toBeDefined()
+      expect(Array.isArray(links)).toBe(true)
+      expect(links).toHaveLength(0)
+    })
+
+    it('should include links in deployed instances', async () => {
+      const { validate, buildLikeC4Model, services } = createTestServices()
+
+      await validate(`
+        specification {
+          element system
+          deploymentNode server
+        }
+        model {
+          cloud = system 'Cloud System'
+        }
+        deployment {
+          server1 = server 'Web Server' {
+            cloudInstance = instanceOf cloud {
+              link https://console.example.com 'Console'
+              link https://health.example.com
+            }
+          }
+        }
+      `)
+
+      const likec4Model = await buildLikeC4Model()
+      const [_name, _config, readDeploymentHandler] = readDeployment(services.likec4.LanguageServices)
+
+      const result = await readDeploymentHandler(
+        { id: 'server1.cloudInstance', project: 'default' as ProjectId },
+        {} as any,
+      )
+
+      expect(result.structuredContent).toBeDefined()
+      const links = result.structuredContent!['links'] as Array<{ url: string; title: string | null }>
+      expect(links).toBeDefined()
+      expect(links).toHaveLength(2)
+
+      expect(links[0]!.url).toBe('https://console.example.com')
+      expect(links[0]!.title).toBe('Console')
+
+      expect(links[1]!.url).toBe('https://health.example.com')
+      expect(links[1]!.title).toBeNull()
+    })
+  })
+})

--- a/packages/language-server/src/mcp/tools/read-deployment.ts
+++ b/packages/language-server/src/mcp/tools/read-deployment.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2025 Denis Davydkov
+// Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { invariant } from '@likec4/core'
 import * as z from 'zod/v3'
 import { likec4Tool } from '../utils'
@@ -26,6 +33,7 @@ Output fields:
 - tags: string[] — Tags assigned to this entity
 - project: string — Project id
 - metadata: Record<string, string>
+- links: Array<{ title: string|null, url: string, relative: string|null }> — external links associated with this deployment entity
 - shape: string — Rendered shape
 - color: string — Rendered color
 - children: string[] — Child deployment ids (empty for instances)
@@ -56,6 +64,7 @@ Example response (deployed instance):
   "tags": ["prod"],
   "project": "default",
   "metadata": {},
+  "links": [],
   "shape": "rectangle",
   "color": "#2F80ED",
   "children": [],
@@ -89,6 +98,11 @@ Example response (deployed instance):
     tags: z.array(z.string()),
     project: z.string(),
     metadata: z.record(z.union([z.string(), z.array(z.string())])),
+    links: z.array(z.object({
+      title: z.string().nullable().describe('Optional link title'),
+      url: z.string().describe('Link URL'),
+      relative: z.string().nullable().describe('Relative path (if URL is relative to workspace root)'),
+    })).describe('External links associated with this deployment entity'),
     shape: z.string(),
     color: z.string(),
     children: z.array(z.string()).describe('Children of this deployment node (Array of Deployment ids)'),
@@ -119,6 +133,11 @@ Example response (deployed instance):
     tags: [...element.tags],
     project: projectId,
     metadata: element.getMetadata(),
+    links: (element.links ?? []).map(link => ({
+      title: link.title ?? null,
+      url: link.url,
+      relative: link.relative ?? null,
+    })),
     shape: element.shape,
     color: element.color,
     children: element.isInstance() ? [] : [...element.children()].map(c => c.id),

--- a/packages/language-server/src/mcp/tools/read-element.ts
+++ b/packages/language-server/src/mcp/tools/read-element.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2025 Denis Davydkov
+// Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { invariant } from '@likec4/core'
 import * as z from 'zod/v3'
 import { likec4Tool } from '../utils'
@@ -22,6 +29,7 @@ Response (JSON object):
 - tags: string[] — assigned tags
 - project: string — project id this element belongs to
 - metadata: Record<string, string> — element metadata
+- links: Array<{ title: string|null, url: string, relative: string|null }> — external links associated with this element
 - shape: string — rendered shape
 - color: string — rendered color
 - children: string[] — ids (FQNs) of direct child elements
@@ -53,6 +61,13 @@ Example response:
   "tags": ["public"],
   "project": "default",
   "metadata": { "owner": "web" },
+  "links": [
+    {
+      "title": "Documentation",
+      "url": "https://docs.example.com/frontend",
+      "relative": null
+    }
+  ],
   "shape": "rounded-rectangle",
   "color": "#2F80ED",
   "children": ["shop.frontend.auth"],
@@ -104,6 +119,11 @@ Example response:
     tags: z.array(z.string()),
     project: z.string(),
     metadata: z.record(z.union([z.string(), z.array(z.string())])),
+    links: z.array(z.object({
+      title: z.string().nullable().describe('Optional link title'),
+      url: z.string().describe('Link URL'),
+      relative: z.string().nullable().describe('Relative path (if URL is relative to workspace root)'),
+    })).describe('External links associated with this element'),
     shape: z.string(),
     color: z.string(),
     children: z.array(z.string()).describe('Children of this element (Array of FQNs)'),
@@ -162,6 +182,11 @@ Example response:
     tags: [...element.tags],
     project: projectId,
     metadata: element.getMetadata(),
+    links: (element.links ?? []).map(link => ({
+      title: link.title ?? null,
+      url: link.url,
+      relative: link.relative ?? null,
+    })),
     shape: element.shape,
     color: element.color,
     children: [...element.children()].map(c => c.id),


### PR DESCRIPTION
# feat(language-server/mcp): include links in read-element and read-deployment tool responses

## Summary

Adds `links` field to MCP tool responses for `read-element` and `read-deployment` tools, exposing element/deployment links to MCP clients.

## Changes

- Added `links` array to `read-element` and `read-deployment` tool responses
- Links format: `{ title: string|null, url: string, relative: string|null }`
- Added 9 unit tests and 2 integration tests (11 total)

## Example Response

```json
{
  "id": "frontend",
  "name": "frontend",
  "kind": "component",
  "title": "Frontend Application",
  "links": [
    {
      "title": "Documentation",
      "url": "https://docs.example.com/frontend",
      "relative": null
    },
    {
      "title": null,
      "url": "./src/frontend/README.md",
      "relative": "src/frontend/README.md"
    }
  ],
  ...
}
```


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask, and propose improvements. We're here to help. -->

- [X] I've thoroughly read the latest [contribution guidelines](https://github.com/likec4/likec4/blob/main/CONTRIBUTING.md).
- [X] I've rebased my branch onto `main` **before** creating this PR.
- [X] My commit messages follow [conventional spec](https://www.conventionalcommits.org/en/)
- [X] I've added tests to cover my changes (if applicable).
- [NA] I've verified that all new and existing tests have passed locally for mobile, tablet, and desktop screen sizes.
- [NA] My change requires documentation updates.
- [NA] I've updated the documentation accordingly.
