### PR TITLE
patch: allow using reserved keyword `relationship`

### DIFF
--- a/.changeset/allow-relationship-id.md
+++ b/.changeset/allow-relationship-id.md
@@ -1,0 +1,5 @@
+---
+'@likec4/language-server': patch
+---
+
+Allow using reserved keyword `relationship` as an identifier in LikeC4 DSL (i.e. as element kind)

--- a/packages/language-server/src/__tests__/model.spec.ts
+++ b/packages/language-server/src/__tests__/model.spec.ts
@@ -59,22 +59,21 @@ describe('model', () => {
       user2 = person
     }`
 
-  test('allow element with kind "element"').valid`
-    specification {
-      element element
-    }
-    model {
-      element el1
-      element el2
-    }`
-
   for (
     const constv of [
       ...ElementShapes,
       ...IconPositions,
+      // Reserved keywords
+      'element',
+      'model',
+      'group',
+      'node',
+      'deployment',
+      'instance',
+      'relationship',
     ]
   ) {
-    test(`allow element with name of constant "${constv}"`).valid`
+    test(`allow element kind "${constv}"`).valid`
       specification {
         element ${constv}
       }
@@ -84,13 +83,16 @@ describe('model', () => {
       }`
   }
 
-  test('allow element with kind "model"').valid`
+  test('allow element "relationship" and relationship kind "element"').valid`
     specification {
-      element model
+      element relationship
+      relationship element
     }
     model {
-      model el1
-      el2 = model
+      relationship el1
+      relationship el2 {
+        .element el1
+      }
     }`
 
   test('allow elements with names "aws"/"azure"/"tech"/"bootstrap"/"gcp"').valid`

--- a/packages/language-server/src/like-c4.langium
+++ b/packages/language-server/src/like-c4.langium
@@ -1007,7 +1007,8 @@ Id returns string:
   DynamicViewDisplayVariantValue |
   IconPositionValue |
   RankValue |
-  'element' | 'model' | 'group' | 'node' | 'deployment' | 'instance';
+  // Allow reserved keywords as Id
+  'element' | 'model' | 'group' | 'node' | 'deployment' | 'instance' | 'relationship';
 
 fragment EqOperator:
   (


### PR DESCRIPTION
Allow using reserved keyword `relationship` as an identifier in LikeC4 DSL (i.e. as element kind)