### PR TITLE
fix(core): display images in markdown descriptions

### DIFF
--- a/.changeset/fix-markdown-images.md
+++ b/.changeset/fix-markdown-images.md
@@ -1,0 +1,5 @@
+---
+'@likec4/core': patch
+---
+
+Fix images not displaying in markdown descriptions by preserving default sanitizer tag list

--- a/packages/core/src/utils/markdown/to-html.ts
+++ b/packages/core/src/utils/markdown/to-html.ts
@@ -1,4 +1,3 @@
-import defu from 'defu'
 import rehypeSanitize, { defaultSchema } from 'rehype-sanitize'
 import rehypeStringify from 'rehype-stringify'
 import remarkGfm from 'remark-gfm'
@@ -15,30 +14,31 @@ function parser() {
     .use(remarkRehype, { allowDangerousHtml: true })
     .use(
       rehypeSanitize,
-      defu(
-        {
-          attributes: {
-            '*': [
-              'className',
-            ],
-            'svg': [
-              'width',
-              'height',
-              'viewBox',
-              'fill',
-              'ariaHidden',
-            ],
-            'path': ['d', 'fill', 'stroke', 'strokeWidth', 'strokeLinecap', 'strokeLinejoin'],
-          },
-          tagNames: [
-            'svg',
-            'g',
-            'path',
-            'div',
+      {
+        ...defaultSchema,
+        attributes: {
+          ...defaultSchema.attributes,
+          '*': [
+            ...(defaultSchema.attributes?.['*'] ?? []),
+            'className',
           ],
+          'svg': [
+            'width',
+            'height',
+            'viewBox',
+            'fill',
+            'ariaHidden',
+          ],
+          'path': ['d', 'fill', 'stroke', 'strokeWidth', 'strokeLinecap', 'strokeLinejoin'],
         },
-        defaultSchema,
-      ),
+        tagNames: [
+          ...(defaultSchema.tagNames ?? []),
+          'svg',
+          'g',
+          'path',
+          'div',
+        ],
+      },
     )
     .use(rehypeStringify, {
       allowDangerousHtml: true,


### PR DESCRIPTION
## Summary

Fix for #2505 — images in markdown descriptions (`![alt](url)`) were not rendering.

### Root Cause

The `rehype-sanitize` configuration in `to-html.ts` used `defu()` to merge custom SVG-related tags with the default sanitizer schema. However, `defu` replaces arrays instead of merging them — the custom `tagNames: ['svg', 'g', 'path', 'div']` completely overwrote `defaultSchema.tagNames` (41 tags including `img`, `a`, `p`, etc.), causing all standard HTML tags to be stripped.

### Fix

Replaced `defu()` with spread-based merging that appends custom tags/attributes to the default lists instead of replacing them.

### Files changed

- `packages/core/src/utils/markdown/to-html.ts` — spread-based schema merge
- `.changeset/fix-markdown-images.md` — patch changeset for `@likec4/core`

Closes #2505

🤖 Generated with [Claude Code](https://claude.ai/code)