### PR TITLE
fix(styles): improve edge visibility in dark mode

### DIFF
--- a/.changeset/fix-dark-mode-edge-contrast.md
+++ b/.changeset/fix-dark-mode-edge-contrast.md
@@ -1,0 +1,5 @@
+---
+'@likec4/styles': patch
+---
+
+Improve edge visibility in dark mode by increasing background stroke opacity

--- a/styled-system/preset/src/recipes/edgePath.ts
+++ b/styled-system/preset/src/recipes/edgePath.ts
@@ -44,7 +44,10 @@ export const edgePath = defineSlotRecipe({
       pointerEvents: 'none',
       fill: 'none',
       strokeWidth: 'calc(var(--xy-edge-stroke-width) + 2)',
-      strokeOpacity: 0.08,
+      strokeOpacity: {
+        base: 0.08,
+        _dark: 0.25,
+      },
       _noReduceGraphics: {
         transitionProperty: 'stroke-width, stroke-opacity',
         transitionDuration: 'fast',
@@ -53,13 +56,22 @@ export const edgePath = defineSlotRecipe({
       _whenHovered: {
         transitionTimingFunction: 'out',
         strokeWidth: 'calc(var(--xy-edge-stroke-width) + 4)',
-        strokeOpacity: 0.2,
+        strokeOpacity: {
+          base: 0.2,
+          _dark: 0.45,
+        },
       },
       _whenSelected: {
         strokeWidth: 'calc(var(--xy-edge-stroke-width) + 6)',
-        strokeOpacity: 0.25,
+        strokeOpacity: {
+          base: 0.25,
+          _dark: 0.5,
+        },
         _whenHovered: {
-          strokeOpacity: 0.4,
+          strokeOpacity: {
+            base: 0.4,
+            _dark: 0.65,
+          },
         },
       },
     },


### PR DESCRIPTION
## Summary

- Increase edge background (`pathBg`) stroke opacity in dark mode for better contrast against the dark canvas
- Light mode values are completely unchanged — no visual regression
- The `pathBg` is a wider, semi-transparent stroke behind each edge that creates a subtle glow/halo effect. In dark mode, the same low opacity values used in light mode result in nearly invisible halos due to lower contrast ratios against dark backgrounds

## Before / After (zoomed, dark mode)

| Before (flat 0.08) | After (dark: 0.25) |
|---|---|
| ![before](https://github.com/user-attachments/assets/9e03a9b8-7e9c-4204-bdfa-4fcf9617c586) | ![after](https://github.com/user-attachments/assets/8670b968-9c3d-44ad-abbc-2df2b4a7c01b) |

> **Note:** The default edge color in the example is gray (rgb(141,141,141)) which has inherently low contrast on dark backgrounds. The improvement is most visible on colored edges and during hover/selection interactions where the opacity jump is larger (0.2→0.45 on hover, 0.25→0.5 on selection).

## Changes

`styled-system/preset/src/recipes/edgePath.ts` — `pathBg` slot:

| State | Light (unchanged) | Dark (new) | Multiplier |
|---|---|---|---|
| Default | 0.08 | **0.25** | ~3x |
| Hovered | 0.2 | **0.45** | ~2.25x |
| Selected | 0.25 | **0.5** | 2x |
| Selected+Hovered | 0.4 | **0.65** | ~1.6x |

## Test plan

- [x] Verified CSS output contains correct `[data-mantine-color-scheme=dark]` rules
- [x] Verified `computedStyle.strokeOpacity` returns `0.25` in dark mode
- [x] Visual check: light mode unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)