### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -54,7 +54,7 @@ jobs:
           pnpm lint:package
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: tarballs
           compression-level: 0
@@ -165,7 +165,7 @@ jobs:
           cache: 'pnpm'
 
       - name: 📦 download tarballs
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: tarballs
           path: packages
@@ -201,7 +201,7 @@ jobs:
         run: |
           echo "::warning::Report published at ${{ steps.cloudflare.outputs.deployment-url }}"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         if: ${{ !cancelled() }}
         with:
           name: playwright-report
@@ -232,7 +232,7 @@ jobs:
           cache: 'pnpm'
 
       - name: 📦 download tarballs
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: tarballs
           path: packages
@@ -251,7 +251,7 @@ jobs:
         working-directory: e2e
         run: pnpm typecheck
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         if: ${{ failure() }}
         with:
           name: generated-e2e-types

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -96,7 +96,7 @@ jobs:
           touch "${{ runner.temp }}/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: digests-${{ env.PLATFORM_PAIR }}
           path: ${{ runner.temp }}/digests/*
@@ -109,7 +109,7 @@ jobs:
       - build-docker
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           path: ${{ runner.temp }}/digests
           pattern: digests-*

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -62,7 +62,7 @@ jobs:
           pnpm turbo run build --filter='@likec4/docs-astro'
 
       - name: upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: docs-astro
           if-no-files-found: error

--- a/.github/workflows/vscode.yaml
+++ b/.github/workflows/vscode.yaml
@@ -39,7 +39,7 @@ jobs:
           pnpm package-vsix
 
       - name: 📦 upload vsix
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: likec4.vsix
           if-no-files-found: error


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/download-artifact` | [`v5`](https://github.com/actions/download-artifact/releases/tag/v5) | [`v7`](https://github.com/actions/download-artifact/releases/tag/v7) | [Release](https://github.com/actions/download-artifact/releases/tag/v7) | checks.yaml, docker.yaml |
| `actions/upload-artifact` | [`v4`](https://github.com/actions/upload-artifact/releases/tag/v4) | [`v6`](https://github.com/actions/upload-artifact/releases/tag/v6) | [Release](https://github.com/actions/upload-artifact/releases/tag/v6) | checks.yaml, docker.yaml, docs.yaml, vscode.yaml |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting March 4th, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: March 4th, 2026
- **Action**: Update to latest action versions that support Node 24

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows to use newer versions of artifact handling tools across continuous integration and deployment pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->