### PR TITLE
fix(language-server): preserve metadata arrays when formatting

### DIFF
--- a/.changeset/fix-metadata-array-format.md
+++ b/.changeset/fix-metadata-array-format.md
@@ -1,0 +1,5 @@
+---
+'@likec4/language-server': patch
+---
+
+Fix formatter preserving metadata arrays instead of converting them to strings.

--- a/packages/language-server/src/formatting/LikeC4Formatter.spec.ts
+++ b/packages/language-server/src/formatting/LikeC4Formatter.spec.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { describe, it } from 'vitest'
 import { createTestServices } from '../test'
 
@@ -229,6 +236,36 @@ describe('formating', () => {
                 prop1 'some'
                 prop2 'other'
                 prop3: 'another';
+              }
+            }
+          }"
+        `),
+    )
+
+    it(
+      'keeps metadata arrays as arrays',
+      async ({ expect }) =>
+        expect(
+          await format`
+          specification {
+            element component
+          }
+          model {
+            component app {
+              metadata {
+                tags ["frontend", 'react', 'typescript']
+              }
+            }
+          }`,
+        ).toMatchInlineSnapshot(`
+          "
+          specification {
+            element component
+          }
+          model {
+            component app {
+              metadata {
+                tags ['frontend', 'react', 'typescript']
               }
             }
           }"

--- a/packages/language-server/src/formatting/LikeC4Formatter.ts
+++ b/packages/language-server/src/formatting/LikeC4Formatter.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { nonexhaustive } from '@likec4/core'
 import {
   type AstNode,
@@ -721,8 +728,17 @@ export class LikeC4Formatter extends AbstractFormatter {
     }
 
     let region = null
-    region = region ?? this.on(node, ast.isStringProperty)
-      ?.property('value')
+    if (ast.isMetadataAttribute(node)) {
+      const value = node.value
+      if (ast.isMetadataArray(value)) {
+        region = this.getNodeFormatter(value).nodes(...value.values)
+      } else if (value) {
+        region = this.getNodeFormatter(node).property('value')
+      }
+    } else {
+      region = this.on(node, ast.isStringProperty)
+        ?.property('value')
+    }
     region = region ?? this.on(node, ast.isElement)
       ?.properties('props')
     region = region ?? this.on(node, ast.isImportsFromPoject)


### PR DESCRIPTION
Fixes #2941.

## Summary
- Preserve metadata arrays when normalizing quotes in the LikeC4 formatter
- Add a regression test for mixed-quote metadata arrays

## Tests
- pnpm generate
- vitest run --no-isolate packages/language-server/src/formatting/LikeC4Formatter.spec.ts
- pnpm --filter @likec4/language-server run typecheck
