### PR TITLE
fix(vscode,lsp): programmatic config stopped working

### DIFF
--- a/.changeset/fix-vscode-programmatic-config.md
+++ b/.changeset/fix-vscode-programmatic-config.md
@@ -1,0 +1,6 @@
+---
+'likec4-vscode': patch
+'@likec4/lsp': patch
+---
+
+Fix programmatic config (`likec4.config.ts`) not being loaded in VSCode extension and standalone LSP

--- a/packages/lsp/package.json
+++ b/packages/lsp/package.json
@@ -50,6 +50,11 @@
     "postpack": "likec4ops postpack",
     "clean": "likec4ops clean"
   },
+  "dependencies": {
+    "bundle-require": "catalog:externals",
+    "esbuild": "catalog:esbuild",
+    "fdir": "catalog:externals"
+  },
   "devDependencies": {
     "@likec4/devops": "workspace:*",
     "@likec4/language-server": "workspace:*",
@@ -58,7 +63,6 @@
     "@likec4/tsconfig": "workspace:*",
     "@types/node": "catalog:",
     "langium": "catalog:langium",
-    "esbuild-wasm": "catalog:esbuild",
     "tsdown": "catalog:",
     "turbo": "catalog:",
     "typescript": "catalog:",

--- a/packages/lsp/tsdown.config.mts
+++ b/packages/lsp/tsdown.config.mts
@@ -8,9 +8,6 @@ export default defineConfig({
   minify: true,
   nodeProtocol: true,
   inlineOnly: false,
-  alias: {
-    'esbuild': import.meta.resolve('esbuild-wasm')
-  },
   outputOptions: {
     keepNames: true,
   },

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -293,12 +293,13 @@
     }
   },
   "dependencies": {
+    "bundle-require": "catalog:externals",
+    "esbuild": "catalog:esbuild",
     "fdir": "catalog:externals",
     "std-env": "catalog:externals"
   },
   "devDependencies": {
     "@hpcc-js/wasm-graphviz": "catalog:externals",
-    "esbuild-wasm": "catalog:esbuild",
     "@likec4/config": "workspace:*",
     "@likec4/core": "workspace:*",
     "@likec4/language-server": "workspace:*",

--- a/packages/vscode/tsdown.config.ts
+++ b/packages/vscode/tsdown.config.ts
@@ -13,9 +13,6 @@ const shared = {
   define: {
     'process.env.NODE_ENV': isProduction ? '"production"' : '"development"',
   },
-  alias: {
-    'esbuild': import.meta.resolve('esbuild-wasm'),
-  },
   minify: isProduction,
   outputOptions: {
     keepNames: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,9 +133,6 @@ catalogs:
     esbuild-plugins-node-modules-polyfill:
       specifier: 1.8.1
       version: 1.8.1
-    esbuild-wasm:
-      specifier: 0.27.4
-      version: 0.27.4
   externals:
     '@hpcc-js/wasm-graphviz':
       specifier: 1.21.2
@@ -2080,6 +2077,16 @@ importers:
         version: 3.0.1
 
   packages/lsp:
+    dependencies:
+      bundle-require:
+        specifier: catalog:externals
+        version: 5.1.0(esbuild@0.27.4)
+      esbuild:
+        specifier: 0.27.4
+        version: 0.27.4
+      fdir:
+        specifier: catalog:externals
+        version: 6.4.0(picomatch@4.0.4)
     devDependencies:
       '@likec4/devops':
         specifier: workspace:*
@@ -2099,9 +2106,6 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 22.19.15
-      esbuild-wasm:
-        specifier: catalog:esbuild
-        version: 0.27.4
       langium:
         specifier: catalog:langium
         version: 3.5.0
@@ -2401,6 +2405,12 @@ importers:
 
   packages/vscode:
     dependencies:
+      bundle-require:
+        specifier: catalog:externals
+        version: 5.1.0(esbuild@0.27.4)
+      esbuild:
+        specifier: 0.27.4
+        version: 0.27.4
       fdir:
         specifier: catalog:externals
         version: 6.4.0(picomatch@4.0.4)
@@ -2456,9 +2466,6 @@ importers:
       esbuild-plugins-node-modules-polyfill:
         specifier: catalog:esbuild
         version: 1.8.1(esbuild@0.27.4)
-      esbuild-wasm:
-        specifier: catalog:esbuild
-        version: 0.27.4
       esm-env:
         specifier: catalog:utils
         version: 1.2.2
@@ -6445,11 +6452,6 @@ packages:
     engines: {node: '>=14.0.0'}
     peerDependencies:
       esbuild: 0.27.4
-
-  esbuild-wasm@0.27.4:
-    resolution: {integrity: sha512-3xhVMcJ8Odvb1QjlWnjBGSYVYESsi3/oJYwLyVvbHOb2CiV4mFtD6x8Lk6JFnRxwEE3fUeVuJLbIxyVQWa867g==}
-    engines: {node: '>=18'}
-    hasBin: true
 
   esbuild@0.27.4:
     resolution: {integrity: sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==}
@@ -14396,8 +14398,6 @@ snapshots:
       esbuild: 0.27.4
       local-pkg: 1.1.2
       resolve.exports: 2.0.3
-
-  esbuild-wasm@0.27.4: {}
 
   esbuild@0.27.4:
     optionalDependencies:


### PR DESCRIPTION
## Summary

- Replace `esbuild-wasm` alias with real `esbuild` and `bundle-require` as runtime dependencies in both `likec4-vscode` and `@likec4/lsp` packages
- The `esbuild-wasm` alias prevented `bundle-require` from loading programmatic config files (`likec4.config.ts`)

## Test plan

- [ ] Verify VSCode extension loads `likec4.config.ts` programmatic config
- [ ] Verify standalone LSP loads `likec4.config.ts` programmatic config
- [ ] Verify extension builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)