### PR TITLE
feat(cli): add --theme option to build command

### DIFF
--- a/.changeset/build-theme-option.md
+++ b/.changeset/build-theme-option.md
@@ -1,0 +1,5 @@
+---
+'likec4': minor
+---
+
+Add `--theme` option to `likec4 build` command to set the default color scheme (light/dark) for the generated static website

--- a/packages/likec4/app/global.d.ts
+++ b/packages/likec4/app/global.d.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 /// <reference types="vite/client" />
 
 declare const __likec4styles: Map<string, string>
@@ -8,6 +15,9 @@ declare const SHADOW_STYLE: string
 
 // default is 'likec4'
 declare const WEBCOMPONENT_PREFIX: string
+
+// default is 'auto', set via --theme CLI option
+declare const __DEFAULT_THEME__: 'light' | 'dark' | 'auto'
 
 interface ImportMetaEnv {
   readonly VITE_KROKI_D2_SVG_URL?: string

--- a/packages/likec4/app/src/routes/__root.tsx
+++ b/packages/likec4/app/src/routes/__root.tsx
@@ -56,10 +56,13 @@ function RootComponent() {
   // writing to localStorage. This preserves the user's manual preference
   // while allowing embeds to override the appearance via URL.
   const forceColorScheme = resolveForceColorScheme(theme)
+  // When ?theme=auto is explicitly set, restore system preference even if
+  // the build default is light or dark.
+  const defaultColorScheme = theme === 'auto' ? 'auto' : __DEFAULT_THEME__
   return (
     <MantineProvider
       theme={mantineTheme}
-      defaultColorScheme="auto"
+      defaultColorScheme={defaultColorScheme}
       {...(forceColorScheme && { forceColorScheme })}
     >
       <Outlet />

--- a/packages/likec4/app/src/searchParams.spec.ts
+++ b/packages/likec4/app/src/searchParams.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { resolveForceColorScheme } from './searchParams'
+
+describe('resolveForceColorScheme', () => {
+  it('should force light/dark and pass through auto/undefined', () => {
+    expect(resolveForceColorScheme('light')).toBe('light')
+    expect(resolveForceColorScheme('dark')).toBe('dark')
+    expect(resolveForceColorScheme('auto')).toBeUndefined()
+    expect(resolveForceColorScheme(undefined)).toBeUndefined()
+  })
+})
+
+describe('--theme build option', () => {
+  // Logic from __root.tsx: theme === 'auto' ? 'auto' : __DEFAULT_THEME__
+  // Logic from config-app.prod.ts: JSON.stringify(cfg?.theme ?? 'auto')
+  const deriveDefault = (url: string | undefined, build: string) => url === 'auto' ? 'auto' : build
+  const defineValue = (theme: string | undefined) => JSON.stringify(theme ?? 'auto')
+
+  it('should default to auto when --theme is omitted', () => {
+    expect(defineValue(undefined)).toBe('"auto"')
+    expect(deriveDefault(undefined, 'auto')).toBe('auto')
+  })
+
+  it('should use build default when no URL override', () => {
+    expect(defineValue('dark')).toBe('"dark"')
+    expect(deriveDefault(undefined, 'dark')).toBe('dark')
+  })
+
+  it('should restore auto when URL explicitly requests ?theme=auto', () => {
+    expect(deriveDefault('auto', 'dark')).toBe('auto')
+    expect(deriveDefault('auto', 'light')).toBe('auto')
+  })
+})

--- a/packages/likec4/app/tsconfig.json
+++ b/packages/likec4/app/tsconfig.json
@@ -17,10 +17,11 @@
     "rootDir": ".",
     "types": [
       "vite/client",
-      "@likec4/vite-plugin/modules",
+      "@likec4/vite-plugin/modules"
     ]
   },
   "include": [
+    "global.d.ts",
     "src",
     "react"
   ],

--- a/packages/likec4/src/cli/build/index.ts
+++ b/packages/likec4/src/cli/build/index.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { fromWorkspace } from '@likec4/language-services/node/without-mcp'
 import { resolve } from 'node:path'
 import k from 'tinyrainbow'
@@ -9,6 +16,7 @@ import {
   base,
   outputSingleFile,
   path,
+  theme,
   title,
   useDotBin,
   useHashHistory,
@@ -38,9 +46,14 @@ const buildCmd = (yargs: yargs.Argv) => {
           .option('webcomponent-prefix', webcomponentPrefix)
           .option('title', title)
           .option('output-single-file', outputSingleFile)
+          .option('theme', theme)
           .example(
             `${k.green('$0 build -o ./build ./src')}`,
             k.gray('Search for likec4 files in \'src\' and output static site to \'build\''),
+          )
+          .example(
+            `${k.green('$0 build --theme dark -o ./build ./src')}`,
+            k.gray('Build with dark color scheme as default'),
           ),
       handler: async (args) => {
         const params = {
@@ -68,6 +81,7 @@ const buildCmd = (yargs: yargs.Argv) => {
           customLogger: logger,
           webcomponentPrefix: params.webcomponentPrefix,
           title: args.title,
+          theme: args.theme,
           languageServices,
           likec4AssetsDir,
           outputDir,

--- a/packages/likec4/src/cli/options.ts
+++ b/packages/likec4/src/cli/options.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { DEV } from 'esm-env'
 import isInsideContainer from 'is-inside-container'
 import { resolve } from 'node:path'
@@ -57,6 +64,12 @@ export const title = {
   string: true,
   desc: 'base title of the app pages (default is "LikeC4")',
   default: 'LikeC4',
+  nargs: 1,
+} as const satisfies Options
+
+export const theme = {
+  choices: ['light', 'dark'] as const,
+  desc: 'default color scheme for the built website (default: auto, follows system preference)',
   nargs: 1,
 } as const satisfies Options
 

--- a/packages/likec4/src/vite/config-app.prod.ts
+++ b/packages/likec4/src/vite/config-app.prod.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { viteAliases } from '#vite/aliases'
 import { LikeC4VitePlugin } from '@likec4/vite-plugin'
 import react from '@vitejs/plugin-react'
@@ -16,6 +23,7 @@ export type LikeC4ViteConfig = {
   outputDir?: string | undefined
   base?: string | undefined
   title?: string | undefined
+  theme?: 'light' | 'dark' | undefined
   webcomponentPrefix?: string | undefined
   useHashHistory?: boolean | undefined
   likec4AssetsDir: string
@@ -99,6 +107,7 @@ export const viteConfig = async ({ languageServices, likec4AssetsDir, ...cfg }: 
       WEBCOMPONENT_PREFIX: JSON.stringify(webcomponentPrefix),
       PAGE_TITLE: JSON.stringify(title),
       __USE_HASH_HISTORY__: cfg?.useHashHistory === true ? 'true' : 'false',
+      __DEFAULT_THEME__: JSON.stringify(cfg?.theme ?? 'auto'),
       'process.env.NODE_ENV': '"production"',
     },
     build: {

--- a/packages/likec4/src/vite/config-app.ts
+++ b/packages/likec4/src/vite/config-app.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { viteAliases } from '#vite/aliases'
 import { LikeC4VitePlugin } from '@likec4/vite-plugin'
 import { TanStackRouterVite } from '@tanstack/router-vite-plugin'
@@ -58,6 +65,7 @@ export const viteConfig = async ({ languageServices, likec4AssetsDir, ...cfg }: 
       WEBCOMPONENT_PREFIX: JSON.stringify(webcomponentPrefix),
       PAGE_TITLE: JSON.stringify(title),
       __USE_HASH_HISTORY__: cfg?.useHashHistory === true ? 'true' : 'false',
+      __DEFAULT_THEME__: JSON.stringify(cfg?.theme ?? 'auto'),
       'process.env.NODE_ENV': '"development"',
     },
     resolve: {

--- a/packages/likec4/src/vite/config-webcomponent.ts
+++ b/packages/likec4/src/vite/config-webcomponent.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { viteAliases } from '#vite/aliases'
 import { logger as consola } from '@likec4/log'
 import { LikeC4VitePlugin } from '@likec4/vite-plugin'
@@ -45,6 +52,7 @@ export async function viteWebcomponentConfig({
       WEBCOMPONENT_PREFIX: JSON.stringify(webcomponentPrefix),
       __USE_HASH_HISTORY__: 'false',
       __USE_OVERVIEW_GRAPH__: 'false',
+      __DEFAULT_THEME__: JSON.stringify('auto'),
       'process.env.NODE_ENV': '"development"',
     },
     build: {


### PR DESCRIPTION
## Summary

Add `--theme light|dark` option to `likec4 build`, setting the default color scheme for the generated static website. When omitted, defaults to `auto` (follows system preference, same as current behavior).

Closes #1934

### How it works
- CLI: new `--theme` option in `likec4 build` (same choices as `likec4 export png --theme`)
- Vite: injected via `define` as `__DEFAULT_THEME__` constant
- App: `MantineProvider` reads `__DEFAULT_THEME__` as `defaultColorScheme` instead of hardcoded `"auto"`
- Users can still override per-page via `?theme=light|dark` URL parameter

### Files changed (7)
- `packages/likec4/src/cli/options.ts` — new `theme` option definition
- `packages/likec4/src/cli/build/index.ts` — wire `--theme` to `viteBuild`
- `packages/likec4/src/vite/config-app.prod.ts` — add `__DEFAULT_THEME__` to Vite define
- `packages/likec4/src/vite/config-app.ts` — same for dev config
- `packages/likec4/src/vite/config-webcomponent.ts` — same for webcomponent config
- `packages/likec4/app/global.d.ts` — type declaration
- `packages/likec4/app/src/routes/__root.tsx` — consume `__DEFAULT_THEME__`