### PR TITLE
feat: Direct links to Relationship Views

### DIFF
--- a/packages/likec4/app/src/pages/ViewEditor.tsx
+++ b/packages/likec4/app/src/pages/ViewEditor.tsx
@@ -5,7 +5,7 @@ import { NotFound } from '../components/NotFound'
 import { isDevelopment, onViewChangeViaPlugin } from '../const'
 import { useLikeC4ModelAtom } from '../context/safeCtx'
 import { useCurrentProject, useCurrentView } from '../hooks'
-import { ListenForDynamicVariantChange } from './ViewReact'
+import { ListenForDynamicVariantChange, OpenRelationshipBrowserFromUrl } from './ViewReact'
 
 export function ViewEditor() {
   const navigate = useNavigate()
@@ -82,6 +82,7 @@ export function ViewEditor() {
         }}
       >
         <ListenForDynamicVariantChange />
+        <OpenRelationshipBrowserFromUrl />
       </LikeC4Diagram>
     </LikeC4EditorProvider>
   )

--- a/packages/likec4/app/src/pages/ViewReact.tsx
+++ b/packages/likec4/app/src/pages/ViewReact.tsx
@@ -1,6 +1,15 @@
-import { LikeC4Diagram, useDiagramContext, useLikeC4Model, useUpdateEffect } from '@likec4/diagram'
+import type { Fqn } from '@likec4/core'
+import {
+  LikeC4Diagram,
+  useDiagram,
+  useDiagramContext,
+  useLikeC4Model,
+  useOnDiagramEvent,
+  useUpdateEffect,
+} from '@likec4/diagram'
 import { useCallbackRef, useDocumentTitle } from '@mantine/hooks'
 import { useNavigate, useRouter, useSearch } from '@tanstack/react-router'
+import { useEffect, useRef } from 'react'
 import { NotFound } from '../components/NotFound'
 import { pageTitle as defaultPageTitle } from '../const'
 import { useCurrentView } from '../hooks'
@@ -69,8 +78,84 @@ export function ViewReact() {
       }}
     >
       <ListenForDynamicVariantChange />
+      <OpenRelationshipBrowserFromUrl />
     </LikeC4Diagram>
   )
+}
+
+/**
+ * Opens Relationship Browser when `?relationships={elementFqn}` URL parameter is present.
+ * Handles both initial load and parameter changes during navigation.
+ * Clears the parameter after opening to prevent reopening on navigation.
+ */
+export function OpenRelationshipBrowserFromUrl() {
+  const router = useRouter()
+  const diagram = useDiagram()
+  const { relationships } = useSearch({
+    from: '__root__',
+  })
+  const processedRef = useRef<Fqn | null>(null)
+  const isInitializedRef = useRef(false)
+  const isProcessingRef = useRef(false)
+  const isMountedRef = useRef(true)
+
+  const openAndClear = async (fqn: Fqn) => {
+    if (isProcessingRef.current || !isMountedRef.current) return
+    isProcessingRef.current = true
+    try {
+      if (!isMountedRef.current) return
+      processedRef.current = fqn
+      diagram.openRelationshipsBrowser(fqn)
+      if (!isMountedRef.current) return
+      await router.buildAndCommitLocation({
+        search: (current: Record<string, unknown>) => {
+          const { relationships: _, ...rest } = current
+          return rest
+        },
+        viewTransition: false,
+      })
+    } catch (error) {
+      if (isMountedRef.current) {
+        console.error('Failed to open relationship browser:', error)
+        processedRef.current = null
+      }
+    } finally {
+      isProcessingRef.current = false
+    }
+  }
+
+  const process = () => {
+    if (!isMountedRef.current || !isInitializedRef.current || isProcessingRef.current) return
+    if (!relationships) {
+      processedRef.current = null
+      return
+    }
+    if (processedRef.current !== relationships) {
+      void openAndClear(relationships)
+    }
+  }
+
+  useOnDiagramEvent('initialized', () => {
+    isInitializedRef.current = true
+    process()
+  })
+
+  // Handle parameter changes after initialization
+  useUpdateEffect(() => {
+    process()
+  }, [relationships])
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      isMountedRef.current = false
+      processedRef.current = null
+      isInitializedRef.current = false
+      isProcessingRef.current = false
+    }
+  }, [])
+
+  return null
 }
 
 export function ListenForDynamicVariantChange() {
@@ -81,7 +166,7 @@ export function ListenForDynamicVariantChange() {
     const search = router.latestLocation.search.dynamic ?? 'diagram'
     if (search !== dynamicViewVariant) {
       void router.buildAndCommitLocation({
-        search: (current?: any) => ({
+        search: (current: Record<string, unknown>) => ({
           ...current,
           dynamic: dynamicViewVariant,
         }),

--- a/packages/likec4/app/src/routes/__root.tsx
+++ b/packages/likec4/app/src/routes/__root.tsx
@@ -1,4 +1,4 @@
-import type { NonEmptyArray, NonEmptyReadonlyArray, ProjectId } from '@likec4/core/types'
+import type { Fqn, NonEmptyArray, NonEmptyReadonlyArray, ProjectId } from '@likec4/core/types'
 import { useMantineColorScheme } from '@mantine/core'
 import { createRootRouteWithContext, Outlet, stripSearchParams } from '@tanstack/react-router'
 import { projects } from 'likec4:projects'
@@ -38,10 +38,26 @@ const asDynamicVariant = (v: unknown): 'diagram' | 'sequence' => {
   return 'diagram'
 }
 
+/**
+ * Validates and normalizes a value as an FQN.
+ * @param v - Value to validate from URL parameters
+ * @returns Trimmed FQN string or undefined
+ */
+const asFqn = (v: unknown): Fqn | undefined => {
+  if (typeof v === 'string') {
+    const trimmed = v.trim()
+    if (trimmed.length > 0) {
+      return trimmed as Fqn
+    }
+  }
+  return undefined
+}
+
 export type SearchParams = {
-  theme?: 'light' | 'dark' | 'auto'
-  dynamic?: 'diagram' | 'sequence'
-  padding?: number
+  theme?: 'light' | 'dark' | 'auto' | undefined
+  dynamic?: 'diagram' | 'sequence' | undefined
+  padding?: number | undefined
+  relationships?: Fqn | undefined // Element FQN to open relationship browser
 }
 
 export type Context = {
@@ -69,6 +85,9 @@ export const Route = createRootRouteWithContext<Context>()({
       ...isTruthy(search.dynamic) && {
         dynamic: asDynamicVariant(search.dynamic),
       },
+      ...isTruthy(search.relationships) && {
+        relationships: asFqn(search.relationships),
+      },
     }
   },
   search: {
@@ -77,6 +96,7 @@ export const Route = createRootRouteWithContext<Context>()({
         padding: 20,
         theme: 'auto',
         dynamic: 'diagram',
+        relationships: undefined,
       }),
     ],
   },


### PR DESCRIPTION
 - Added support for deep linking directly to relationship views via URL parameter.
 - Added ?relationships={elementFqn} URL parameter to automatically open the Relationship Browser for a specific element on page load.
 - Added "Copy Link" button to the Relationship Browser to easily share these direct views.

<img width="1312" height="671" alt="image" src="https://github.com/user-attachments/assets/5bf9c273-9187-41c0-b4f4-785b4d14844b" />


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask, and propose improvements. We're here to help. -->

- [X] I've thoroughly read the latest [contribution guidelines](https://github.com/likec4/likec4/blob/main/CONTRIBUTING.md).
- [X] I've rebased my branch onto `main` **before** creating this PR.
- [X] My commit messages follow [conventional spec](https://www.conventionalcommits.org/en/)
- [NA ] I've added tests to cover my changes (if applicable).
- [X] I've verified that all new and existing tests have passed locally for mobile, tablet, and desktop screen sizes.
- [NA] My change requires documentation updates.
- [NA ] I've updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added copy-to-clipboard functionality to create and share direct links to relationship views with visual confirmation feedback
  * Relationship views can now be accessed and shared via URL parameters, enabling users to send teammates direct links to specific relationship perspectives

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->