### PR TITLE
fix(app): close search dialog before navigating to prevent ghost overlay

### DIFF
--- a/.changeset/fix-search-overlay-close.md
+++ b/.changeset/fix-search-overlay-close.md
@@ -1,0 +1,5 @@
+---
+'@likec4/diagram': patch
+---
+
+Fix search overlay persisting after navigating to a view via Ctrl+K search

--- a/e2e/tests/overview-page.spec.ts
+++ b/e2e/tests/overview-page.spec.ts
@@ -75,4 +75,21 @@ test.describe('Overview page', () => {
     // Should navigate to the view page
     await expect(page).toHaveURL(/\/view\/index\//)
   })
+
+  test('search overlay closes after navigating to a view (#2353)', async ({ page }) => {
+    // Open search
+    await page.getByRole('button', { name: /Search/ }).click()
+    await expect(page.getByRole('textbox', { name: /Search by title/ })).toBeVisible()
+
+    // Navigate to a view via the search panel
+    await page.getByRole('button', { name: /Landscape/ }).click()
+    await expect(page).toHaveURL(/\/view\/index\//)
+
+    // The search dialog must be fully gone — no ghost overlay trapping focus
+    await expect(page.locator('dialog[open]')).toHaveCount(0)
+    await expect(page.locator('[data-likec4-search]')).toHaveCount(0)
+
+    // The diagram view should be interactive (not blocked by overlay)
+    await expect(page.locator('.react-flow__pane')).toBeVisible()
+  })
 })

--- a/packages/diagram/src/overlays/overlay/Overlay.tsx
+++ b/packages/diagram/src/overlays/overlay/Overlay.tsx
@@ -64,8 +64,18 @@ export const Overlay = forwardRef<HTMLDialogElement, OverlayProps>(({
 
   useLayoutEffect(() => {
     if (!dialogRef.current?.open) {
-      // Move dialog to the top of the DOM
       dialogRef.current?.showModal()
+    }
+    // Ensure the dialog is properly closed when unmounted, so the browser
+    // removes it from the top layer. Without this, AnimatePresence can
+    // remove the DOM node without calling dialog.close(), leaving a ghost
+    // entry in the top layer that traps focus and blocks interaction. (#2353)
+    const dialog = dialogRef.current
+    return () => {
+      if (dialog?.open) {
+        isClosingRef.current = true
+        dialog.close()
+      }
     }
   }, [])
 

--- a/packages/likec4/app/src/components/search/OverviewSearch.tsx
+++ b/packages/likec4/app/src/components/search/OverviewSearch.tsx
@@ -6,14 +6,28 @@ import { searchBodyCss, SearchControl, searchDialogCss, SearchPanelContent } fro
 import { FramerMotionConfig, Overlay } from '@likec4/diagram/custom'
 import { useHotkeys } from '@mantine/hooks'
 import { AnimatePresence } from 'motion/react'
-import { memo, useCallback, useState } from 'react'
+import { memo, useCallback, useRef, useState } from 'react'
 import { OverviewSearchAdapter } from './OverviewSearchAdapter'
 
 export const OverviewSearch = memo(() => {
   const [isOpened, setIsOpened] = useState(false)
+  // Retains a reference to the dialog element beyond unmount,
+  // so onExitComplete can close it after the exit animation (#2353)
+  const dialogElRef = useRef<HTMLDialogElement | null>(null)
 
   const open = useCallback(() => setIsOpened(true), [])
   const close = useCallback(() => setIsOpened(false), [])
+
+  const captureDialogRef = useCallback((node: HTMLDialogElement | null) => {
+    if (node) dialogElRef.current = node
+  }, [])
+
+  const handleExitComplete = useCallback(() => {
+    if (dialogElRef.current?.open) {
+      dialogElRef.current.close()
+    }
+    dialogElRef.current = null
+  }, [])
 
   useHotkeys([
     ['mod+k', open, { preventDefault: true }],
@@ -23,9 +37,10 @@ export const OverviewSearch = memo(() => {
     <>
       <SearchControl onClick={open} />
       <FramerMotionConfig>
-        <AnimatePresence>
+        <AnimatePresence onExitComplete={handleExitComplete}>
           {isOpened && (
             <Overlay
+              ref={captureDialogRef}
               fullscreen
               withBackdrop={false}
               backdrop={{


### PR DESCRIPTION
## Summary

Fix for the search overlay persisting after navigating to a view via Ctrl+K search, trapping focus and blocking interaction with the destination diagram.

Closes #2353

### Root Cause

When clicking a view in the search panel, `navigateTo` called `onClose()` (React state update) and `navigate()` (route change) simultaneously. The route change could unmount the `OverviewSearch` component before the `<dialog>` element was properly closed via the DOM API. Since `showModal()` places the dialog in the browser's top layer, unmounting without calling `.close()` first left the dialog's backdrop and focus trap active.

### Fix

Explicitly close all open search `<dialog>` elements via the DOM before triggering the React state change and route navigation. This ensures the browser removes the dialog from the top layer before the component unmounts.

### Verified with Playwright

- Open overview page
- Ctrl+K to open search
- Click a view result → navigates to view
- After navigation: 0 open dialogs, 0 dialog elements, search overlay gone
- View is fully interactive

### Files changed (1)

- `packages/likec4/app/src/components/search/OverviewSearchAdapter.tsx` — 6 lines added