### PR TITLE
test(core): implement missing tests for exclude predicate in deployment view

### DIFF
--- a/packages/core/src/compute-view/deployment-view/predicates/__test__/relations.filter.participant.spec.ts
+++ b/packages/core/src/compute-view/deployment-view/predicates/__test__/relations.filter.participant.spec.ts
@@ -3,136 +3,105 @@ import { Builder } from '../../../../builder'
 import { TestHelper } from '../../__test__/TestHelper'
 
 describe('RelationPredicate', () => {
-  const builder = Builder
-    .specification({
-      elements: {
-        el: {},
-      },
-      deployments: {
-        node: {},
-      },
-      tags: {
-        next: {},
-        alpha: {},
-      },
-    })
-    .model(({ el, rel }, _) =>
-      _(
-        el('client'),
-        el('cloud'),
-        el('cloud.ui', { tags: ['next'] }),
-        el('cloud.backend'),
-        el('cloud.backend.api'),
-        el('cloud.db'),
-        rel('client', 'cloud.ui'),
-        rel('cloud.ui', 'cloud.backend.api', { tags: ['next'] }),
-        rel('cloud.backend.api', 'cloud.db'),
-      )
+  const builder = Builder.specification({
+    elements: {
+      el: {},
+    },
+    deployments: {
+      node: {},
+    },
+    tags: {
+      next: {},
+      alpha: {},
+    },
+  }).model(({ el, rel }, _) =>
+    _(
+      el('client'),
+      el('cloud'),
+      el('cloud.ui', { tags: ['next'] }),
+      el('cloud.backend'),
+      el('cloud.backend.api'),
+      el('cloud.db'),
+      rel('client', 'cloud.ui'),
+      rel('cloud.ui', 'cloud.backend.api', { tags: ['next'] }),
+      rel('cloud.backend.api', 'cloud.db'),
     )
+  )
 
-  const { $include } = TestHelper
+  const { $include, $exclude } = TestHelper
 
   describe('* -> * where participant is', () => {
-    const t = TestHelper.from(builder.deployment((_, deploymentModel) =>
-      deploymentModel(
-        _.node('a'),
-        _.node('a.b'),
-        _.node('a.b.c').with(
-          _.instanceOf('cloud.ui'),
-        ),
-        _.node('a.b.d').with(
-          _.instanceOf('api', 'cloud.backend.api', { tags: ['alpha'] }),
-        ),
-        _.node('a.b.d.e', { tags: ['alpha'] }).with(
-          _.instanceOf('cloud.db'),
-        ),
-        _.rel('a.b.d.api', 'a.b.d.e'),
-      )
-    ))
+    const t = TestHelper.from(
+      builder.deployment((_, deploymentModel) =>
+        deploymentModel(
+          _.node('a'),
+          _.node('a.b'),
+          _.node('a.b.c').with(_.instanceOf('cloud.ui')),
+          _.node('a.b.d').with(_.instanceOf('api', 'cloud.backend.api', { tags: ['alpha'] })),
+          _.node('a.b.d.e', { tags: ['alpha'] }).with(_.instanceOf('cloud.db')),
+          _.rel('a.b.d.api', 'a.b.d.e'),
+        )
+      ),
+    )
 
     describe('model', () => {
       it('should exclude relation when porperties match', () => {
-        // TODO: implementation of the $exclude helper for model ref required
+        t.expectComputedView(
+          $include('a.b.c.ui -> a.b.d.api'),
+          $exclude('a.b.c.ui -> a.b.d.api', { where: 'source.tag is #next' }),
+        ).toHave({
+          nodes: [],
+          edges: [],
+        })
       })
 
       it('should exclude relation when porperties do not match', () => {
-        // TODO: implementation of the $exclude helper for model ref required
+        t.expectComputedView(
+          $include('a.b.c.ui -> a.b.d.api'),
+          $exclude('a.b.c.ui -> a.b.d.api', { where: 'source.tag is #alpha' }),
+        ).toHave({
+          nodes: ['a.b.c.ui', 'a.b.d', 'a.b.d.api'],
+          edges: ['a.b.c.ui -> a.b.d.api'],
+        })
       })
     })
 
     describe('instance', () => {
       it('should include relation when model porperties match', () => {
-        t.expectComputedView(
-          $include('a.b.c.ui -> a.b.d.api', { where: 'source.tag is #next' }),
-        ).toHave(
-          {
-            nodes: [
-              'a.b.c.ui',
-              'a.b.d',
-              'a.b.d.api',
-            ],
-            edges: [
-              'a.b.c.ui -> a.b.d.api',
-            ],
-          },
-        )
+        t.expectComputedView($include('a.b.c.ui -> a.b.d.api', { where: 'source.tag is #next' })).toHave({
+          nodes: ['a.b.c.ui', 'a.b.d', 'a.b.d.api'],
+          edges: ['a.b.c.ui -> a.b.d.api'],
+        })
       })
 
       it('should include relation when deployment porperties match', () => {
-        t.expectComputedView(
-          $include('a.b.c.ui -> a.b.d.api', { where: 'target.tag is #alpha' }),
-        ).toHave(
-          {
-            nodes: [
-              'a.b.c.ui',
-              'a.b.d',
-              'a.b.d.api',
-            ],
-            edges: [
-              'a.b.c.ui -> a.b.d.api',
-            ],
-          },
-        )
+        t.expectComputedView($include('a.b.c.ui -> a.b.d.api', { where: 'target.tag is #alpha' })).toHave({
+          nodes: ['a.b.c.ui', 'a.b.d', 'a.b.d.api'],
+          edges: ['a.b.c.ui -> a.b.d.api'],
+        })
       })
 
       it('should not include relation when neither model nor deployment porperties match', () => {
-        t.expectComputedView(
-          $include('a.b.c.ui -> a.b.d.api', { where: 'source.tag is #alpha' }),
-        ).toHave(
-          {
-            nodes: [],
-            edges: [],
-          },
-        )
+        t.expectComputedView($include('a.b.c.ui -> a.b.d.api', { where: 'source.tag is #alpha' })).toHave({
+          nodes: [],
+          edges: [],
+        })
       })
     })
 
     describe('node', () => {
       it('should include relation when porperties match', () => {
-        t.expectComputedView(
-          $include('a.b.d.api -> a.b.d.e', { where: 'target.tag is #alpha' }),
-        ).toHave(
-          {
-            nodes: [
-              'a.b.d.api',
-              'a.b.d.e',
-            ],
-            edges: [
-              'a.b.d.api -> a.b.d.e',
-            ],
-          },
-        )
+        t.expectComputedView($include('a.b.d.api -> a.b.d.e', { where: 'target.tag is #alpha' })).toHave({
+          nodes: ['a.b.d.api', 'a.b.d.e'],
+          edges: ['a.b.d.api -> a.b.d.e'],
+        })
       })
 
       it('should include relation when porperties do not match', () => {
-        t.expectComputedView(
-          $include('a.b.d.api -> a.b.d.e', { where: 'target.tag is #next' }),
-        ).toHave(
-          {
-            nodes: [],
-            edges: [],
-          },
-        )
+        t.expectComputedView($include('a.b.d.api -> a.b.d.e', { where: 'target.tag is #next' })).toHave({
+          nodes: [],
+          edges: [],
+        })
       })
     })
   })


### PR DESCRIPTION
Implemented the missing test cases for `$exclude` predicate in `deployment-view`. Verified that relations can be excluded based on model properties.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure with improved helper utilities and streamlined assertion patterns.

---

**Note:** This release contains no user-facing changes. Updates are limited to internal testing infrastructure improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->