### PR TITLE
fix(vite-plugin): apply manual layouts in codegen React hooks

### DIFF
--- a/.changeset/fix-codegen-manual-layout.md
+++ b/.changeset/fix-codegen-manual-layout.md
@@ -1,0 +1,5 @@
+---
+'@likec4/vite-plugin': patch
+---
+
+Fix codegen react and view hooks not applying manual layouts (views now use `$layouted` via LikeC4ViewModel)

--- a/packages/vite-plugin/src/internal.ts
+++ b/packages/vite-plugin/src/internal.ts
@@ -7,7 +7,7 @@ import { useStore } from '@nanostores/react'
 import { createBirpc } from 'birpc'
 import type { Atom, WritableAtom } from 'nanostores'
 import { computed } from 'nanostores'
-import { useEffect, useState } from 'react'
+import { useMemo } from 'react'
 import { isDeepEqual, mapValues } from 'remeda'
 import type { LikeC4VitePluginRpc } from './rpc/protocol'
 
@@ -72,9 +72,10 @@ export const createHooksForModel: ($atom: WritableAtom) => any = ($atom: Writabl
     $atom.set(next as LayoutedLikeC4ModelData)
   }
 
+  // Return views with manual layouts applied via $layouted (#2553).
   const $likec4views: Atom<ReadonlyArray<DiagramView>> = computed(
-    $atom,
-    (model) => Object.values(model.views),
+    $likec4model,
+    (model) => [...model.views()].map(v => v.$layouted),
   )
 
   function useLikeC4Model(): LikeC4Model.Layouted {
@@ -86,13 +87,11 @@ export const createHooksForModel: ($atom: WritableAtom) => any = ($atom: Writabl
   }
 
   function useLikeC4View(viewId: string): DiagramView | null {
-    const [view, setView] = useState($atom.value?.views[viewId] ?? null)
-    useEffect(() => {
-      return $atom.subscribe((next) => {
-        setView(next.views[viewId] ?? null)
-      })
-    }, [viewId])
-    return view
+    const $view = useMemo(
+      () => computed($likec4model, (model) => model.findView(viewId)?.$layouted ?? null),
+      [viewId],
+    )
+    return useStore($view)
   }
 
   return {


### PR DESCRIPTION
## Summary

Fix for #2553 — codegen React hooks (`useLikeC4Views`, `useLikeC4View`) were not applying manual layouts.

### Root Cause

The hooks in `packages/vite-plugin/src/internal.ts` read raw view data directly from `$atom.views`, bypassing `LikeC4ViewModel.$layouted` which applies manual layout overrides.

### Fix

- `$likec4views` now derives from `$likec4model` and maps through `v.$layouted`
- `useLikeC4View` uses `computed($likec4model, ...)` with `$layouted`, wrapped in `useMemo` for stable atom identity
- Removed unused `useState`/`useEffect` imports

This matches the pattern already used in `packages/likec4/app/src/hooks.ts`.

### Files changed

- `packages/vite-plugin/src/internal.ts` — hooks use `$layouted` via `LikeC4ViewModel`
- `.changeset/fix-codegen-manual-layout.md` — patch changeset for `@likec4/vite-plugin`

🤖 Generated with [Claude Code](https://claude.ai/code)