### PR TITLE
feat(vscode): add `likec4.exclude` setting for file/folder exclusion

### DIFF
--- a/.changeset/vscode-exclude-config.md
+++ b/.changeset/vscode-exclude-config.md
@@ -1,0 +1,6 @@
+---
+'@likec4/language-server': patch
+'likec4-vscode': patch
+---
+
+Add `likec4.exclude` VS Code setting to exclude files and folders from LikeC4 processing via glob patterns

--- a/apps/playground/tsconfig.frontend.json
+++ b/apps/playground/tsconfig.frontend.json
@@ -42,10 +42,16 @@
       "path": "../../packages/diagram/tsconfig.src.json"
     },
     {
+      "path": "../../packages/generators/"
+    },
+    {
       "path": "../../packages/layouts/"
     },
     {
       "path": "../../packages/language-server/"
+    },
+    {
+      "path": "../../packages/log/"
     },
     {
       "path": "../../styled-system/styles/"

--- a/apps/playground/tsconfig.worker.json
+++ b/apps/playground/tsconfig.worker.json
@@ -19,7 +19,7 @@
   ],
   "references": [
     {
-      "path": "../../packages/core/tsconfig.json"
+      "path": "../../packages/core/"
     }
   ]
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -7,7 +7,7 @@
     "rootDir": "src",
     "target": "es2024",
     "incremental": true,
-    "composite": true,
+    "composite": true
   },
   "include": [
     "src/",
@@ -16,6 +16,9 @@
   "references": [
     {
       "path": "../../styled-system/preset/"
+    },
+    {
+      "path": "../../styled-system/styles/"
     }
   ]
 }

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -166,6 +166,7 @@
     "json5": "catalog:utils",
     "langium": "catalog:langium",
     "nano-spawn": "catalog:externals",
+    "pathe": "catalog:utils",
     "p-limit": "catalog:utils",
     "p-queue": "catalog:utils",
     "p-timeout": "catalog:utils",

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -168,6 +168,7 @@
     "nano-spawn": "catalog:externals",
     "p-limit": "catalog:utils",
     "p-queue": "catalog:utils",
+    "p-timeout": "catalog:utils",
     "picomatch": "catalog:externals",
     "pretty-ms": "^9.3.0",
     "remeda": "catalog:utils",

--- a/packages/language-server/src/Rpc.ts
+++ b/packages/language-server/src/Rpc.ts
@@ -381,35 +381,10 @@ export class Rpc extends ADisposable {
         }
       }),
       // ----------
-      workspace.ConfigurationProvider.onConfigurationSectionUpdate((update) => {
-        if (update.section !== this.services.LanguageMetaData.languageId) return
-        const excludeConfig = update.configuration?.exclude
-        if (excludeConfig !== undefined) {
-          logger.debug`received workspace exclude patterns update`
-          void workspace.ProjectsManager.applyWorkspaceExcludePatterns(
-            (excludeConfig as Record<string, boolean>) ?? {},
-          )
-        }
-      }),
       Disposable.create(() => {
         notifyModelParsed.cancel()
       }),
     )
-
-    // Read initial exclude configuration (onConfigurationSectionUpdate does not fire for the initial load)
-    void workspace.ConfigurationProvider.ready.then(async () => {
-      try {
-        const excludeConfig = await workspace.ConfigurationProvider.getConfiguration(
-          this.services.LanguageMetaData.languageId,
-          'exclude',
-        )
-        if (excludeConfig && typeof excludeConfig === 'object') {
-          await workspace.ProjectsManager.applyWorkspaceExcludePatterns(excludeConfig as Record<string, boolean>)
-        }
-      } catch (e) {
-        logger.warn('Failed to read initial exclude configuration', { error: e })
-      }
-    })
 
     function reportLayoutDrift(diagrams: DiagramView[]) {
       return pipe(

--- a/packages/language-server/src/Rpc.ts
+++ b/packages/language-server/src/Rpc.ts
@@ -380,10 +380,36 @@ export class Rpc extends ADisposable {
           projectsView,
         }
       }),
+      // ----------
+      workspace.ConfigurationProvider.onConfigurationSectionUpdate((update) => {
+        if (update.section !== this.services.LanguageMetaData.languageId) return
+        const excludeConfig = update.configuration?.exclude
+        if (excludeConfig !== undefined) {
+          logger.debug`received workspace exclude patterns update`
+          void workspace.ProjectsManager.applyWorkspaceExcludePatterns(
+            (excludeConfig as Record<string, boolean>) ?? {},
+          )
+        }
+      }),
       Disposable.create(() => {
         notifyModelParsed.cancel()
       }),
     )
+
+    // Read initial exclude configuration (onConfigurationSectionUpdate does not fire for the initial load)
+    void workspace.ConfigurationProvider.ready.then(async () => {
+      try {
+        const excludeConfig = await workspace.ConfigurationProvider.getConfiguration(
+          this.services.LanguageMetaData.languageId,
+          'exclude',
+        )
+        if (excludeConfig && typeof excludeConfig === 'object') {
+          await workspace.ProjectsManager.applyWorkspaceExcludePatterns(excludeConfig as Record<string, boolean>)
+        }
+      } catch (e) {
+        logger.warn('Failed to read initial exclude configuration', { error: e })
+      }
+    })
 
     function reportLayoutDrift(diagrams: DiagramView[]) {
       return pipe(

--- a/packages/language-server/src/Rpc.ts
+++ b/packages/language-server/src/Rpc.ts
@@ -380,7 +380,6 @@ export class Rpc extends ADisposable {
           projectsView,
         }
       }),
-      // ----------
       Disposable.create(() => {
         notifyModelParsed.cancel()
       }),

--- a/packages/language-server/src/workspace/ProjectsManager.ts
+++ b/packages/language-server/src/workspace/ProjectsManager.ts
@@ -22,8 +22,9 @@ import {
   URI,
   UriUtils,
 } from 'langium'
+import { isAbsolute } from 'pathe'
 import picomatch from 'picomatch'
-import { find, hasAtLeast, isEmptyish, isNullish, map, prop, purry } from 'remeda'
+import { filter, find, hasAtLeast, isEmptyish, isNullish, isTruthy, map, pipe, prop, purry } from 'remeda'
 import type { Tagged } from 'type-fest'
 import {
   cleanDoubleSlashes,
@@ -301,7 +302,7 @@ export class ProjectsManager {
   })
 
   constructor(protected services: LikeC4SharedServices) {
-    logger.debug`created`
+    logger.trace`created`
   }
 
   #isExcludedByWorkspace(uri: NormalizedUri): boolean {
@@ -312,22 +313,28 @@ export class ProjectsManager {
    * Updates the workspace-level exclude patterns from VS Code settings.
    * Called during initial server startup; dynamic changes restart the server.
    */
-  setWorkspaceExcludePatterns(patterns: Record<string, boolean>): void {
+  setWorkspaceExcludePatterns(patterns: string[] | undefined): void {
     try {
-      if (!patterns || typeof patterns !== 'object') {
+      if (!Array.isArray(patterns)) {
         this.#workspaceExclude = undefined
         return
       }
-      const excludePatterns = Object.entries(patterns)
-        .filter(([_, enabled]) => enabled)
-        .map(([pattern]) => pattern)
-
-      if (excludePatterns.length === 0) {
+      const normalizedPatterns = pipe(
+        patterns,
+        filter(isTruthy),
+        map(p => {
+          if (!isAbsolute(p) && !p.startsWith('**')) {
+            p = joinURL('**', p)
+          }
+          return p
+        }),
+      )
+      if (!hasAtLeast(normalizedPatterns, 1)) {
         this.#workspaceExclude = undefined
         return
       }
-
-      this.#workspaceExclude = picomatch(excludePatterns, { dot: true })
+      logger.debug`set workspace exclude patterns: ${normalizedPatterns}`
+      this.#workspaceExclude = picomatch(normalizedPatterns, { dot: true })
     } catch (e) {
       logger.warn('Failed to set workspace exclude patterns', { error: e })
       this.#workspaceExclude = undefined
@@ -482,11 +489,17 @@ export class ProjectsManager {
    * Registers likec4 project by config file.
    */
   async registerConfigFile(configUri: URI, cancelToken?: Cancellation.CancellationToken): Promise<ProjectData> {
-    if (isExcludedByDefault(normalizeUri(configUri))) {
+    const normalizedUri = normalizeUri(configUri)
+    if (isExcludedByDefault(normalizedUri)) {
       throw new Error(
         `Failed to register project config, path ${configUri.fsPath} is excluded by: ${
           DefaultProject.config.exclude.map(p => `"${p}"`).join(', ')
         }`,
+      )
+    }
+    if (this.#isExcludedByWorkspace(normalizedUri)) {
+      throw new Error(
+        `Failed to register project config, path ${configUri.fsPath} is excluded by editor settings`,
       )
     }
     try {

--- a/packages/language-server/src/workspace/ProjectsManager.ts
+++ b/packages/language-server/src/workspace/ProjectsManager.ts
@@ -310,37 +310,19 @@ export class ProjectsManager {
 
   /**
    * Updates the workspace-level exclude patterns from VS Code settings.
-   * Returns true if patterns changed.
+   * Called during initial server startup; dynamic changes restart the server.
    */
-  setWorkspaceExcludePatterns(patterns: Record<string, boolean>): boolean {
+  setWorkspaceExcludePatterns(patterns: Record<string, boolean>): void {
     const excludePatterns = Object.entries(patterns)
       .filter(([_, enabled]) => enabled)
       .map(([pattern]) => pattern)
 
     if (excludePatterns.length === 0) {
-      if (!this.#workspaceExclude) return false
       this.#workspaceExclude = undefined
-      return true
+      return
     }
 
     this.#workspaceExclude = picomatch(excludePatterns, { dot: true })
-    return true
-  }
-
-  /**
-   * Updates workspace-level exclude patterns and triggers rebuild if changed.
-   */
-  async applyWorkspaceExcludePatterns(
-    patterns: Record<string, boolean>,
-    cancelToken?: Cancellation.CancellationToken,
-  ): Promise<void> {
-    const changed = this.setWorkspaceExcludePatterns(patterns)
-    if (!changed) return
-
-    logger.info`workspace exclude patterns updated`
-    this.resetCaches()
-    this.notifyListeners()
-    await this.services.workspace.WorkspaceManager.rebuildAll(cancelToken)
   }
 
   /**

--- a/packages/language-server/src/workspace/ProjectsManager.ts
+++ b/packages/language-server/src/workspace/ProjectsManager.ts
@@ -313,16 +313,25 @@ export class ProjectsManager {
    * Called during initial server startup; dynamic changes restart the server.
    */
   setWorkspaceExcludePatterns(patterns: Record<string, boolean>): void {
-    const excludePatterns = Object.entries(patterns)
-      .filter(([_, enabled]) => enabled)
-      .map(([pattern]) => pattern)
+    try {
+      if (!patterns || typeof patterns !== 'object') {
+        this.#workspaceExclude = undefined
+        return
+      }
+      const excludePatterns = Object.entries(patterns)
+        .filter(([_, enabled]) => enabled)
+        .map(([pattern]) => pattern)
 
-    if (excludePatterns.length === 0) {
+      if (excludePatterns.length === 0) {
+        this.#workspaceExclude = undefined
+        return
+      }
+
+      this.#workspaceExclude = picomatch(excludePatterns, { dot: true })
+    } catch (e) {
+      logger.warn('Failed to set workspace exclude patterns', { error: e })
       this.#workspaceExclude = undefined
-      return
     }
-
-    this.#workspaceExclude = picomatch(excludePatterns, { dot: true })
   }
 
   /**

--- a/packages/language-server/src/workspace/ProjectsManager.ts
+++ b/packages/language-server/src/workspace/ProjectsManager.ts
@@ -240,6 +240,11 @@ export class ProjectsManager {
   #defaultProjectId: ProjectId | undefined = undefined
 
   /**
+   * Workspace-level exclude matcher from VS Code settings (likec4.exclude).
+   */
+  #workspaceExclude: ((test: string) => boolean) | undefined = undefined
+
+  /**
    * Registered projects.
    * Sorted descending by the number of segments in the folder path.
    * This ensures that the most specific project is used for a document.
@@ -269,6 +274,10 @@ export class ProjectsManager {
 
   #excludedDocuments = new DefaultMap((document: NormalizedUri) => {
     const docuri = normalizeUri(document)
+    // Workspace-level excludes (from VS Code settings) take precedence
+    if (this.#isExcludedByWorkspace(docuri)) {
+      return true
+    }
     const owner = this.#ownerOf.get(docuri)
     if (!owner) {
       return isExcludedByDefault(docuri)
@@ -293,11 +302,45 @@ export class ProjectsManager {
 
   constructor(protected services: LikeC4SharedServices) {
     logger.debug`created`
-    // onNextTick(() => {
-    //   this.services.workspace.WorkspaceManager.onForceCleanCache(() => {
-    //     this.resetCaches()
-    //   })
-    // })
+  }
+
+  #isExcludedByWorkspace(uri: NormalizedUri): boolean {
+    return this.#workspaceExclude?.(withoutProtocol(uri)) ?? false
+  }
+
+  /**
+   * Updates the workspace-level exclude patterns from VS Code settings.
+   * Returns true if patterns changed.
+   */
+  setWorkspaceExcludePatterns(patterns: Record<string, boolean>): boolean {
+    const excludePatterns = Object.entries(patterns)
+      .filter(([_, enabled]) => enabled)
+      .map(([pattern]) => pattern)
+
+    if (excludePatterns.length === 0) {
+      if (!this.#workspaceExclude) return false
+      this.#workspaceExclude = undefined
+      return true
+    }
+
+    this.#workspaceExclude = picomatch(excludePatterns, { dot: true })
+    return true
+  }
+
+  /**
+   * Updates workspace-level exclude patterns and triggers rebuild if changed.
+   */
+  async applyWorkspaceExcludePatterns(
+    patterns: Record<string, boolean>,
+    cancelToken?: Cancellation.CancellationToken,
+  ): Promise<void> {
+    const changed = this.setWorkspaceExcludePatterns(patterns)
+    if (!changed) return
+
+    logger.info`workspace exclude patterns updated`
+    this.resetCaches()
+    this.notifyListeners()
+    await this.services.workspace.WorkspaceManager.rebuildAll(cancelToken)
   }
 
   /**
@@ -427,6 +470,10 @@ export class ProjectsManager {
    */
   isIncluded(projectId: ProjectId, document: LangiumDocument | URI | string): boolean {
     const uri = normalizeUri(document)
+    // Workspace-level excludes (from VS Code settings) take precedence
+    if (this.#isExcludedByWorkspace(uri)) {
+      return false
+    }
     // If there are no projects, check if document is not excluded
     if (!hasAtLeast(this.#projects, 1)) {
       return !isExcludedByDefault(uri)

--- a/packages/language-server/src/workspace/WorkspaceManager.ts
+++ b/packages/language-server/src/workspace/WorkspaceManager.ts
@@ -8,6 +8,7 @@ import type {
   LangiumDocumentFactory,
 } from 'langium'
 import { DefaultWorkspaceManager, Disposable, UriUtils } from 'langium'
+import pTimeout from 'p-timeout'
 import { hasAtLeast, uniqueBy } from 'remeda'
 import type { WorkspaceFolder } from 'vscode-languageserver'
 import { URI } from 'vscode-uri'
@@ -70,14 +71,11 @@ export class LikeC4WorkspaceManager extends DefaultWorkspaceManager {
   private async readInitialExcludeConfig(): Promise<void> {
     const configProvider = this.services.workspace.ConfigurationProvider
     try {
-      await Promise.race([
-        configProvider.ready,
-        new Promise(resolve => setTimeout(resolve, 1000)),
-      ])
-      const excludeConfig = await Promise.race([
+      await pTimeout(configProvider.ready, { milliseconds: 1000 })
+      const excludeConfig = await pTimeout(
         configProvider.getConfiguration('likec4', 'exclude'),
-        new Promise<undefined>(resolve => setTimeout(resolve, 1000)),
-      ])
+        { milliseconds: 1000 },
+      )
       if (excludeConfig && typeof excludeConfig === 'object') {
         this.services.workspace.ProjectsManager.setWorkspaceExcludePatterns(
           excludeConfig as Record<string, boolean>,

--- a/packages/language-server/src/workspace/WorkspaceManager.ts
+++ b/packages/language-server/src/workspace/WorkspaceManager.ts
@@ -39,7 +39,7 @@ export class LikeC4WorkspaceManager extends DefaultWorkspaceManager {
    * First load all project config files, then load all documents in the workspace.
    */
   protected override async performStartup(folders: WorkspaceFolder[]): Promise<LangiumDocument[]> {
-    await this.readInitialExcludeConfig()
+    await this.readExcludeConfig()
     this.folders ??= folders
     const configFiles = [] as FileSystemNode[]
     for (const folder of folders) {
@@ -68,18 +68,25 @@ export class LikeC4WorkspaceManager extends DefaultWorkspaceManager {
    * Read workspace exclude patterns from configuration before workspace scan.
    * Uses a timeout fallback for third-party IDEs that may not support workspace/configuration.
    */
-  private async readInitialExcludeConfig(): Promise<void> {
+  private async readExcludeConfig(): Promise<void> {
+    if (!this.services.lsp.Connection) {
+      logger.debug`no LSP connection, skipping initial configuration read`
+      return
+    }
     const configProvider = this.services.workspace.ConfigurationProvider
+    const wait = <T>(promise: Promise<T>) => pTimeout(promise, { milliseconds: 1000, message: false })
     try {
-      await pTimeout(configProvider.ready, { milliseconds: 1000 })
-      const excludeConfig = await pTimeout(
+      logger.trace`waiting for ConfigurationProvider ready...`
+      await wait(configProvider.ready)
+      logger.trace`ConfigurationProvider ready, reading exclude patterns...`
+      const excludeConfig = await wait<string[]>(
         configProvider.getConfiguration('likec4', 'exclude'),
-        { milliseconds: 1000 },
       )
-      if (excludeConfig && typeof excludeConfig === 'object') {
-        this.services.workspace.ProjectsManager.setWorkspaceExcludePatterns(
-          excludeConfig as Record<string, boolean>,
-        )
+      if (excludeConfig) {
+        logger.trace`exclude configuration found ${excludeConfig}`
+        this.services.workspace.ProjectsManager.setWorkspaceExcludePatterns(excludeConfig)
+      } else {
+        logger.trace('no initial exclude configuration found')
       }
     } catch (e) {
       logger.warn('Failed to read initial exclude configuration', { error: e })

--- a/packages/language-server/src/workspace/WorkspaceManager.ts
+++ b/packages/language-server/src/workspace/WorkspaceManager.ts
@@ -38,6 +38,7 @@ export class LikeC4WorkspaceManager extends DefaultWorkspaceManager {
    * First load all project config files, then load all documents in the workspace.
    */
   protected override async performStartup(folders: WorkspaceFolder[]): Promise<LangiumDocument[]> {
+    await this.readInitialExcludeConfig()
     this.folders ??= folders
     const configFiles = [] as FileSystemNode[]
     for (const folder of folders) {
@@ -60,6 +61,31 @@ export class LikeC4WorkspaceManager extends DefaultWorkspaceManager {
       }
     }
     return await super.performStartup(folders)
+  }
+
+  /**
+   * Read workspace exclude patterns from configuration before workspace scan.
+   * Uses a timeout fallback for third-party IDEs that may not support workspace/configuration.
+   */
+  private async readInitialExcludeConfig(): Promise<void> {
+    const configProvider = this.services.workspace.ConfigurationProvider
+    try {
+      await Promise.race([
+        configProvider.ready,
+        new Promise(resolve => setTimeout(resolve, 1000)),
+      ])
+      const excludeConfig = await Promise.race([
+        configProvider.getConfiguration('likec4', 'exclude'),
+        new Promise<undefined>(resolve => setTimeout(resolve, 1000)),
+      ])
+      if (excludeConfig && typeof excludeConfig === 'object') {
+        this.services.workspace.ProjectsManager.setWorkspaceExcludePatterns(
+          excludeConfig as Record<string, boolean>,
+        )
+      }
+    } catch (e) {
+      logger.warn('Failed to read initial exclude configuration', { error: e })
+    }
   }
 
   /**

--- a/packages/language-server/src/workspace/WorkspaceManager.ts
+++ b/packages/language-server/src/workspace/WorkspaceManager.ts
@@ -129,7 +129,7 @@ export class LikeC4WorkspaceManager extends DefaultWorkspaceManager {
   protected override includeEntry(_: WorkspaceFolder, entry: FileSystemNode, selector: FileSelector): boolean {
     const name = UriUtils.basename(entry.uri)
     if (entry.isDirectory) {
-      return !excludeNodeModules(name)
+      return !excludeNodeModules(name) && !this.services.workspace.ProjectsManager.isExcluded(entry.uri)
     } else if (entry.isFile) {
       const selected = selector.fileExtensions.includes(UriUtils.extname(entry.uri)) ||
         selector.fileNames.includes(name)

--- a/packages/language-services/tsconfig.json
+++ b/packages/language-services/tsconfig.json
@@ -8,7 +8,7 @@
     "composite": true,
     "incremental": true,
     "lib": [
-      "ES2024",
+      "ES2024"
     ],
     "target": "ES2024",
     "rootDirs": [
@@ -26,19 +26,22 @@
   ],
   "references": [
     {
-      "path": "../core/tsconfig.json"
+      "path": "../config/"
     },
     {
-      "path": "../config/tsconfig.json"
+      "path": "../core/"
     },
     {
-      "path": "../language-server/tsconfig.json"
+      "path": "../generators/"
     },
     {
-      "path": "../layouts/tsconfig.json"
+      "path": "../language-server/"
     },
     {
-      "path": "../log/tsconfig.json"
+      "path": "../layouts/"
+    },
+    {
+      "path": "../log/"
     }
   ]
 }

--- a/packages/likec4/tsconfig.cli.json
+++ b/packages/likec4/tsconfig.cli.json
@@ -31,31 +31,34 @@
   ],
   "references": [
     {
-      "path": "../core/tsconfig.json"
+      "path": "../core/"
     },
     {
-      "path": "../config/tsconfig.json"
+      "path": "../config/"
     },
     {
-      "path": "../language-services/tsconfig.json"
+      "path": "../language-services/"
     },
     {
-      "path": "../language-server/tsconfig.json"
+      "path": "../language-server/"
     },
     {
-      "path": "../vite-plugin/tsconfig.json"
+      "path": "../vite-plugin/"
     },
     {
       "path": "../diagram/tsconfig.src.json"
     },
     {
-      "path": "../generators/tsconfig.json"
+      "path": "../generators/"
     },
     {
-      "path": "../layouts/tsconfig.json"
+      "path": "../layouts/"
     },
     {
-      "path": "../leanix-bridge/tsconfig.json"
+      "path": "../leanix-bridge/"
+    },
+    {
+      "path": "../log/"
     }
   ]
 }

--- a/packages/lsp/tsconfig.json
+++ b/packages/lsp/tsconfig.json
@@ -15,6 +15,15 @@
   ],
   "references": [
     {
+      "path": "../core/"
+    },
+    {
+      "path": "../config/"
+    },
+    {
+      "path": "../layouts/"
+    },
+    {
       "path": "../log/"
     },
     {

--- a/packages/vite-plugin/tsconfig.json
+++ b/packages/vite-plugin/tsconfig.json
@@ -8,7 +8,7 @@
     "composite": true,
     "incremental": true,
     "lib": [
-      "ES2024",
+      "ES2024"
     ],
     "target": "ES2024",
     "rootDirs": [
@@ -37,28 +37,28 @@
   ],
   "references": [
     {
-      "path": "../core/tsconfig.json"
+      "path": "../core/"
     },
     {
-      "path": "../config/tsconfig.json"
+      "path": "../config/"
     },
     {
       "path": "../diagram/tsconfig.src.json"
     },
     {
-      "path": "../language-server/tsconfig.json"
+      "path": "../language-server/"
     },
     {
-      "path": "../language-services/tsconfig.json"
+      "path": "../language-services/"
     },
     {
-      "path": "../layouts/tsconfig.json"
+      "path": "../layouts/"
     },
     {
-      "path": "../generators/tsconfig.json"
+      "path": "../generators/"
     },
     {
-      "path": "../log/tsconfig.json"
+      "path": "../log/"
     }
   ]
 }

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -39,7 +39,7 @@
     "vsce:publish": "pnpx vsce publish --skip-duplicate"
   },
   "engines": {
-    "vscode": "^1.84.0"
+    "vscode": "^1.110.0"
   },
   "keywords": [
     "architecture",
@@ -128,7 +128,7 @@
         "likec4.mcp.enabled": {
           "type": "boolean",
           "default": false,
-          "markdownDescription": "Enable MCP Server  \nAdd MCP Server to your `#mcp#` configuration: \n```jsonc\n{\n  servers: {\n    likec4: {\n      type: 'sse',\n      url: 'http://localhost:33335/mcp'\n    }\n  }\n}\n```"
+          "markdownDescription": "Enable MCP Server  \nAdd to your `mcp.json`: \n```json\n{\n  \"servers\": {\n    \"likec4\": {\n      \"type\": \"sse\",\n      \"url\": \"http://localhost:33335/mcp\"\n    }\n  }\n}\n```"
         },
         "likec4.mcp.port": {
           "description": "Port to use for MCP Server",
@@ -136,8 +136,7 @@
           "default": 33335
         },
         "likec4.graphviz.mode": {
-          "title": "Graphviz mode",
-          "description": "If you are experiencing issues with the bundled WASM Graphviz, try switch to local binary (\"dot\")",
+          "markdownDescription": "If you are experiencing issues with the bundled WASM Graphviz, try switch to local binary.  \nThe local binary mode is slower, but more stable and supports larger diagrams.  \n(`dot` must be installed and available in PATH or configured via `#likec4.graphviz.path#`)",
           "type": "string",
           "enum": [
             "wasm",
@@ -151,9 +150,8 @@
         },
         "likec4.graphviz.path": {
           "type": "string",
-          "title": "Graphviz binary path",
           "default": "",
-          "description": "Path to the Graphviz dot executable.\nIf empty, extension will try to find it in the PATH."
+          "markdownDescription": "Path to the Graphviz `dot` executable.\nIf empty, extension will try to find it in the PATH."
         },
         "likec4.trace.extension": {
           "type": "string",
@@ -184,19 +182,19 @@
             "ignore"
           ],
           "default": "auto",
-          "description": "Default quote style to use for the LikeC4 formatter. If `ignore`, the formatter will not change the quote style. If `auto`, the formatter will use the quote style of the file it is formatting."
+          "markdownDescription": "Default quote style to use for the LikeC4 formatter. If `ignore`, the formatter will not change the quote style. If `auto`, the formatter will use the quote style of the file it is formatting."
         },
         "likec4.node.path": {
           "type": "string",
           "default": "",
-          "description": "Path to the Node.js executable used to run the language server. If empty, uses 'node' from PATH."
+          "markdownDescription": "Path to the Node.js executable used to run the language server. If empty, uses `node` from PATH."
         },
         "likec4.exclude": {
-          "type": "object",
-          "default": {},
-          "markdownDescription": "Configure glob patterns for excluding files and folders from LikeC4 processing. The pattern format is the same as `#files.exclude#`. Each pattern is a glob and the value is a boolean (`true` to exclude).\n\nExample:\n```json\n{\n  \"**/generated/**\": true,\n  \"**/legacy/**\": true\n}\n```",
-          "additionalProperties": {
-            "type": "boolean"
+          "type": "array",
+          "default": [],
+          "markdownDescription": "Configure glob patterns for excluding files and folders from LikeC4 processing.  \nThe pattern format is the same as `exclude` in `likec4.config.json`.  \nExample:\n```js\n\"**/generated/**\"\n\"**/.worktrees/**\"\n```",
+          "items": {
+            "type": "string"
           }
         }
       }
@@ -305,13 +303,12 @@
     }
   },
   "dependencies": {
-    "bundle-require": "catalog:externals",
-    "esbuild": "catalog:esbuild",
     "fdir": "catalog:externals",
     "std-env": "catalog:externals"
   },
   "devDependencies": {
     "@hpcc-js/wasm-graphviz": "catalog:externals",
+    "esbuild-wasm": "catalog:esbuild",
     "@likec4/config": "workspace:*",
     "@likec4/core": "workspace:*",
     "@likec4/language-server": "workspace:*",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -190,6 +190,14 @@
           "type": "string",
           "default": "",
           "description": "Path to the Node.js executable used to run the language server. If empty, uses 'node' from PATH."
+        },
+        "likec4.exclude": {
+          "type": "object",
+          "default": {},
+          "markdownDescription": "Configure glob patterns for excluding files and folders from LikeC4 processing. The pattern format is the same as `#files.exclude#`. Each pattern is a glob and the value is a boolean (`true` to exclude).\n\nExample:\n```json\n{\n  \"**/generated/**\": true,\n  \"**/legacy/**\": true\n}\n```",
+          "additionalProperties": {
+            "type": "boolean"
+          }
         }
       }
     },

--- a/packages/vscode/package.nls.json
+++ b/packages/vscode/package.nls.json
@@ -7,6 +7,5 @@
   "ext.cmd.preview-context-open-source": "Open source",
   "ext.cmd.print-dot-of-currentview": "Print DOT of current view to output",
   "ext.cmd.validate-layout": "Validate layout",
-  "ext.cmd.open-projects-overview": "Open Projects Overview",
-  "ext.config.node.path.title": "Node.js binary path"
+  "ext.cmd.open-projects-overview": "Open Projects Overview"
 }

--- a/packages/vscode/src/useLanguageClient.ts
+++ b/packages/vscode/src/useLanguageClient.ts
@@ -72,9 +72,13 @@ export const useLanguageClient = createSingletonComposable(() => {
     await restartLanguageServer()
   })
 
-  watch(() => config.exclude, async () => {
-    logger.info('likec4.exclude configuration changed, restarting language server')
-    await restartLanguageServer()
+  let excludeRestartTimer: ReturnType<typeof setTimeout> | undefined
+  watch(() => config.exclude, () => {
+    clearTimeout(excludeRestartTimer)
+    excludeRestartTimer = setTimeout(() => {
+      logger.info('likec4.exclude configuration changed, restarting language server')
+      void restartLanguageServer()
+    }, 800)
   })
 
   return {

--- a/packages/vscode/src/useLanguageClient.ts
+++ b/packages/vscode/src/useLanguageClient.ts
@@ -1,5 +1,6 @@
 import useDocumentSelector from '#useDocumentSelector'
 import useEnvLanguageClient from '#useLanguageClient'
+import { watchDebounced } from '@reactive-vscode/vueuse'
 import {
   createSingletonComposable,
   useDisposable,
@@ -72,14 +73,10 @@ export const useLanguageClient = createSingletonComposable(() => {
     await restartLanguageServer()
   })
 
-  let excludeRestartTimer: ReturnType<typeof setTimeout> | undefined
-  watch(() => config.exclude, () => {
-    clearTimeout(excludeRestartTimer)
-    excludeRestartTimer = setTimeout(() => {
-      logger.info('likec4.exclude configuration changed, restarting language server')
-      void restartLanguageServer()
-    }, 800)
-  })
+  watchDebounced(() => config.exclude, () => {
+    logger.info('likec4.exclude configuration changed, restarting language server')
+    void restartLanguageServer()
+  }, { debounce: 800 })
 
   return {
     client,

--- a/packages/vscode/src/useLanguageClient.ts
+++ b/packages/vscode/src/useLanguageClient.ts
@@ -74,9 +74,12 @@ export const useLanguageClient = createSingletonComposable(() => {
   })
 
   watchDebounced(() => config.exclude, () => {
-    logger.info('likec4.exclude configuration changed, restarting language server')
+    logger.debug`${'exclude'} configuration changed, restarting language server`
     void restartLanguageServer()
-  }, { debounce: 800 })
+  }, {
+    deep: true,
+    debounce: 800,
+  })
 
   return {
     client,

--- a/packages/vscode/src/useLanguageClient.ts
+++ b/packages/vscode/src/useLanguageClient.ts
@@ -6,6 +6,7 @@ import {
   watch,
 } from 'reactive-vscode'
 import { State } from 'vscode-languageclient'
+import { config } from './config'
 import { isDev } from './const'
 import { useExtensionLogger } from './useExtensionLogger'
 import { useIsActivated } from './useIsActivated'
@@ -68,6 +69,11 @@ export const useLanguageClient = createSingletonComposable(() => {
   watch(documentSelector, async (selector) => {
     logger.info('updated document selector', { selector })
     client.clientOptions.documentSelector = selector
+    await restartLanguageServer()
+  })
+
+  watch(() => config.exclude, async () => {
+    logger.info('likec4.exclude configuration changed, restarting language server')
     await restartLanguageServer()
   })
 

--- a/packages/vscode/tsconfig.json
+++ b/packages/vscode/tsconfig.json
@@ -11,7 +11,7 @@
     "rootDirs": [
       "src",
       "."
-    ],
+    ]
   },
   "include": [
     "src",
@@ -19,19 +19,25 @@
   ],
   "references": [
     {
-      "path": "../core/tsconfig.json"
+      "path": "../core/"
     },
     {
-      "path": "../log/tsconfig.json"
+      "path": "../log/"
     },
     {
-      "path": "../config/tsconfig.json"
+      "path": "../config/"
+    },
+    {
+      "path": "../layouts/"
     },
     {
       "path": "../vscode-preview/tsconfig.protocol.json"
     },
     {
-      "path": "../language-server/tsconfig.json"
+      "path": "../language-server/"
+    },
+    {
+      "path": "../language-services/"
     }
   ]
 }

--- a/packages/vscode/tsdown.config.ts
+++ b/packages/vscode/tsdown.config.ts
@@ -13,6 +13,9 @@ const shared = {
   define: {
     'process.env.NODE_ENV': isProduction ? '"production"' : '"development"',
   },
+  alias: {
+    'esbuild': import.meta.resolve('esbuild-wasm'),
+  },
   minify: isProduction,
   outputOptions: {
     keepNames: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -382,11 +382,11 @@ catalogs:
       version: 6.1.1
   vitest:
     '@vitest/ui':
-      specifier: 4.1.0
-      version: 4.1.0
+      specifier: 4.1.3
+      version: 4.1.3
     vitest:
-      specifier: 4.1.0
-      version: 4.1.0
+      specifier: 4.1.3
+      version: 4.1.3
   vscode:
     '@types/vscode':
       specifier: ^1.106.1
@@ -503,7 +503,7 @@ importers:
         version: link:devops
       '@vitest/ui':
         specifier: catalog:vitest
-        version: 4.1.0(vitest@4.1.0)
+        version: 4.1.3(vitest@4.1.3)
       dprint:
         specifier: ^0.53.2
         version: 0.53.2
@@ -542,7 +542,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:vitest
-        version: 4.1.0(@types/node@22.19.15)(@vitest/ui@4.1.0)(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.39.2)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.3(@types/node@22.19.15)(@vitest/ui@4.1.3)(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.39.2)(tsx@4.21.0)(yaml@2.8.3))
 
   apps/docs:
     devDependencies:
@@ -920,7 +920,7 @@ importers:
         version: 4.21.0
       vitest:
         specifier: catalog:vitest
-        version: 4.1.0(@types/node@22.19.15)(@vitest/ui@4.1.0)(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.39.2)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.3(@types/node@22.19.15)(@vitest/ui@4.1.3)(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.39.2)(tsx@4.21.0)(yaml@2.8.3))
       zx:
         specifier: 8.8.5
         version: 8.8.5
@@ -1003,7 +1003,7 @@ importers:
         version: 1.6.3
       vitest:
         specifier: catalog:vitest
-        version: 4.1.0(@types/node@22.19.15)(@vitest/ui@4.1.0)(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.39.2)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.3(@types/node@22.19.15)(@vitest/ui@4.1.3)(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.39.2)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/core:
     dependencies:
@@ -1142,7 +1142,7 @@ importers:
         version: 11.0.5
       vitest:
         specifier: catalog:vitest
-        version: 4.1.0(@types/node@22.19.15)(@vitest/ui@4.1.0)(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.39.2)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.3(@types/node@22.19.15)(@vitest/ui@4.1.3)(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.39.2)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/diagram:
     dependencies:
@@ -1290,7 +1290,7 @@ importers:
         version: 4.5.4(@types/node@22.19.15)(rollup@4.60.1)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.39.2)(tsx@4.21.0)(yaml@2.8.3))
       vitest:
         specifier: catalog:vitest
-        version: 4.1.0(@types/node@22.19.15)(@vitest/ui@4.1.0)(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.39.2)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.3(@types/node@22.19.15)(@vitest/ui@4.1.3)(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.39.2)(tsx@4.21.0)(yaml@2.8.3))
       wireit:
         specifier: 'catalog:'
         version: 0.14.12
@@ -1357,7 +1357,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:vitest
-        version: 4.1.0(@types/node@22.19.15)(@vitest/ui@4.1.0)(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.39.2)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.3(@types/node@22.19.15)(@vitest/ui@4.1.3)(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.39.2)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/icons:
     devDependencies:
@@ -1457,6 +1457,9 @@ importers:
       p-timeout:
         specifier: catalog:utils
         version: 7.0.1
+      pathe:
+        specifier: catalog:utils
+        version: 2.0.3
       picomatch:
         specifier: catalog:externals
         version: 4.0.4
@@ -1559,7 +1562,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:vitest
-        version: 4.1.0(@types/node@22.19.15)(@vitest/ui@4.1.0)(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.39.2)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.3(@types/node@22.19.15)(@vitest/ui@4.1.3)(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.39.2)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/language-services:
     dependencies:
@@ -1638,7 +1641,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:vitest
-        version: 4.1.0(@types/node@22.19.15)(@vitest/ui@4.1.0)(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.39.2)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.3(@types/node@22.19.15)(@vitest/ui@4.1.3)(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.39.2)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/layouts:
     dependencies:
@@ -1714,7 +1717,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:vitest
-        version: 4.1.0(@types/node@22.19.15)(@vitest/ui@4.1.0)(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.39.2)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.3(@types/node@22.19.15)(@vitest/ui@4.1.3)(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.39.2)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/leanix-bridge:
     dependencies:
@@ -1742,7 +1745,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:vitest
-        version: 4.1.0(@types/node@22.19.15)(@vitest/ui@4.1.0)(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.39.2)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.3(@types/node@22.19.15)(@vitest/ui@4.1.3)(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.39.2)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/likec4:
     dependencies:
@@ -2025,7 +2028,7 @@ importers:
         version: 11.3.3(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.39.2)(tsx@4.21.0)(yaml@2.8.3))
       vitest:
         specifier: catalog:vitest
-        version: 4.1.0(@types/node@22.19.15)(@vitest/ui@4.1.0)(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.39.2)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.3(@types/node@22.19.15)(@vitest/ui@4.1.3)(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.39.2)(tsx@4.21.0)(yaml@2.8.3))
       vscode-jsonrpc:
         specifier: 8.2.1
         version: 8.2.1
@@ -2192,7 +2195,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:vitest
-        version: 4.1.0(@types/node@22.19.15)(@vitest/ui@4.1.0)(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.39.2)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.3(@types/node@22.19.15)(@vitest/ui@4.1.3)(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.39.2)(tsx@4.21.0)(yaml@2.8.3))
       vscode-uri:
         specifier: 3.1.0
         version: 3.1.0
@@ -2388,16 +2391,10 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:vitest
-        version: 4.1.0(@types/node@22.19.15)(@vitest/ui@4.1.0)(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.39.2)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.3(@types/node@22.19.15)(@vitest/ui@4.1.3)(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.39.2)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/vscode:
     dependencies:
-      bundle-require:
-        specifier: catalog:externals
-        version: 5.1.0(esbuild@0.27.4)
-      esbuild:
-        specifier: 0.27.4
-        version: 0.27.4
       fdir:
         specifier: catalog:externals
         version: 6.4.0(picomatch@4.0.4)
@@ -2450,6 +2447,9 @@ importers:
       esbuild-plugins-node-modules-polyfill:
         specifier: catalog:esbuild
         version: 1.8.1(esbuild@0.27.4)
+      esbuild-wasm:
+        specifier: catalog:esbuild
+        version: 0.27.4
       esm-env:
         specifier: catalog:utils
         version: 1.2.2
@@ -5400,39 +5400,39 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  '@vitest/expect@4.1.0':
-    resolution: {integrity: sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==}
+  '@vitest/expect@4.1.3':
+    resolution: {integrity: sha512-CW8Q9KMtXDGHj0vCsqui0M5KqRsu0zm0GNDW7Gd3U7nZ2RFpPKSCpeCXoT+/+5zr1TNlsoQRDEz+LzZUyq6gnQ==}
 
-  '@vitest/mocker@4.1.0':
-    resolution: {integrity: sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==}
+  '@vitest/mocker@4.1.3':
+    resolution: {integrity: sha512-XN3TrycitDQSzGRnec/YWgoofkYRhouyVQj4YNsJ5r/STCUFqMrP4+oxEv3e7ZbLi4og5kIHrZwekDJgw6hcjw==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0-0
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       msw:
         optional: true
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.1.0':
-    resolution: {integrity: sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==}
+  '@vitest/pretty-format@4.1.3':
+    resolution: {integrity: sha512-hYqqwuMbpkkBodpRh4k4cQSOELxXky1NfMmQvOfKvV8zQHz8x8Dla+2wzElkMkBvSAJX5TRGHJAQvK0TcOafwg==}
 
-  '@vitest/runner@4.1.0':
-    resolution: {integrity: sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==}
+  '@vitest/runner@4.1.3':
+    resolution: {integrity: sha512-VwgOz5MmT0KhlUj40h02LWDpUBVpflZ/b7xZFA25F29AJzIrE+SMuwzFf0b7t4EXdwRNX61C3B6auIXQTR3ttA==}
 
-  '@vitest/snapshot@4.1.0':
-    resolution: {integrity: sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==}
+  '@vitest/snapshot@4.1.3':
+    resolution: {integrity: sha512-9l+k/J9KG5wPJDX9BcFFzhhwNjwkRb8RsnYhaT1vPY7OufxmQFc9sZzScRCPTiETzl37mrIWVY9zxzmdVeJwDQ==}
 
-  '@vitest/spy@4.1.0':
-    resolution: {integrity: sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==}
+  '@vitest/spy@4.1.3':
+    resolution: {integrity: sha512-ujj5Uwxagg4XUIfAUyRQxAg631BP6e9joRiN99mr48Bg9fRs+5mdUElhOoZ6rP5mBr8Bs3lmrREnkrQWkrsTCw==}
 
-  '@vitest/ui@4.1.0':
-    resolution: {integrity: sha512-sTSDtVM1GOevRGsCNhp1mBUHKo9Qlc55+HCreFT4fe99AHxl1QQNXSL3uj4Pkjh5yEuWZIx8E2tVC94nnBZECQ==}
+  '@vitest/ui@4.1.3':
+    resolution: {integrity: sha512-xBPy+43o1fgMLUDlufUXh7tlT/Es8uS5eiyBY2PyPfFYSGpApZskLw65DROoDz+rgYkPuAmb20Mv9Z9g1WQE7w==}
     peerDependencies:
-      vitest: 4.1.0
+      vitest: 4.1.3
 
-  '@vitest/utils@4.1.0':
-    resolution: {integrity: sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==}
+  '@vitest/utils@4.1.3':
+    resolution: {integrity: sha512-Pc/Oexse/khOWsGB+w3q4yzA4te7W4gpZZAvk+fr8qXfTURZUMj5i7kuxsNK5mP/dEB6ao3jfr0rs17fHhbHdw==}
 
   '@volar/kit@2.4.26':
     resolution: {integrity: sha512-shgNg7PbV8SIxxQLOQh5zMr8KV0JvdG9If0MwJb5L1HMrBU91jBxR0ANi2OJPMMme6/l1vIYm4hCaO6W2JaEcQ==}
@@ -8996,6 +8996,10 @@ packages:
     resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
     engines: {node: '>=14.0.0'}
 
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
   to-buffer@1.2.2:
     resolution: {integrity: sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==}
     engines: {node: '>= 0.4'}
@@ -9507,21 +9511,23 @@ packages:
       vite:
         optional: true
 
-  vitest@4.1.0:
-    resolution: {integrity: sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==}
+  vitest@4.1.3:
+    resolution: {integrity: sha512-DBc4Tx0MPNsqb9isoyOq00lHftVx/KIU44QOm2q59npZyLUkENn8TMFsuzuO+4U2FUa9rgbbPt3udrP25GcjXw==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.0
-      '@vitest/browser-preview': 4.1.0
-      '@vitest/browser-webdriverio': 4.1.0
-      '@vitest/ui': 4.1.0
+      '@vitest/browser-playwright': 4.1.3
+      '@vitest/browser-preview': 4.1.3
+      '@vitest/browser-webdriverio': 4.1.3
+      '@vitest/coverage-istanbul': 4.1.3
+      '@vitest/coverage-v8': 4.1.3
+      '@vitest/ui': 4.1.3
       happy-dom: '*'
       jsdom: '*'
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0-0
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -9534,6 +9540,10 @@ packages:
       '@vitest/browser-preview':
         optional: true
       '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
         optional: true
       '@vitest/ui':
         optional: true
@@ -13159,57 +13169,57 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/expect@4.1.0':
+  '@vitest/expect@4.1.3':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.2
-      '@vitest/spy': 4.1.0
-      '@vitest/utils': 4.1.0
+      '@vitest/spy': 4.1.3
+      '@vitest/utils': 4.1.3
       chai: 6.2.2
-      tinyrainbow: 3.0.3
+      tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.0(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.39.2)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.3(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.39.2)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
-      '@vitest/spy': 4.1.0
+      '@vitest/spy': 4.1.3
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       vite: 7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.39.2)(tsx@4.21.0)(yaml@2.8.3)
 
-  '@vitest/pretty-format@4.1.0':
+  '@vitest/pretty-format@4.1.3':
     dependencies:
-      tinyrainbow: 3.0.3
+      tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.1.0':
+  '@vitest/runner@4.1.3':
     dependencies:
-      '@vitest/utils': 4.1.0
+      '@vitest/utils': 4.1.3
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.0':
+  '@vitest/snapshot@4.1.3':
     dependencies:
-      '@vitest/pretty-format': 4.1.0
-      '@vitest/utils': 4.1.0
+      '@vitest/pretty-format': 4.1.3
+      '@vitest/utils': 4.1.3
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.1.0': {}
+  '@vitest/spy@4.1.3': {}
 
-  '@vitest/ui@4.1.0(vitest@4.1.0)':
+  '@vitest/ui@4.1.3(vitest@4.1.3)':
     dependencies:
-      '@vitest/utils': 4.1.0
+      '@vitest/utils': 4.1.3
       fflate: 0.8.2
       flatted: 3.4.2
       pathe: 2.0.3
       sirv: 3.0.2
       tinyglobby: 0.2.15
-      tinyrainbow: 3.0.3
-      vitest: 4.1.0(@types/node@22.19.15)(@vitest/ui@4.1.0)(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.39.2)(tsx@4.21.0)(yaml@2.8.3))
+      tinyrainbow: 3.1.0
+      vitest: 4.1.3(@types/node@22.19.15)(@vitest/ui@4.1.3)(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.39.2)(tsx@4.21.0)(yaml@2.8.3))
 
-  '@vitest/utils@4.1.0':
+  '@vitest/utils@4.1.3':
     dependencies:
-      '@vitest/pretty-format': 4.1.0
+      '@vitest/pretty-format': 4.1.3
       convert-source-map: 2.0.0
-      tinyrainbow: 3.0.3
+      tinyrainbow: 3.1.0
 
   '@volar/kit@2.4.26(typescript@5.9.3)':
     dependencies:
@@ -17582,6 +17592,8 @@ snapshots:
 
   tinyrainbow@3.0.3: {}
 
+  tinyrainbow@3.1.0: {}
+
   to-buffer@1.2.2:
     dependencies:
       isarray: 2.0.5
@@ -18005,15 +18017,15 @@ snapshots:
     optionalDependencies:
       vite: 6.4.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.39.2)(tsx@4.21.0)(yaml@2.8.3)
 
-  vitest@4.1.0(@types/node@22.19.15)(@vitest/ui@4.1.0)(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.39.2)(tsx@4.21.0)(yaml@2.8.3)):
+  vitest@4.1.3(@types/node@22.19.15)(@vitest/ui@4.1.3)(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.39.2)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
-      '@vitest/expect': 4.1.0
-      '@vitest/mocker': 4.1.0(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.39.2)(tsx@4.21.0)(yaml@2.8.3))
-      '@vitest/pretty-format': 4.1.0
-      '@vitest/runner': 4.1.0
-      '@vitest/snapshot': 4.1.0
-      '@vitest/spy': 4.1.0
-      '@vitest/utils': 4.1.0
+      '@vitest/expect': 4.1.3
+      '@vitest/mocker': 4.1.3(vite@7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.39.2)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.3
+      '@vitest/runner': 4.1.3
+      '@vitest/snapshot': 4.1.3
+      '@vitest/spy': 4.1.3
+      '@vitest/utils': 4.1.3
       es-module-lexer: 2.0.0
       expect-type: 1.3.0
       magic-string: 0.30.21
@@ -18024,12 +18036,12 @@ snapshots:
       tinybench: 2.9.0
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
-      tinyrainbow: 3.0.3
+      tinyrainbow: 3.1.0
       vite: 7.3.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.39.2)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.15
-      '@vitest/ui': 4.1.0(vitest@4.1.0)
+      '@vitest/ui': 4.1.3(vitest@4.1.3)
     transitivePeerDependencies:
       - msw
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1454,6 +1454,9 @@ importers:
       p-queue:
         specifier: catalog:utils
         version: 8.1.1
+      p-timeout:
+        specifier: catalog:utils
+        version: 7.0.1
       picomatch:
         specifier: catalog:externals
         version: 4.0.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -163,8 +163,8 @@ catalogs:
     vite-plugin-node-polyfills: ^0.25.0
     vite-tsconfig-paths: ^6.1.1
   vitest:
-    "@vitest/ui": 4.1.0
-    vitest: 4.1.0
+    "@vitest/ui": 4.1.3
+    vitest: 4.1.3
   vscode:
     "@types/vscode": ^1.106.1
     vscode-jsonrpc: 8.2.1


### PR DESCRIPTION
Adds a new `likec4.exclude` workspace-level configuration option to the VSCode extension. Users can configure glob patterns as an array of strings (e.g. `["**/generated/**", "**/.worktrees/**"]`) to exclude files and folders from LikeC4 processing directly from VSCode settings, without needing a `.likec4rc` config file.

The language server reads the initial exclude configuration during workspace startup (in `WorkspaceManager.performStartup`) with a 1s timeout fallback for third-party IDEs. When the setting changes at runtime, the VSCode extension restarts the language server (debounced 800ms) so a fresh scan picks up the new patterns — this avoids the complexity of incremental rebuilds with incomplete workspace rescanning.

### Key changes

- **`packages/vscode/package.json`** — New `likec4.exclude` setting (array of glob strings)
- **`packages/vscode/src/useLanguageClient.ts`** — `watchDebounced` on `config.exclude` to restart the language server on change
- **`packages/language-server/src/workspace/WorkspaceManager.ts`** — `readExcludeConfig()` reads initial config with `p-timeout` fallback before workspace scan
- **`packages/language-server/src/workspace/ProjectsManager.ts`** — `setWorkspaceExcludePatterns(string[])` with defensive guards, workspace-level exclude predicate used in `isExcluded()`

## Checklist

- [x] I've thoroughly read the latest [contribution guidelines](https://github.com/likec4/likec4/blob/main/CONTRIBUTING.md).
- [x] I've rebased my branch onto `main` **before** creating this PR.
- [x] I've added tests to cover my changes (if applicable).
- [x] I've verified `pnpm typecheck` and `pnpm test`.
- [x] I've added [changesets](https://changesets-docs.vercel.app/) (you can use `/changeset-generator` SKILL).
- [ ] My change requires documentation updates.
- [ ] I've updated the documentation accordingly (or will do in follow-up PR).