### PR TITLE
fix(core): skip re-application of manual layout instead of crashing

### DIFF
--- a/.changeset/fix-manual-layout-crash.md
+++ b/.changeset/fix-manual-layout-crash.md
@@ -1,0 +1,5 @@
+---
+'@likec4/core': patch
+---
+
+Fix crash on views with manual layout in dev mode (applyManualLayout invariant)

--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -17,6 +17,7 @@ tests/*.spec.ts
 !tests/overview-page.spec.ts
 !tests/search-params.spec.ts
 !tests/static-navigation.spec.ts
+!tests/manual-layout-views.spec.ts
 
 pnpm-lock.yaml
 package-lock.json

--- a/e2e/tests/manual-layout-views.spec.ts
+++ b/e2e/tests/manual-layout-views.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from '@playwright/test'
+import { canvas } from '../helpers/selectors'
+import { TIMEOUT_CANVAS } from '../helpers/timeouts'
+
+/**
+ * E2E test: views with manual layout snapshots (.likec4.snap) render without crashing
+ * on the interactive view route (#2882).
+ *
+ * The export route (/export/) uses a different rendering path and was not affected.
+ * This test covers the interactive route (/view/) which calls LikeC4ViewModel.$layouted.
+ */
+test('view with manual layout renders on interactive route (#2882)', async ({ page }) => {
+  test.setTimeout(30_000)
+  // Navigate to the interactive view route (not export)
+  await page.goto('/project/e2e/view/view-with-custom-colors/')
+
+  // Should render the diagram, not a red error screen
+  await expect(canvas(page)).toBeVisible({ timeout: TIMEOUT_CANVAS })
+
+  // Verify no error boundary fired
+  const errorText = page.locator('text=Something went wrong')
+  await expect(errorText).not.toBeVisible()
+})

--- a/packages/core/src/model/view/LikeC4ViewModel.ts
+++ b/packages/core/src/model/view/LikeC4ViewModel.ts
@@ -274,6 +274,11 @@ export class LikeC4ViewModel<A extends Any = Any, V extends $View<A> = $View<A>>
     }
     const snapshot = this.#manualLayoutSnapshot
     if (snapshot) {
+      // If the view already has manual layout applied (can happen when the
+      // Vite client receives pre-processed data), return it as-is (#2882).
+      if (this.#view._layout === 'manual') {
+        return this.#view
+      }
       return memoizeProp(this, 'snapshotWithManualLayout', () => {
         return applyManualLayout(this.#view, snapshot)
       })


### PR DESCRIPTION
## Summary

Fix for #2882 — views with manual layout snapshots crash on the interactive view route in dev mode.

### Root Cause

The Vite dev server client receives view data where `_layout` is already `'manual'`, but `LikeC4ViewModel.$manual` unconditionally calls `applyManualLayout()` which throws an invariant on `_layout === 'manual'`.

Server-side: `layoutedModel()` returns `_layout: 'auto'` — correct. The Vite client pipeline modifies the value before rendering.

### Fix

Guard in `LikeC4ViewModel.$manual` (`packages/core/src/model/view/LikeC4ViewModel.ts`): if `this.#view._layout === 'manual'`, return `this.#view` directly — it already has current data + manual positions. The `applyManualLayout` invariant is preserved as a contract guard.

### Before / After

- **Before:** Navigating to `/project/e2e/view/view-with-custom-colors/` shows red "Something went wrong" error screen with `applyManualLayout: expected auto-layouted view`
- **After:** The view renders correctly with custom colors, nested containers, and edges

### Test

Added `e2e/tests/manual-layout-views.spec.ts` — navigates to the **interactive** view route (`/view/`, not `/export/`) for `view-with-custom-colors` and verifies the diagram renders without the error boundary firing.

### Files changed

- `packages/core/src/model/view/LikeC4ViewModel.ts` — guard in `$manual` getter
- `e2e/tests/manual-layout-views.spec.ts` — e2e regression test for interactive route
- `e2e/.gitignore` — whitelist new test
- `.changeset/fix-manual-layout-crash.md` — patch changeset

Closes #2882

🤖 Generated with [Claude Code](https://claude.ai/code)