### PR TITLE
fix(language-server): allow group metadata key

### DIFF
--- a/.changeset/fix-metadata-group-key.md
+++ b/.changeset/fix-metadata-group-key.md
@@ -1,0 +1,5 @@
+---
+'@likec4/language-server': patch
+---
+
+Fixes [#2932](https://github.com/likec4/likec4/issues/2932) by allowing reserved keywords such as `group` as metadata keys.

--- a/packages/language-server/src/like-c4.langium
+++ b/packages/language-server/src/like-c4.langium
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 grammar LikeC4
 
 entry LikeC4Grammar:
@@ -261,7 +268,7 @@ MetadataBody: '{'
 ;
 
 MetadataAttribute:
-  key=IdTerminal ':'? (value=MetadataValue | boolValue=BOOLEAN) ';'?
+  key=Id ':'? (value=MetadataValue | boolValue=BOOLEAN) ';'?
 ;
 
 MetadataValue:

--- a/packages/language-server/src/model/__tests__/model-builder.spec.ts
+++ b/packages/language-server/src/model/__tests__/model-builder.spec.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import type { Element, ViewId } from '@likec4/core'
 import { viewsWithReadableEdges, withReadableEdges } from '@likec4/core/compute-view'
 import { keys, values } from 'remeda'
@@ -218,6 +225,51 @@ describe('LikeC4ModelBuilder', () => {
         },
       },
     })
+  })
+
+  it('builds model with group metadata key', async ({ expect }) => {
+    const { validate, buildModel } = createTestServices()
+    const { diagnostics } = await validate(`
+    specification {
+      element system
+    }
+    model {
+      system test {
+        metadata {
+          team 'team name'
+          _group '_group name'
+          group 'group name'
+          other 'other name'
+        }
+      }
+      system skipped {
+        metadata {
+          group 'other group'
+        }
+      }
+    }
+    views {
+      view index {
+        include * where metadata.group is 'group name'
+      }
+    }
+    `)
+    expect(diagnostics).toHaveLength(0)
+    const model = await buildModel()
+    expect(model).toBeDefined()
+    expect(model.elements).toMatchObject({
+      test: {
+        kind: 'system',
+        metadata: {
+          team: 'team name',
+          _group: '_group name',
+          group: 'group name',
+          other: 'other name',
+        },
+      },
+    })
+    const indexView = model.views['index' as ViewId]!
+    expect(indexView.nodes.map(node => node.id)).toStrictEqual(['test'])
   })
 
   it('builds model with array metadata using array syntax', async ({ expect }) => {


### PR DESCRIPTION
Fixes #2932

Summary:
- allow metadata keys to use the existing LikeC4 `Id` rule
- add regression coverage for `metadata.group`

Checks:
- `pnpm generate`
- `vitest run --no-isolate packages/language-server/src/model/__tests__/model-builder.spec.ts -t "group metadata key"`
- `vitest run --no-isolate packages/language-server/src`
- `pnpm --filter @likec4/language-server run typecheck`
- `pnpm --filter @likec4/language-server run lint`