### PR TITLE
feat: auto-approve renovate PRs

### DIFF
--- a/.github/workflows/auto-approve-renovate.yaml
+++ b/.github/workflows/auto-approve-renovate.yaml
@@ -1,0 +1,33 @@
+name: auto-approve renovate
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+
+permissions:
+  pull-requests: write
+
+jobs:
+  approve:
+    name: approve
+    if: github.actor == 'renovate[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: 🤖 bot token
+        id: bot-token
+        uses: ./.github/actions/bot-token
+        with:
+          app-id: ${{ secrets.BOT_APP_ID }}
+          private-key-base64: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+          configure-git: "false"
+          fetch-user-id: "false"
+
+      - name: approve PR
+        run: gh pr review --approve "${{ github.event.pull_request.html_url }}"
+        env:
+          GH_TOKEN: ${{ steps.bot-token.outputs.token }}


### PR DESCRIPTION
Adds a GitHub Actions workflow that automatically approves PRs opened by Renovate bot. Uses the existing CI bot GitHub App token to submit the approval, so the review comes from a different identity than the PR author (satisfying branch protection rules).

Triggered on `pull_request_target` for `opened` and `synchronize` events, gated to `renovate[bot]` actor only.

## Checklist

- [x] I've thoroughly read the latest [contribution guidelines](https://github.com/likec4/likec4/blob/main/CONTRIBUTING.md).
- [x] I've rebased my branch onto `main` **before** creating this PR.
- [x] My commit messages follow [conventional spec](https://www.conventionalcommits.org/en/)
- [ ] I've added tests to cover my changes (if applicable).
- [ ] I've verified that all new and existing tests have passed locally for mobile, tablet, and desktop screen sizes.
- [ ] My change requires documentation updates.
- [ ] I've updated the documentation accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated approval system for Renovate-generated dependency update pull requests, streamlining the dependency management process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->