### PR TITLE
fix(diagram): handle text overflow in popover and element details

### DIFF
--- a/.changeset/fix-overflow-long-names.md
+++ b/.changeset/fix-overflow-long-names.md
@@ -1,0 +1,5 @@
+---
+'@likec4/diagram': patch
+---
+
+Fix text overflow in relationship popover and element details card when displaying long element names, relationship titles, and technology strings

--- a/examples/overflow-test/likec4.config.json
+++ b/examples/overflow-test/likec4.config.json
@@ -1,0 +1,3 @@
+{
+  "name": "overflow-test"
+}

--- a/examples/overflow-test/model.c4
+++ b/examples/overflow-test/model.c4
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Synthetic model to reproduce long-name overflow issues
+
+specification {
+  element system {
+    style {
+      opacity 10%
+    }
+  }
+  element service {
+    style {
+      opacity 50%
+    }
+  }
+  element component
+
+  tag sensor
+  tag perception
+  tag dataProcessing
+  tag plugin
+  tag graphlet
+}
+
+model {
+  system vehiclePlatform 'Vehicle Platform' {
+    description 'Central vehicle computing platform for autonomous driving'
+
+    service sensorProcessing 'SensorProcessingPipeline' {
+      description 'Handles raw sensor data acquisition, preprocessing and calibration'
+
+      component cameraFrameAcquisition 'CameraFrameAcquisitionController' {
+        #sensor #plugin #graphlet
+        description 'Acquires raw camera frames from ISP hardware via DMA ring buffer'
+      }
+
+      component rawFrameDecoder 'RawBayerFrameDecoderModule' {
+        #sensor #dataProcessing
+        description 'Decodes raw Bayer pattern frames into RGB'
+      }
+
+      component frameTimestampSync 'FrameTimestampSynchronizationModule' {
+        #sensor
+        description 'Synchronizes frame timestamps across multiple camera sensors'
+      }
+
+      component outputSelector 'outputSelectorIsp0.CameraOutputSelectorNode :CameraOutputSelectorDispatcherGraphlet :FisheyeRectificationPipelineStageController' {
+        #sensor #dataProcessing #plugin #graphlet
+        description 'Routes processed frames to downstream perception consumers based on ISP pipeline configuration'
+      }
+    }
+
+    service perceptionStack 'PerceptionProcessingStack' {
+      description 'Multi-modal perception fusion for object detection'
+
+      component objectDetector 'LidarCameraFusionObjectDetector' {
+        #perception
+        description 'Fuses lidar point clouds with camera images for 3D object detection'
+      }
+
+      component sceneClassifier 'DrivableSpaceGridClassifier' {
+        #perception
+        description 'Classifies road surface into drivable and non-drivable grid cells'
+      }
+
+      component trackingModule 'MultiObjectTrackingStateEstimator' {
+        #perception
+        description 'Maintains temporal object tracks using extended Kalman filtering'
+      }
+    }
+  }
+
+  cameraFrameAcquisition -> rawFrameDecoder 'RAW_FRAME -> TIMESTAMPED_FRAME :dwCameraFrameHandle_t' {
+    technology 'CGF Channel DMA Transfer'
+  }
+
+  rawFrameDecoder -> outputSelector 'CAMERA_FRAME -> CAMERA_FRAME :dwCameraFrameHandle_t' {
+    technology 'CGF Channel Zero-Copy Transfer'
+  }
+
+  frameTimestampSync -> outputSelector 'SYNCED_FRAME -> PROCESSED_FRAME :dwImageHandle_t' {
+    technology 'CGF Channel Synchronized Pipeline'
+  }
+
+  outputSelector -> objectDetector 'IMAGE_NATIVE_PROCESSED_CUDA_YUV420->EXTERNAL:PERCEPTION_CAMERA_SENSOR0_FISHEYE0_CUDA_PROCESSED_RECTIFIED:dwImageHandle_t' {
+    technology 'CGF Channel Multi-Consumer Broadcast Pipeline with Zero-Copy DMA Transfer and Temporal Synchronization'
+  }
+
+  outputSelector -> objectDetector 'CALIBRATION_INTRINSICS_EEPROM_FISHEYE0->CALIBRATION_OVERLAY_INTRINSICS_UNDISTORTED:dwCameraIntrinsicsHandle_t' {
+    technology 'Shared Memory IPC Zero-Copy Feedback Channel with Hardware-Accelerated Buffer Management'
+  }
+
+  outputSelector -> objectDetector 'TIMESTAMP_METADATA_PTP_SYNCED_CORRECTED->DETECTION_TIMESTAMP_SYNC_ALIGNED_EXTRAPOLATED:dwSensorTimestamp_t' {
+    technology 'CGF Channel Synchronized Metadata Pipeline with Temporal Alignment and Jitter Compensation'
+  }
+
+  objectDetector -> sceneClassifier 'FUSED_DETECTIONS->DRIVABLE_SPACE_OBSTACLE_OVERLAY:dwObjectArray_t' {
+    technology 'dwframework::dwBaseDrainerTemplate<dwObjectArray_t>::CGFNodeChannelPacketFingerprint_v2::FUSED_DETECTIONS_CUDA'
+  }
+
+  outputSelector -> sceneClassifier 'IMAGE_NATIVE_PROCESSED -> DRIVABLE_SPACE_INPUT :dwImageHandle_t' {
+    technology 'CGF Channel Filtered Pipeline'
+  }
+
+  outputSelector -> trackingModule 'IMAGE_NATIVE_PROCESSED -> TRACKING_IMAGE_INPUT :dwImageHandle_t' {
+    technology 'CGF Channel Temporal Buffer'
+  }
+
+  objectDetector -> trackingModule 'DETECTED_OBJECTS -> TRACKING_OBSERVATIONS :dwObjectArray_t' {
+    technology 'CGF Channel Low-Latency Pipeline'
+  }
+}
+
+views {
+  view index {
+    include *
+  }
+
+  view sensorPipeline of sensorProcessing {
+    description 'Sensor processing pipeline'
+    include
+      *,
+      outputSelector -> perceptionStack.*
+  }
+
+  view perceptionView of perceptionStack {
+    description 'Perception stack with incoming sensor data'
+    include
+      *,
+      sensorProcessing.* -> perceptionStack.*
+  }
+}

--- a/packages/diagram/src/base-primitives/edge/EdgeLabelContainer.tsx
+++ b/packages/diagram/src/base-primitives/edge/EdgeLabelContainer.tsx
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
 import type { DiagramEdge } from '@likec4/core/types'
 import { cx } from '@likec4/styles/css'
 import { EdgeLabelRenderer } from '@xyflow/react'
@@ -47,7 +52,7 @@ export function EdgeLabelContainer({
   },
   labelPosition: labelXY,
   className,
-  style: _, // omit styles for container
+  style: contentStyle, // applied to inner content div, not the positioned container
   children,
   ...rest
 }: EdgeLabelContainerProps) {
@@ -89,11 +94,10 @@ export function EdgeLabelContainer({
         }}
       >
         <div
-          style={labelBBox ?
-            {
-              maxWidth: labelBBox.width + 20,
-            } :
-            undefined}>
+          style={{
+            ...contentStyle,
+            ...(labelBBox && { maxWidth: labelBBox.width + 20 }),
+          }}>
           {children}
         </div>
       </div>

--- a/packages/diagram/src/likec4diagram/relationship-popover/RelationshipPopover.tsx
+++ b/packages/diagram/src/likec4diagram/relationship-popover/RelationshipPopover.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 //
 // Copyright (c) 2023-2026 Denis Davydkov
-// Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
 
@@ -583,13 +583,18 @@ const Relationship = forwardRef<
       {r.kind && (
         <HStack gap="2">
           <Label>kind</Label>
-          <Text size="xs" className={css({ userSelect: 'all' })}>{r.kind}</Text>
+          <Text size="xs" className={css({ userSelect: 'all', wordBreak: 'break-word', minWidth: 0 })}>{r.kind}</Text>
         </HStack>
       )}
       {r.technology && (
         <HStack gap="2">
           <Label>technology</Label>
-          <Text size="xs" className={css({ userSelect: 'all' })}>{r.technology}</Text>
+          <Text
+            size="xs"
+            className={css({ userSelect: 'all', wordBreak: 'break-word', minWidth: 0 })}
+          >
+            {r.technology}
+          </Text>
         </HStack>
       )}
       {r.summary.nonEmpty && (

--- a/packages/diagram/src/likec4diagram/relationship-popover/components.tsx
+++ b/packages/diagram/src/likec4diagram/relationship-popover/components.tsx
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
 import type { Color } from '@likec4/core/types'
 import { styled } from '@likec4/styles/jsx'
 import { txt } from '@likec4/styles/patterns'
@@ -11,6 +16,9 @@ export const Endpoint = ({ children, likec4color }: PropsWithChildren<{ likec4co
         size: 'xxs',
         fontWeight: 'medium',
         whiteSpace: 'nowrap',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        maxWidth: '160px',
         paddingX: '1',
         paddingY: '0.5',
         rounded: 'xs',
@@ -34,5 +42,8 @@ export const RelationshipTitle = styled('div', {
     fontSize: 'sm',
     lineHeight: 'sm',
     userSelect: 'all',
+    overflowWrap: 'anywhere',
+    wordBreak: 'break-word',
+    minWidth: 0,
   },
 })

--- a/packages/diagram/src/overlays/element-details/ElementDetailsCard.css.ts
+++ b/packages/diagram/src/overlays/element-details/ElementDetailsCard.css.ts
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
 import { css } from '@likec4/styles/css'
 
 export const backdropBlur = '--_blur'
@@ -61,9 +66,11 @@ export const title = css({
   fontStyle: 'normal',
   fontWeight: 'bold',
   fontSize: '24px',
-  // lineHeight: 1.15,
   lineHeight: 'xs',
-  // color: vars.element.hiContrast
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  wordBreak: 'break-word',
+  lineClamp: 2,
 })
 
 const iconSize = '40px'

--- a/packages/diagram/src/overlays/element-details/ElementDetailsCard.tsx
+++ b/packages/diagram/src/overlays/element-details/ElementDetailsCard.tsx
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
 // oxlint-disable no-misused-spread
 // oxlint-disable no-misused-spread
 import type {
@@ -293,14 +298,21 @@ export function ElementDetailsCard({
           }}>
           <div className={styles.cardHeader} onPointerDown={e => controls.start(e)}>
             <HStack alignItems="start" justify="space-between" gap={'sm'} mb={'sm'} flexWrap="nowrap">
-              <HStack alignItems="start" gap={'sm'} style={{ cursor: 'default' }} flexWrap="nowrap">
+              <HStack
+                alignItems="start"
+                gap={'sm'}
+                style={{ cursor: 'default', minWidth: 0, overflow: 'hidden' }}
+                flexWrap="nowrap"
+              >
                 {elementIcon}
-                <div>
-                  <Text
-                    component={'div'}
-                    className={styles.title}>
-                    {elementModel.title}
-                  </Text>
+                <div style={{ minWidth: 0, overflow: 'hidden' }}>
+                  <Tooltip label={elementModel.title} openDelay={600} position="bottom-start">
+                    <Text
+                      component={'div'}
+                      className={styles.title}>
+                      {elementModel.title}
+                    </Text>
+                  </Tooltip>
                   {notation && (
                     <Text component="div" c={'dimmed'} fz={'sm'} fw={500} lh={1.3} lineClamp={1}>
                       {notation}
@@ -329,7 +341,7 @@ export function ElementDetailsCard({
                   {elementModel.kind}
                 </Badge>
               </div>
-              <div style={{ flex: 1 }}>
+              <div style={{ flex: 1, minWidth: 0, overflow: 'hidden' }}>
                 <SmallLabel>tags</SmallLabel>
                 <ElementTags
                   tags={elementModel.tags}

--- a/packages/diagram/src/overlays/relationship-details/layout.ts
+++ b/packages/diagram/src/overlays/relationship-details/layout.ts
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
 import {
   treeFromElements,
 } from '@likec4/core/compute-view'
@@ -51,7 +56,7 @@ const Sizes = {
   } satisfies GraphLabel,
   edgeLabel: {
     width: 220,
-    height: 14,
+    height: 55,
     // minlen: 1,
   } satisfies EdgeConfig,
 
@@ -69,37 +74,6 @@ const Sizes = {
   },
 }
 
-// /**
-//  * All constants related to the layout
-//  */
-// const Sizes = {
-//   dagre: {
-//     ranksep: 60,
-//     nodesep: 35,
-//     edgesep: 25,
-//   } satisfies GraphLabel,
-//   edgeLabel: {
-//     width: 120,
-//     height: 10,
-//     minlen: 1,
-//     weight: 1,
-//   } satisfies EdgeConfig,
-
-//   emptyNodeOffset: 120,
-
-//   nodeWidth: 330,
-//   nodeHeight: 180,
-
-//   // Spacer between elements in a compound node
-//   // 0 means no spacer
-//   spacerHeight: 0,
-
-//   compound: {
-//     labelHeight: 2,
-//     paddingTop: 50,
-//     paddingBottom: 32,
-//   },
-// }
 type NodeData = {
   column: RelationshipDetailsTypes.Column
   portId: string

--- a/packages/likec4/src/LikeC4.spec.ts
+++ b/packages/likec4/src/LikeC4.spec.ts
@@ -326,6 +326,12 @@ describe('LikeC4', () => {
           ],
           "folder": "multi-relation-extend",
         },
+        "overflow-test": {
+          "documents": [
+            "model.c4",
+          ],
+          "folder": "overflow-test",
+        },
         "projectA": {
           "documents": [
             "_spec.c4",

--- a/styled-system/preset/src/globalCss.ts
+++ b/styled-system/preset/src/globalCss.ts
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
 import type { Config } from '@pandacss/dev'
 import { keys, mapToObj } from 'remeda'
 import { __v, vars } from './const.ts'
@@ -59,6 +64,20 @@ export const globalCss: ExtendableGlobalCss = {
       },
       willChange: 'transform',
       zIndex: 'likec4.diagram.edge.label',
+    },
+    // Constrain edge label width in the relationship-details overlay,
+    // where edges lack labelBBox data. Text and technology lines are
+    // clamped to one line each via the rules below.
+    // In the main diagram, inline maxWidth from labelBBox (or the
+    // caller's style prop) overrides this CSS rule on the inner div.
+    ':where(.likec4-relationship-details) .likec4-edge-label-container > :first-child': {
+      maxWidth: '350px',
+    },
+    '.likec4-relationship-details :is(.likec4-edge-label__text, .likec4-edge-label__technology)': {
+      display: '-webkit-box!',
+      WebkitBoxOrient: 'vertical!',
+      WebkitLineClamp: '1!',
+      overflow: 'hidden!',
     },
 
     '.likec4-root': {

--- a/styled-system/preset/src/recipes/edgeLabel.ts
+++ b/styled-system/preset/src/recipes/edgeLabel.ts
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
 import { defineParts, defineRecipe } from '@pandacss/dev'
 
 const parts = defineParts({
@@ -57,6 +62,7 @@ export const edgeLabel = defineRecipe({
     },
     label: {
       whiteSpaceCollapse: 'preserve-breaks',
+      overflowWrap: 'anywhere',
       fontSize: '14px',
       lineHeight: '1.2',
       margin: '0',
@@ -64,6 +70,7 @@ export const edgeLabel = defineRecipe({
     technology: {
       textAlign: 'center',
       whiteSpaceCollapse: 'preserve-breaks',
+      overflowWrap: 'anywhere',
       fontSize: '11px',
       lineHeight: '1',
       opacity: 0.75,


### PR DESCRIPTION
## Summary

Fix text overflow in relationship popover, element details card, and relationship-details overlay when displaying long element names, relationship titles, and technology strings.

Tested with a synthetic `examples/overflow-test` model using automotive-style long identifiers.

## Changes

### Relationship popover overflow
- **Endpoint badges**: truncated with ellipsis at 160px (tooltip shows full FQN)
- **RelationshipTitle**: `word-break: break-word` + `overflow-wrap: anywhere`
- **Kind/technology labels**: `word-break: break-word` + `minWidth: 0`

### Element details card title overflow
- **Title**: `line-clamp: 2` with `word-break: break-word`, full text via tooltip
- **Flex container**: `minWidth: 0` + `overflow: hidden` on icon+title wrapper
- **Tags container**: `minWidth: 0` + `overflow: hidden`

### Relationship-details overlay edge label overflow
- **EdgeLabelContainer**: Stop dropping the `style` prop — merge `contentStyle` with `labelBBox` (labelBBox wins precedence)
- **globalCss**: CSS fallback `max-width: 350px` + `line-clamp: 1` for `.likec4-relationship-details`
- **edgeLabel recipe**: `overflowWrap: 'anywhere'` on label and technology text
- **layout.ts**: Dagre `edgeLabel.height` 14 → 55 for proper vertical spacing

## Test plan

- [ ] `likec4 start examples/overflow-test` → navigate to `sensorPipeline` view
- [ ] Click `[...]` edge label → verify relationship titles wrap in popover
- [ ] Click "browse relationships" → verify edge labels constrained, truncated, no overlap
- [ ] Click element details on `outputSelector` node → verify title clamped to 2 lines
- [ ] Hover clamped title → verify tooltip shows full name
- [ ] Verify main diagram edge labels unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
