### PR TITLE
fix(vscode-preview): enable left-click on external links in diagram preview

### DIFF
--- a/.changeset/fix-left-click-links-vscode.md
+++ b/.changeset/fix-left-click-links-vscode.md
@@ -1,0 +1,5 @@
+---
+'@likec4/vscode-preview': patch
+---
+
+Fix left-click on external links in VSCode extension diagram preview. Links in element details now open in the default browser on left-click, not just right-click.

--- a/packages/vscode-preview/src/interceptExternalLinks.spec.ts
+++ b/packages/vscode-preview/src/interceptExternalLinks.spec.ts
@@ -8,7 +8,7 @@ function mockAnchor(href: string | null) {
 }
 
 function mockEvent(target: unknown) {
-  return { target, preventDefault: vi.fn() } as unknown as MouseEvent
+  return { target, preventDefault: vi.fn(), stopPropagation: vi.fn() } as unknown as MouseEvent
 }
 
 describe('handleExternalLinkClick (#2422)', () => {
@@ -37,7 +37,12 @@ describe('handleExternalLinkClick (#2422)', () => {
 
   it('walks up to parent anchor via closest()', () => {
     const nested = {
-      closest: vi.fn(() => ({ getAttribute: () => 'https://parent.example.com' })),
+      closest: vi.fn((selector: string) => {
+        if (selector === 'a[href]') {
+          return { getAttribute: () => 'https://parent.example.com' }
+        }
+        return null // not inside an interactive element
+      }),
     }
     handleExternalLinkClick(mockEvent(nested), openUrl)
     expect(openUrl).toHaveBeenCalledWith('https://parent.example.com')
@@ -82,26 +87,91 @@ describe('handleExternalLinkClick (#2422)', () => {
     handleExternalLinkClick(mockEvent(mockAnchor(null)), openUrl)
     expect(openUrl).not.toHaveBeenCalled()
   })
+
+  it.each([
+    'button',
+    '[role="button"]',
+    'input',
+    'select',
+    'textarea',
+  ])('skips interactive element inside link: %s', (tag) => {
+    const target = {
+      closest: vi.fn((selector: string) => {
+        // Match the interactiveSelector only when it contains this specific tag
+        const selectors = selector.split(',').map(s => s.trim())
+        if (selectors.some(s => s === tag || s.includes(tag))) {
+          return { tagName: tag.toUpperCase() }
+        }
+        if (selector === 'a[href]') {
+          return { getAttribute: () => 'https://example.com' }
+        }
+        return null
+      }),
+    }
+    const e = mockEvent(target)
+    handleExternalLinkClick(e, openUrl)
+    expect(openUrl).not.toHaveBeenCalled()
+    // Still prevents anchor navigation (defense-in-depth for webview blank-page bug)
+    expect(e.preventDefault).toHaveBeenCalled()
+  })
+
+  it('skips interactive element NOT inside a link (no preventDefault)', () => {
+    const target = {
+      closest: vi.fn((selector: string) => {
+        const selectors = selector.split(',').map(s => s.trim())
+        if (selectors.some(s => s === 'button')) {
+          return { tagName: 'BUTTON' }
+        }
+        // No parent anchor
+        return null
+      }),
+    }
+    const e = mockEvent(target)
+    handleExternalLinkClick(e, openUrl)
+    expect(openUrl).not.toHaveBeenCalled()
+    expect(e.preventDefault).not.toHaveBeenCalled()
+  })
+
+  it('also calls stopPropagation on intercepted links', () => {
+    const e = {
+      ...mockEvent(mockAnchor('https://example.com')),
+      stopPropagation: vi.fn(),
+    } as unknown as MouseEvent
+    handleExternalLinkClick(e, openUrl)
+    expect(e.stopPropagation).toHaveBeenCalled()
+    expect(openUrl).toHaveBeenCalledWith('https://example.com')
+  })
 })
 
 describe('interceptExternalLinks wiring', () => {
-  it('registers both click and auxclick listeners and cleanup removes them', () => {
+  it('registers click (capture) and auxclick (bubble) listeners, cleanup removes them', () => {
     const openUrl = vi.fn()
+    const calls: Array<{ type: string; capture: boolean; action: 'add' | 'remove' }> = []
     const listeners: Record<string, EventListener[]> = {}
     const mockDoc: Pick<Document, 'addEventListener' | 'removeEventListener'> = {
-      addEventListener: vi.fn((type: string, handler: EventListener) => {
+      addEventListener: vi.fn((type: string, handler: EventListener, options?: boolean | AddEventListenerOptions) => {
+        const capture = typeof options === 'boolean' ? options : (options as AddEventListenerOptions)?.capture ?? false
+        calls.push({ type, capture, action: 'add' })
         listeners[type] = listeners[type] || []
         listeners[type].push(handler)
       }) as Document['addEventListener'],
-      removeEventListener: vi.fn((type: string, handler: EventListener) => {
-        listeners[type] = (listeners[type] || []).filter(h => h !== handler)
-      }) as Document['removeEventListener'],
+      removeEventListener: vi.fn(
+        (type: string, handler: EventListener, options?: boolean | EventListenerOptions) => {
+          const capture = typeof options === 'boolean' ? options : (options as EventListenerOptions)?.capture ?? false
+          calls.push({ type, capture, action: 'remove' })
+          listeners[type] = (listeners[type] || []).filter(h => h !== handler)
+        },
+      ) as Document['removeEventListener'],
     }
 
     const cleanup = interceptExternalLinks(openUrl, mockDoc)
 
     expect(listeners['click']).toHaveLength(1)
     expect(listeners['auxclick']).toHaveLength(1)
+
+    // Verify click uses capture phase, auxclick uses bubble
+    expect(calls).toContainEqual({ type: 'click', capture: true, action: 'add' })
+    expect(calls).toContainEqual({ type: 'auxclick', capture: false, action: 'add' })
 
     // Simulate auxclick with an https anchor — verifies the wired handler works
     const anchor = mockAnchor('https://example.com')
@@ -111,9 +181,11 @@ describe('interceptExternalLinks wiring', () => {
     auxclickHandler!(event as unknown as Event)
     expect(openUrl).toHaveBeenCalledWith('https://example.com')
 
-    // Cleanup removes both
+    // Cleanup removes both with matching capture flags
     cleanup()
     expect(listeners['click']).toHaveLength(0)
     expect(listeners['auxclick']).toHaveLength(0)
+    expect(calls).toContainEqual({ type: 'click', capture: true, action: 'remove' })
+    expect(calls).toContainEqual({ type: 'auxclick', capture: false, action: 'remove' })
   })
 })

--- a/packages/vscode-preview/src/interceptExternalLinks.ts
+++ b/packages/vscode-preview/src/interceptExternalLinks.ts
@@ -5,9 +5,18 @@
  * In VSCode webviews, default link navigation shows a blank page.
  * This handler catches http(s) links and delegates to the extension host
  * via vscode.env.openExternal() (#2422).
+ *
+ * Left-click uses capture phase so it fires before React's event system
+ * can stop propagation (React 18+ attaches at the root, and diagram
+ * components use stopPropagation() on click events). Without capture,
+ * left-clicks on links inside element details overlays never reach the
+ * document-level handler.
  */
 
 const isHttpUrl = /^https?:\/\//i
+
+/** Interactive elements that should handle their own clicks, even inside <a> tags. */
+const interactiveSelector = 'button, [role="button"], input, select, textarea'
 
 export function handleExternalLinkClick(
   e: MouseEvent,
@@ -15,11 +24,30 @@ export function handleExternalLinkClick(
 ): void {
   const target = e.target
   if (!target || typeof (target as Element).closest !== 'function') return
-  const anchor = (target as Element).closest('a[href]')
+
+  const el = target as Element
+
+  // Skip interactive elements (e.g., copy button inside a link badge),
+  // but still prevent anchor navigation to avoid the webview blank-page bug.
+  // The interceptor owns "no blank-page navigation" — components shouldn't
+  // need webview-awareness.
+  if (el.closest(interactiveSelector)) {
+    const anchor = el.closest('a[href]')
+    if (anchor) {
+      const href = anchor.getAttribute('href')
+      if (href && isHttpUrl.test(href)) {
+        e.preventDefault()
+      }
+    }
+    return
+  }
+
+  const anchor = el.closest('a[href]')
   if (!anchor) return
   const href = anchor.getAttribute('href')
   if (href && isHttpUrl.test(href)) {
     e.preventDefault()
+    e.stopPropagation()
     openExternalUrl(href)
   }
 }
@@ -30,11 +58,14 @@ export function interceptExternalLinks(
 ): () => void {
   const handler = (e: Event) => handleExternalLinkClick(e as MouseEvent, openExternalUrl)
 
-  target.addEventListener('click', handler)
+  // Use capture phase for click so the handler fires before React's
+  // event system can stopPropagation(). auxclick doesn't need capture
+  // because React doesn't handle non-primary button clicks.
+  target.addEventListener('click', handler, true)
   target.addEventListener('auxclick', handler)
 
   return () => {
-    target.removeEventListener('click', handler)
+    target.removeEventListener('click', handler, true)
     target.removeEventListener('auxclick', handler)
   }
 }


### PR DESCRIPTION
## Summary

Fix left-click on external links in the VSCode extension diagram preview. Previously, only right-click opened links in the browser. Now left-click works too.

Ref: https://github.com/likec4/likec4/issues/2422#issuecomment-4253494202

## Root Cause

The click event listener was registered in the **bubble phase** (default). React 18+ attaches event listeners to the React root node, and diagram overlay components call `stopPropagation()` on click events. This prevents the native DOM event from reaching the document-level link interceptor.

Right-click (`auxclick`) wasn't affected because React doesn't handle non-primary button clicks.

## Fix

1. **Capture phase** for the `click` listener (`addEventListener('click', handler, true)`). This fires before React's event system, ensuring the interceptor always sees clicks on links.

2. **Interactive element guard** — skips clicks on `<button>`, `[role="button"]`, `<input>`, `<select>`, `<textarea>` inside links. Prevents the copy button in link badges from triggering URL navigation.

3. **Defense-in-depth `preventDefault()`** — when an interactive element is inside an external `<a href>`, the interceptor calls `preventDefault()` to suppress anchor navigation even though it doesn't open the URL. This prevents the VSCode webview blank-page bug regardless of whether the interactive element's own handler calls `preventDefault()`. The interceptor owns "no blank-page navigation" — components shouldn't need webview-awareness.

4. **`stopPropagation()`** after intercepting — prevents the captured click from also triggering diagram interactions (node selection, panning).

## Files changed

| File | Change |
|---|---|
| `packages/vscode-preview/src/interceptExternalLinks.ts` | Capture phase + interactive guard + defense-in-depth preventDefault |
| `packages/vscode-preview/src/interceptExternalLinks.spec.ts` | 20 tests (6 new: per-selector interactive guard, preventDefault on interactive-inside-link, button-not-inside-link, stopPropagation, capture phase wiring) |

## Test plan

- [x] Unit tests: 20 passed (6 new tests covering capture phase, interactive guard per selector, defense-in-depth preventDefault)
- [x] **Manual: Tested with combined VSIX** (this PR + PR #2910 packaging fix merged locally into `test/vscode-combined` branch, built via `pnpm package-vsix`, installed in VSCode, opened monaco_aml_lidar project)
- [ ] Manual: Left-click link in element details Properties tab → opens in browser
- [ ] Manual: Right-click link → still opens in browser (regression check)
- [ ] Manual: Click copy icon inside link badge → copies URL, does NOT navigate
- [ ] CI passes

## Manual testing instructions

```bash
# To test both this PR and the packaging fix (#2910) together:
git checkout fix/vscode-extension-packaging
git checkout -b test/vscode-combined
git merge fix/left-click-links-vscode-2422 --no-edit
pnpm build
cd packages/vscode && pnpm package-vsix
code --install-extension likec4.vsix --force

# Then in VSCode:
# 1. Reload Window (Ctrl+Shift+P → Developer: Reload Window)
# 2. Open a LikeC4 workspace with elements that have links
# 3. Ctrl+Shift+P → "LikeC4: Open Preview"
# 4. Click element → Properties tab → LEFT-CLICK a link
# 5. Verify: link opens in browser, no blank page
# 6. Click copy icon next to link → should copy, NOT navigate
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
