### PR TITLE
chore(changesets): fix prepare release - remove @likec4/devops from drawio-import-postpack

### DIFF
--- a/.changeset/drawio-import-postpack.md
+++ b/.changeset/drawio-import-postpack.md
@@ -1,7 +1,6 @@
 ---
 "@likec4/generators": patch
 likec4: patch
-"@likec4/devops": patch
 "@likec4/language-server": patch
 ---
 


### PR DESCRIPTION
Fixes the "prepare release pr" job failure:

```
Found changeset drawio-import-postpack for package @likec4/devops which is not in the workspace
```

- Removes `@likec4/devops` from that changeset (private package; not published).
- Postpack is still documented in the changelog body; no user-facing change.

**Conformidade (AGENTS.md):**
- Commit: Conventional style `chore(changesets): ...`, single focused change.
- No new changeset: this is a fix to release tooling, not a user-facing package change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed a dependency reference from release metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->