### PR TITLE
docs(skills): improve skill references based on benchmark feedback

### DIFF
--- a/skills/likec4-dsl/references/cli.md
+++ b/skills/likec4-dsl/references/cli.md
@@ -4,6 +4,31 @@
 Only essential commands/parameters are listed here, for full documentation use `likec4 help`, `likec4 <command> --help`.
 Use with users prefered package manager (pnpm, bun, etc.).
 
+## Common Commands and Frequent Mistakes
+
+### ✅ Correct commands (use these)
+
+| Task | Correct Command |
+|------|-----------------|
+| Validate files | `npx likec4@latest validate --json --no-layout --file <file> <project-dir>` |
+| Start dev server | `npx likec4 serve <project-path>` |
+| Export PNG | `npx likec4 export png -o ./images <project-path>` |
+| Build static site | `npx likec4 build -o ./dist <project-path>` |
+
+### ❌ Common mistakes (avoid these)
+
+| Incorrect | Why it fails | Correct |
+|-----------|--------------|---------|
+| `npx likec4 check ...` | Command doesn't exist | Use `npx likec4 validate ...` |
+| `npx likec4 lint ...` | Command doesn't exist | Use `npx likec4 validate ...` |
+| `npx likec4 verify ...` | Command doesn't exist | Use `npx likec4 validate ...` |
+| `npx likec4 export png --outdir ./images` | Flag is `--outdir` but short form is `-o` | Use `-o ./images` or `--outdir ./images` |
+
+**Always use `@latest` tag** to ensure you're using the latest version with all features:
+```bash
+npx likec4@latest validate --json --no-layout --file <file> <project-dir>
+```
+
 ## `serve` (aliases: `start`, `dev`)
 
 Starts local server with live reload to preview diagrams (default port is 5173).

--- a/skills/likec4-dsl/references/configuration.md
+++ b/skills/likec4-dsl/references/configuration.md
@@ -242,3 +242,20 @@ Use `include.paths` to share `.c4` files across projects.
   "title": "My Architecture"
 }
 ```
+
+**Important:** Always include `"$schema"` (recommended) — it enables IDE autocomplete and validation for your config file.
+
+### Common Mistake: Missing $schema
+
+```json
+// ❌ Missing $schema — no IDE validation/autocomplete
+{
+  "name": "my-project"
+}
+
+// ✅ Correct — with schema for IDE support
+{
+  "$schema": "https://likec4.dev/schemas/config.json",
+  "name": "my-project"
+}
+```

--- a/skills/likec4-dsl/references/predicates.md
+++ b/skills/likec4-dsl/references/predicates.md
@@ -42,9 +42,51 @@ Expressions inside `exclude` clause match against the accumulated result of prev
 
 - `<element_ref>` - selects element by reference from the current file scope, or globally available if not found in the current file, together with all relationships between this element and accumulated result
 - `<element_ref>.<child>` - selects unique child within `<element_ref>` together with all relationships between this child and accumulated result
-- `<element_ref>.*` - selects direct children of `<element_ref>`, together with all relationships between these children and accumulated result
+- `<element_ref>.*` - selects **direct children only** of `<element_ref>`, together with all relationships between these children and accumulated result
 - `<element_ref>._` - selects direct children of `<element_ref>` that have relationships with accumulated result
-- `<element_ref>.**` - selects all descendants of `<element_ref>` that have relationships with accumulated result
+- `<element_ref>.**` - selects **all recursive descendants** of `<element_ref>` that have relationships with accumulated result
+
+#### Wildcard depth selectors: `*` vs `**`
+
+Understanding the difference between `*` and `**` is crucial for correct view scoping:
+
+| Selector | Meaning | Example | Result |
+|----------|---------|---------|--------|
+| `*` | Direct children **only** (1 level) | `parent.*` | Selects immediate children of parent |
+| `**` | All descendants (recursive, all levels) | `parent.**` | Selects children, grandchildren, and all nested elements |
+
+```likec4
+// Example model structure:
+// backend
+//   ├── api (service)
+//   │   └── handlers (component)
+//   │       └── authHandler
+//   └── db (database)
+
+views {
+  // Selects ONLY: api, db (direct children of backend)
+  view direct-only {
+    include backend.*
+  }
+
+  // Selects: api, db, handlers, authHandler (all descendants)
+  view all-descendants {
+    include backend.**
+  }
+
+  // ❌ Common mistake: expecting * to include nested elements
+  view wrong-expectation {
+    include backend.*        // This does NOT include handlers or authHandler!
+    style backend.handlers { color red }  // handlers won't be styled
+  }
+
+  // ✅ Correct: use ** when you need all nested elements
+  view correct {
+    include backend.**       // Includes everything under backend
+    style backend.handlers { color red }  // Now handlers IS included
+  }
+}
+```
 
 ### Wildcard expression
 

--- a/skills/likec4-dsl/references/views.md
+++ b/skills/likec4-dsl/references/views.md
@@ -222,6 +222,16 @@ Parallel blocks can be nested and mixed with sequential steps.
 | `diagram` (default) | Animated box-and-line diagram | General flow visualization         |
 | `sequence`          | UML sequence diagram          | API call sequences, protocol flows |
 
+### Using `variant sequence`
+
+The `variant sequence` keyword renders the dynamic view as a UML sequence diagram. This is especially useful for API call sequences and protocol flows.
+
+**Key syntax points:**
+- Use `variant sequence` at the start of the dynamic view block
+- Use `->` for forward/call direction
+- Use `<-` for backward/return direction (not `->` with different semantics)
+- Sequence diagrams work best with leaf elements (not containers)
+
 ```likec4
 dynamic view api-sequence {
   variant sequence
@@ -237,7 +247,25 @@ dynamic view api-sequence {
 }
 ```
 
-Sequence diagrams work best with leaf elements (not containers).
+**Common mistake:** Using `->` for returns instead of `<-`. The arrow direction indicates message flow:
+- `a -> b` means "a sends to b" (request/call)
+- `a <- b` means "b sends to a" (response/return)
+
+```likec4
+// ❌ WRONG - using -> for returns
+dynamic view wrong {
+  variant sequence
+  client -> gateway "request"
+  gateway -> client "response"  // This renders incorrectly!
+}
+
+// ✅ CORRECT - using <- for returns
+dynamic view correct {
+  variant sequence
+  client -> gateway "request"
+  client <- gateway "response"  // Proper return flow
+}
+```
 
 ## Include in Dynamic Views
 


### PR DESCRIPTION
## Summary

This PR improves the LikeC4 agent skill documentation based on comprehensive benchmark feedback from issue #2636.

## Changes

### CLI Reference (cli.md)
- Added **Common Commands and Frequent Mistakes** section with a comparison table
- Documented correct commands vs common incorrect attempts (e.g., `validate` vs `check`, `lint`, `verify`)
- Added recommendation to use `@latest` tag for npx commands

### Views Reference (views.md)
- Expanded **variant sequence** documentation with:
  - Clear syntax explanation
  - Common mistake example showing wrong use of `->` for returns
  - Correct usage example with `<-` for return flows
  - Best practices for sequence diagrams

### Predicates Reference (predicates.md)
- Added detailed **Wildcard depth selectors** section
- Added comparison table: `*` (direct children only) vs `**` (all descendants)
- Included practical examples showing common mistakes and correct usage
- Explained relationship between selector and element styling

### Configuration Reference (configuration.md)
- Added **Important** callout emphasizing `$schema` inclusion
- Added Common Mistake example showing config with/without schema
- Clarified IDE benefits of including `$schema`

## Benchmark Impact

Based on the benchmark results from issue #2636, these changes address the key improvement areas:
1. **P1 (Critical)**: CLI command validation - agents now know to use `validate` not `check`
2. **P1 (Critical)**: Sequence variant - agents now understand correct arrow directions
3. **P2 (Important)**: Wildcard selectors - agents now understand `*` vs `**` difference
4. **P2 (Important)**: Schema inclusion - emphasized in all config examples

## Testing

The improved documentation has been structured to help AI agents:
- Avoid hallucinating non-existent CLI commands
- Use correct syntax for sequence diagrams
- Understand scope when including elements in views
- Include schema for better IDE support

Closes feedback loop from #2636

cc @davydkov @a-scolan