### PR TITLE
docs: Fix broken link to vite-plugin/modules.d.ts location in documentation

### DIFF
--- a/apps/docs/src/content/docs/tooling/vite-plugin.mdx
+++ b/apps/docs/src/content/docs/tooling/vite-plugin.mdx
@@ -289,7 +289,7 @@ import { loadDotSources } from 'likec4:dot'
 import { mmdSource } from 'likec4:mmd/project-a'
 ```
 
-Complete list - <a href="https://github.com/likec4/likec4/blob/main/packages/likec4/src/vite-plugin/modules.d.ts">vite-plugin/modules.d.ts</a>
+Complete list - <a href="https://github.com/likec4/likec4/blob/main/packages/vite-plugin/src/modules.d.ts">vite-plugin/modules.d.ts</a>
 
 
 ## Usage 


### PR DESCRIPTION

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask, and propose improvements. We're here to help. -->

- [X] I've thoroughly read the latest [contribution guidelines](https://github.com/likec4/likec4/blob/main/CONTRIBUTING.md).
- [X] I've rebased my branch onto `main` **before** creating this PR.
- [X] My commit messages follow [conventional spec](https://www.conventionalcommits.org/en/)
- [ ] I've added tests to cover my changes (if applicable).
- [ ] I've verified that all new and existing tests have passed locally for mobile, tablet, and desktop screen sizes.
- [X] My change requires documentation updates.
- [X] I've updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated the reference link for the Vite plugin module documentation to point to the current location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->