### PR TITLE
perf(generators): add /drawio subpath export to isolate pako from main bundle

### DIFF
--- a/.changeset/isolate-drawio-bundle.md
+++ b/.changeset/isolate-drawio-bundle.md
@@ -1,0 +1,6 @@
+---
+'@likec4/generators': patch
+'likec4': patch
+---
+
+Isolate Draw.io export dependencies into a lazy-loaded bundle chunk, reducing initial JS load by ~134 KB. The drawio code now only loads when the user clicks "Export to Draw.io". Fixes [#2689](https://github.com/likec4/likec4/issues/2689)

--- a/packages/generators/build.config.ts
+++ b/packages/generators/build.config.ts
@@ -5,6 +5,7 @@ export default defineBuildConfig({
     type: 'bundle',
     input: [
       './src/index.ts',
+      './src/drawio/index.ts',
       './src/likec4/index.ts',
     ],
     rolldown: {

--- a/packages/generators/package.json
+++ b/packages/generators/package.json
@@ -31,6 +31,14 @@
         "default": "./dist/index.mjs"
       }
     },
+    "./drawio": {
+      "sources": "./src/drawio/index.ts",
+      "default": {
+        "types": "./dist/drawio/index.d.mts",
+        "import": "./dist/drawio/index.mjs",
+        "default": "./dist/drawio/index.mjs"
+      }
+    },
     "./likec4": {
       "sources": "./src/likec4/index.ts",
       "default": {

--- a/packages/generators/src/drawio/index.ts
+++ b/packages/generators/src/drawio/index.ts
@@ -1,3 +1,4 @@
+export { DEFAULT_DRAWIO_ALL_FILENAME } from './constants'
 export {
   buildDrawioExportOptionsForViews,
   buildDrawioExportOptionsFromSource,
@@ -8,6 +9,9 @@ export {
   generateDrawioMulti,
   type GenerateDrawioOptions,
 } from './generate-drawio'
+export {
+  decompressDrawioDiagram,
+} from './parse-drawio'
 export {
   type DiagramInfo,
   type DrawioCell,

--- a/packages/likec4/package.json
+++ b/packages/likec4/package.json
@@ -139,6 +139,7 @@
     "cli:preview": "pnpm cli preview -o dev/dist dev",
     "cli:export": "pnpm cli export png -o dev/export dev",
     "cli:export:json": "pnpm cli export json -o dev/export/likec4.json dev",
+    "check:bundle-size": "tsx scripts/check-bundle-size.ts",
     "test": "vitest run --no-isolate",
     "vitest:ui": "vitest --no-isolate --ui",
     "test:watch": "vitest"

--- a/packages/likec4/scripts/bundle-app.ts
+++ b/packages/likec4/scripts/bundle-app.ts
@@ -92,6 +92,12 @@ export async function bundleApp() {
             if (id.endsWith('.css')) {
               return undefined
             }
+            // Isolate drawio deps into a lazy-loaded chunk.
+            // Must check before the broad 'likec4'/'node_modules' matches.
+            // See: https://github.com/likec4/likec4/issues/2689
+            if (id.includes('drawio') || id.includes('pako')) {
+              return 'drawio'
+            }
             if (id.includes('@tabler') || id.includes('diagram/src') || id.includes('styled-system')) {
               return 'likec4'
             }

--- a/packages/likec4/scripts/check-bundle-size.ts
+++ b/packages/likec4/scripts/check-bundle-size.ts
@@ -1,0 +1,102 @@
+/**
+ * Bundle size budget check.
+ * Builds the cloud-system example and asserts JS chunk sizes stay under budget.
+ * Run: tsx scripts/check-bundle-size.ts
+ *
+ * Prevents regressions like https://github.com/likec4/likec4/issues/2689
+ * where a single JS file grew from 709 KB to 6.2 MB.
+ */
+import { execSync } from 'node:child_process'
+import { mkdtemp, readdir, rm, stat } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+
+const BUDGETS: Record<string, number> = {
+  // Per-chunk budgets in KB (uncompressed)
+  'likec4': 1400,
+  'vendors': 1300,
+  'drawio': 150,
+  // Total JS budget
+  '_total': 3200,
+}
+
+async function main() {
+  const outDir = await mkdtemp(join(tmpdir(), 'likec4-bundle-check-'))
+  const exampleDir = resolve(import.meta.dirname, '../../../examples/cloud-system')
+
+  console.log(`Building ${exampleDir} → ${outDir}`)
+
+  try {
+    execSync(
+      `node ${resolve(import.meta.dirname, '../bin/likec4.mjs')} build ${exampleDir} --output ${outDir}`,
+      { stdio: 'pipe', timeout: 120_000 },
+    )
+  } catch (e: unknown) {
+    const stderr = e != null && typeof e === 'object' && 'stderr' in e
+      ? (e as { stderr?: Buffer }).stderr
+      : undefined
+    console.error('Build failed:', stderr?.toString().slice(-500) ?? (e instanceof Error ? e.message : String(e)))
+    process.exit(1)
+  }
+
+  const assetsDir = join(outDir, 'assets')
+  try {
+    await stat(assetsDir)
+  } catch {
+    console.error(`Assets directory not found: ${assetsDir}`)
+    process.exit(1)
+  }
+  const files = await readdir(assetsDir)
+  const jsFiles = files.filter(f => f.endsWith('.js'))
+
+  let totalKB = 0
+  const chunks: Array<{ name: string; file: string; sizeKB: number }> = []
+
+  for (const file of jsFiles) {
+    const { size } = await stat(join(assetsDir, file))
+    const sizeKB = Math.round(size / 1024)
+    totalKB += sizeKB
+
+    // Extract chunk name from filename (e.g., "likec4-DhdE54_o.js" → "likec4")
+    const name = file.replace(/-[A-Za-z0-9_-]+\.js$/, '')
+    chunks.push({ name, file, sizeKB })
+  }
+
+  console.log('\nBundle size report:')
+  console.log('─'.repeat(50))
+  for (const { name, file, sizeKB } of chunks.sort((a, b) => b.sizeKB - a.sizeKB)) {
+    const budget = BUDGETS[name]
+    const status = budget ? (sizeKB <= budget ? '✅' : '❌') : '  '
+    const budgetStr = budget ? ` (budget: ${budget} KB)` : ''
+    console.log(`${status} ${file}: ${sizeKB} KB${budgetStr}`)
+  }
+  console.log('─'.repeat(50))
+
+  const totalBudget = BUDGETS['_total']
+  const totalStatus = totalKB <= totalBudget ? '✅' : '❌'
+  console.log(`${totalStatus} Total JS: ${totalKB} KB (budget: ${totalBudget} KB)`)
+
+  // Check budgets
+  let failed = false
+  for (const { name, file, sizeKB } of chunks) {
+    const budget = BUDGETS[name]
+    if (budget && sizeKB > budget) {
+      console.error(`\n❌ OVER BUDGET: ${file} is ${sizeKB} KB, budget is ${budget} KB`)
+      failed = true
+    }
+  }
+  if (totalKB > totalBudget) {
+    console.error(`\n❌ OVER BUDGET: Total JS is ${totalKB} KB, budget is ${totalBudget} KB`)
+    failed = true
+  }
+
+  await rm(outDir, { recursive: true, force: true })
+
+  if (failed) {
+    console.error('\nBundle size check FAILED. Update budgets in scripts/check-bundle-size.ts if intentional.')
+    process.exit(1)
+  }
+  console.log('\n✅ All chunks within budget.')
+}
+
+main()

--- a/packages/likec4/src/cli/export/drawio/handler.ts
+++ b/packages/likec4/src/cli/export/drawio/handler.ts
@@ -1,12 +1,12 @@
 import type { LikeC4ViewModel } from '@likec4/core/model'
 import type { aux, ProjectId } from '@likec4/core/types'
-import type { GenerateDrawioOptions } from '@likec4/generators'
 import {
+  type GenerateDrawioOptions,
   buildDrawioExportOptionsForViews,
   DEFAULT_DRAWIO_ALL_FILENAME,
   generateDrawio,
   generateDrawioMulti,
-} from '@likec4/generators'
+} from '@likec4/generators/drawio'
 import { fromWorkspace } from '@likec4/language-services/node'
 import { loggable } from '@likec4/log'
 import { mkdir, readdir, readFile, realpath, stat, writeFile } from 'node:fs/promises'

--- a/packages/likec4/src/drawio-demo-export-import.spec.ts
+++ b/packages/likec4/src/drawio-demo-export-import.spec.ts
@@ -14,7 +14,7 @@ import {
   generateDrawioMulti,
   getAllDiagrams,
   parseDrawioToLikeC4Multi,
-} from '@likec4/generators'
+} from '@likec4/generators/drawio'
 import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
@@ -48,41 +48,41 @@ describe('DrawIO export/import with cloud-system demo', () => {
     'exported DrawIO has same number of elements and edges per view (no extra, none missing)',
     { timeout: 20000 },
     async () => {
-    expect(likec4.hasErrors()).toBe(false)
+      expect(likec4.hasErrors()).toBe(false)
 
-    expectDrawioXmlLoadableInDrawio(drawioXml)
+      expectDrawioXmlLoadableInDrawio(drawioXml)
 
-    const diagrams = getAllDiagrams(drawioXml)
-    expect(diagrams.length).toBe(viewmodels.length)
+      const diagrams = getAllDiagrams(drawioXml)
+      expect(diagrams.length).toBe(viewmodels.length)
 
-    for (let i = 0; i < viewmodels.length; i++) {
-      const vm = viewmodels[i]!
-      const d = diagrams[i]!
-      const view = vm.$view
-      const nodeCount = view.nodes.length
-      const expectedEdges = view.edges.length
-      // Export adds one extra vertex per container (title cell); match generate-drawio logic
-      const containerCount = view.nodes.filter(
-        n =>
-          Array.isArray(n.children) &&
-          n.children.length > 0 &&
-          view.nodes.some(m => n.children!.includes(m.id)),
-      ).length
-      const expectedNodes = nodeCount + containerCount
+      for (let i = 0; i < viewmodels.length; i++) {
+        const vm = viewmodels[i]!
+        const d = diagrams[i]!
+        const view = vm.$view
+        const nodeCount = view.nodes.length
+        const expectedEdges = view.edges.length
+        // Export adds one extra vertex per container (title cell); match generate-drawio logic
+        const containerCount = view.nodes.filter(
+          n =>
+            Array.isArray(n.children) &&
+            n.children.length > 0 &&
+            view.nodes.some(m => n.children!.includes(m.id)),
+        ).length
+        const expectedNodes = nodeCount + containerCount
 
-      const { vertices, edges } = countDrawioCells(d.content)
-      // DrawIO: 1 vertex = root/defaultParent, rest = nodes + container title cells
-      const actualNodes = Math.max(0, vertices - 1)
-      expect(
-        actualNodes,
-        `View "${view.id}": expected ${expectedNodes} nodes in diagram, got ${actualNodes} vertices (vertices-1)`,
-      ).toBe(expectedNodes)
-      expect(
-        edges,
-        `View "${view.id}": expected ${expectedEdges} edges in diagram, got ${edges}`,
-      ).toBe(expectedEdges)
-    }
-  }
+        const { vertices, edges } = countDrawioCells(d.content)
+        // DrawIO: 1 vertex = root/defaultParent, rest = nodes + container title cells
+        const actualNodes = Math.max(0, vertices - 1)
+        expect(
+          actualNodes,
+          `View "${view.id}": expected ${expectedNodes} nodes in diagram, got ${actualNodes} vertices (vertices-1)`,
+        ).toBe(expectedNodes)
+        expect(
+          edges,
+          `View "${view.id}": expected ${expectedEdges} edges in diagram, got ${edges}`,
+        ).toBe(expectedEdges)
+      }
+    },
   )
 
   it('exported DrawIO contains expected element titles and no stray Array tags', () => {

--- a/packages/likec4/src/drawio-test-utils.ts
+++ b/packages/likec4/src/drawio-test-utils.ts
@@ -2,7 +2,7 @@
  * Shared test helpers for DrawIO export/import specs (DRY between drawio-tutorial and drawio-demo).
  */
 
-import { getAllDiagrams } from '@likec4/generators'
+import { getAllDiagrams } from '@likec4/generators/drawio'
 import { expect } from 'vitest'
 
 /** Regex: nested <Array><Array> inside mxGeometry (invalid in draw.io; causes "Could not add object Array"). */

--- a/packages/likec4/src/drawio-tutorial-export-import.spec.ts
+++ b/packages/likec4/src/drawio-tutorial-export-import.spec.ts
@@ -10,7 +10,7 @@ import {
   getAllDiagrams,
   parseDrawioToLikeC4,
   parseDrawioToLikeC4Multi,
-} from '@likec4/generators'
+} from '@likec4/generators/drawio'
 import { describe, expect, it } from 'vitest'
 import { expectDrawioXmlLoadableInDrawio } from './drawio-test-utils'
 import { LikeC4 } from './LikeC4'

--- a/packages/likec4/src/vite/config-app.prod.ts
+++ b/packages/likec4/src/vite/config-app.prod.ts
@@ -137,6 +137,14 @@ export const viteConfig = async ({ languageServices, likec4AssetsDir, ...cfg }: 
               ) {
                 return undefined
               }
+              // Isolate drawio virtual module into a lazy-loaded chunk.
+              // The 'likec4:drawio/*' virtual module contains Draw.io URLs
+              // generated at build time. Must check before 'likec4' catch-all
+              // since the module ID contains 'likec4'.
+              // See: https://github.com/likec4/likec4/issues/2689
+              if (id.includes('drawio')) {
+                return 'drawio'
+              }
               if (id.includes('__app__')) {
                 let match = id.match(/__app__\/src\/([\w]+)\.js/)?.[1]
                 if (match) {

--- a/packages/vite-plugin/src/virtuals/drawio.ts
+++ b/packages/vite-plugin/src/virtuals/drawio.ts
@@ -1,5 +1,5 @@
 import type { LikeC4Model } from '@likec4/core/model'
-import { generateDrawio, generateDrawioEditUrl } from '@likec4/generators'
+import { generateDrawio, generateDrawioEditUrl } from '@likec4/generators/drawio'
 import { CompositeGeneratorNode, expandToNode, joinToNode, NL, toString } from 'langium/generate'
 import k from 'tinyrainbow'
 import { type ProjectVirtualModule, generateCombinedProjects, generateMatches } from './_shared'


### PR DESCRIPTION
## Summary

Adds `@likec4/generators/drawio` subpath export to isolate Draw.io dependencies (pako, generate-drawio, parse-drawio) from the main bundle. The drawio code now loads lazily only when the user clicks "Export to Draw.io". Also adds a bundle size budget check script to prevent future regressions.

Closes #2689

## Changes

### @likec4/generators
- **package.json**: Add `./drawio` subpath export pointing to `src/drawio/index.ts`
- **build.config.ts**: Add `./src/drawio/index.ts` as a separate build entry
- **src/drawio/index.ts**: Export `DEFAULT_DRAWIO_ALL_FILENAME` and `decompressDrawioDiagram`

### @likec4/vite-plugin
- **virtuals/drawio.ts**: Import from `@likec4/generators/drawio` instead of `@likec4/generators`

### likec4 (CLI)
- **cli/export/drawio/handler.ts**: Import from `@likec4/generators/drawio`
- **scripts/bundle-app.ts**: Add `drawio` chunk to `manualChunks`
- **vite/config-app.prod.ts**: Add `drawio` chunk before `likec4` catch-all for virtual modules
- **scripts/check-bundle-size.ts**: New — builds cloud-system example and asserts chunk sizes stay under budget
- **drawio-test-utils.ts** + spec files: Import from `@likec4/generators/drawio`

### Bundle size budget (`check-bundle-size.ts`)
| Chunk | Budget | Current |
|---|---|---|
| `likec4-*.js` | 1,400 KB | 1,180 KB |
| `vendors-*.js` | 1,300 KB | 1,135 KB |
| `drawio-*.js` | 150 KB | 79 KB |
| **Total JS** | **3,200 KB** | **2,825 KB** |

Run: `pnpm --filter likec4 check:bundle-size`

## Bundle Impact

| Chunk | Before | After | Change |
|---|---|---|---|
| `likec4-*.js` (initial load) | 1,289 KB | 1,180 KB | **-109 KB** |
| `drawio-*.js` (lazy) | — | 79 KB | New lazy chunk |
| `vendors-*.js` | 1,162 KB | 1,135 KB | -27 KB |
| **Total initial** | **2,893 KB** | **2,759 KB** | **-134 KB (-5%)** |

## Test plan

- [x] `pnpm --filter @likec4/generators test` — 18 files, 250 tests passed
- [x] `pnpm --filter likec4 test` — 7 files, 33 tests passed
- [x] `pnpm --filter likec4 check:bundle-size` — all chunks within budget
- [x] Static site build produces separate `drawio-*.js` chunk
- [ ] CI passes (typecheck, build, e2e)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
