### PR TITLE
fix: support bidirectional model relationships

### DIFF
--- a/.changeset/fix-bidirectional-model-relations.md
+++ b/.changeset/fix-bidirectional-model-relations.md
@@ -3,4 +3,4 @@
 '@likec4/language-server': patch
 ---
 
-Allow model relationships to use the documented `<->` syntax, render them with a tail arrow, and include them from either endpoint in view relationship expressions. Fixes [#2927](https://github.com/likec4/likec4/issues/2927).
+Allow model relationships to use the documented `<->` and `-[kind]<->` syntax, preserve bidirectional semantics through styling and relationship extensions, and include/exclude them from either endpoint in view relationship expressions. Fixes [#2927](https://github.com/likec4/likec4/issues/2927).

--- a/.changeset/fix-bidirectional-model-relations.md
+++ b/.changeset/fix-bidirectional-model-relations.md
@@ -1,5 +1,6 @@
 ---
+'@likec4/core': patch
 '@likec4/language-server': patch
 ---
 
-Allow model relationships to use the documented `<->` syntax and render them with a tail arrow. Fixes [#2927](https://github.com/likec4/likec4/issues/2927).
+Allow model relationships to use the documented `<->` syntax, render them with a tail arrow, and include them from either endpoint in view relationship expressions. Fixes [#2927](https://github.com/likec4/likec4/issues/2927).

--- a/.changeset/fix-bidirectional-model-relations.md
+++ b/.changeset/fix-bidirectional-model-relations.md
@@ -1,0 +1,5 @@
+---
+'@likec4/language-server': patch
+---
+
+Allow model relationships to use the documented `<->` syntax and render them with a tail arrow. Fixes [#2927](https://github.com/likec4/likec4/issues/2927).

--- a/apps/docs/src/content/docs/dsl/relationships.mdx
+++ b/apps/docs/src/content/docs/dsl/relationships.mdx
@@ -109,6 +109,7 @@ specification {
 model {
   system1 = system 'System 1'
   system2 = system 'System 2'
+  system3 = system 'System 3'
 
   system1 -[async]-> system2
   system1 -[async]<-> system3

--- a/apps/docs/src/content/docs/dsl/relationships.mdx
+++ b/apps/docs/src/content/docs/dsl/relationships.mdx
@@ -12,7 +12,7 @@ Relationships describe the connections, data flows and interactions within your 
 
 ## Relationship definition
 
-Relationships are defined with the **`->`** operator:
+Relationships are usually defined with the **`->`** operator:
 
 ```likec4
 model {
@@ -22,6 +22,21 @@ model {
   customer -> cloud
 }
 ```
+
+Use **`<->`** when both elements actively communicate with each other:
+
+```likec4
+model {
+  frontend = component 'Frontend'
+  backend = component 'Backend'
+
+  frontend <-> backend 'Sync'
+}
+```
+
+Bidirectional relationships render with arrows at both ends. Use them for mutual interactions, such as synchronized
+replication or protocols where both sides initiate meaningful communication. For request-response calls where one side
+initiates the interaction, prefer `->`.
 
 Relationships may be nested
 

--- a/apps/docs/src/content/docs/dsl/relationships.mdx
+++ b/apps/docs/src/content/docs/dsl/relationships.mdx
@@ -111,11 +111,14 @@ model {
   system2 = system 'System 2'
 
   system1 -[async]-> system2
+  system1 -[async]<-> system3
 
   // Or prefix with '.' to use the kind
   system1 .uses system2
 }
 ```
+
+Use `-[kind]<->` when a bidirectional relationship should also inherit a relationship kind.
 
 This makes it possible to add richer semantics to the interactions between elements, for example,
 from a technology perspective (REST, gRPC, GraphQL, Sync/Async, etc.)

--- a/apps/docs/src/content/docs/dsl/relationships.mdx
+++ b/apps/docs/src/content/docs/dsl/relationships.mdx
@@ -34,9 +34,9 @@ model {
 }
 ```
 
-Bidirectional relationships render with arrows at both ends. Use them for mutual interactions, such as synchronized
-replication or protocols where both sides initiate meaningful communication. For request-response calls where one side
-initiates the interaction, prefer `->`.
+Bidirectional relationships render with arrows at both ends by default. Use them for mutual interactions, such as
+synchronized replication or protocols where both sides initiate meaningful communication. Relationship style can still
+override the rendered tail. For request-response calls where one side initiates the interaction, prefer `->`.
 
 Relationships may be nested
 

--- a/packages/core/src/builder/Builder.deploymentModel.ts
+++ b/packages/core/src/builder/Builder.deploymentModel.ts
@@ -435,7 +435,7 @@ export type AddDeploymentRelation<Props = unknown> =
 
 export type DeloymentModelHelpers<T extends AnyTypes> = AddDeploymentNodeHelpers<T> & {
   instanceOf: AddDeployedInstance<T['NewDeploymentNodeProps']>
-  rel: AddDeploymentRelation<T['NewRelationshipProps']>
+  rel: AddDeploymentRelation<T['NewDeploymentRelationshipProps']>
   deployment: typeof deployment
 }
 

--- a/packages/core/src/builder/Builder.ts
+++ b/packages/core/src/builder/Builder.ts
@@ -1026,7 +1026,7 @@ function builder<Spec extends BuilderSpecification, T extends AnyTypes>(
             return b as any
           }
         },
-        rel: (source: string, target: string, _props?: T['NewRelationshipProps'] | string) => {
+        rel: (source: string, target: string, _props?: T['NewDeploymentRelationshipProps'] | string) => {
           return <T extends AnyTypes>(b: DeploymentModelBuilder<T>) => {
             const {
               title = null,

--- a/packages/core/src/builder/_types.ts
+++ b/packages/core/src/builder/_types.ts
@@ -139,12 +139,18 @@ export type NewRelationProps<Kind, Tag, Metadata> = {
   notes?: MarkdownOrString | string
   tags?: [Tag, ...Tag[]]
   metadata?: Metadata
+  isBidirectional?: boolean
   head?: RelationshipArrowType
   tail?: RelationshipArrowType
   line?: RelationshipLineType
   color?: Color
   links?: NonEmptyArray<string | { title?: string; url: string }>
 }
+
+export type NewDeploymentRelationProps<Kind, Tag, Metadata> = Omit<
+  NewRelationProps<Kind, Tag, Metadata>,
+  'isBidirectional'
+>
 
 export type Invalid<Message extends string> = Tagged<Message, 'Error'>
 export type Warn<Id, Existing> = IsLiteral<Existing> extends true ? Id extends Existing ? Invalid<'Already exists'> : Id
@@ -183,6 +189,7 @@ export interface Types<
 
   NewElementProps: NewElementProps<Tag, Metadata<MetadataKey>>
   NewRelationshipProps: NewRelationProps<RelationshipKind, Tag, Metadata<MetadataKey>>
+  NewDeploymentRelationshipProps: NewDeploymentRelationProps<RelationshipKind, Tag, Metadata<MetadataKey>>
   NewViewProps: NewViewProps<Tag>
 
   NewDeploymentNodeProps: NewDeploymentNodeProps<Tag, Metadata<MetadataKey>>

--- a/packages/core/src/compute-view/element-view/__test__/incoming-expr.spec.ts
+++ b/packages/core/src/compute-view/element-view/__test__/incoming-expr.spec.ts
@@ -1,7 +1,30 @@
 import { describe, expect, it } from 'vitest'
+import { Builder } from '../../../builder'
 import { $exclude, $include, computeView } from './fixture'
+import { TestHelper } from './TestHelper'
 
 describe('incoming-expr', () => {
+  it('includes a bidirectional relationship from either endpoint', () => {
+    const { $include } = TestHelper
+    const builder = Builder
+      .specification({
+        elements: {
+          component: {},
+        },
+      })
+      .model(({ component, rel }, _) =>
+        _(
+          component('a'),
+          component('b'),
+          rel('a', 'b', { tail: 'normal' }),
+        )
+      )
+    const test = TestHelper.from(builder)
+
+    expect(test.computeView($include('-> b')).edges.map(edge => edge.id)).toEqual(['a -> b'])
+    expect(test.computeView($include('-> a')).edges.map(edge => edge.id)).toEqual(['a -> b'])
+  })
+
   describe('top level', () => {
     it('include -> amazon.*', () => {
       const { nodeIds, edgeIds } = computeView([$include('-> amazon.*')])

--- a/packages/core/src/compute-view/element-view/__test__/incoming-expr.spec.ts
+++ b/packages/core/src/compute-view/element-view/__test__/incoming-expr.spec.ts
@@ -25,6 +25,110 @@ describe('incoming-expr', () => {
     expect(test.computeView($include('-> a')).edges.map(edge => edge.id)).toEqual(['a -> b'])
   })
 
+  it('includes a bidirectional relationship to the declared source by element kind', () => {
+    const { $include } = TestHelper
+    const builder = Builder
+      .specification({
+        elements: {
+          component: {},
+          database: {},
+        },
+      })
+      .model(({ component, database, rel }, _) =>
+        _(
+          component('a'),
+          database('b'),
+          rel('a', 'b', { isBidirectional: true, tail: 'normal' } as any),
+        )
+      )
+    const test = TestHelper.from(builder)
+
+    expect(
+      test.computeView($include({
+        incoming: {
+          elementKind: 'component',
+          isEqual: true,
+        },
+      })).edges.map(edge => edge.id),
+    ).toEqual(['a -> b'])
+  })
+
+  it('includes a bidirectional relationship to the declared source by element tag', () => {
+    const { $include } = TestHelper
+    const builder = Builder
+      .specification({
+        elements: {
+          component: {},
+          database: {},
+        },
+        tags: {
+          source: {},
+        },
+      })
+      .model(({ component, database, rel }, _) =>
+        _(
+          component('a', { tags: ['source'] }),
+          database('b'),
+          rel('a', 'b', { isBidirectional: true, tail: 'normal' } as any),
+        )
+      )
+    const test = TestHelper.from(builder)
+
+    expect(
+      test.computeView($include({
+        incoming: {
+          elementTag: 'source',
+          isEqual: true,
+        },
+      })).edges.map(edge => edge.id),
+    ).toEqual(['a -> b'])
+  })
+
+  it('includes a styled bidirectional relationship from the declared source', () => {
+    const { $include } = TestHelper
+    const builder = Builder
+      .specification({
+        elements: {
+          component: {},
+        },
+      })
+      .model(({ component, rel }, _) =>
+        _(
+          component('a'),
+          component('b'),
+          rel('a', 'b', { isBidirectional: true, tail: 'diamond' } as any),
+        )
+      )
+    const test = TestHelper.from(builder)
+
+    expect(test.computeView($include('-> a')).edges.map(edge => edge.id)).toEqual(['a -> b'])
+  })
+
+  it('excludes a bidirectional relationship from the declared source', () => {
+    const { $exclude, $include } = TestHelper
+    const builder = Builder
+      .specification({
+        elements: {
+          component: {},
+        },
+      })
+      .model(({ component, rel }, _) =>
+        _(
+          component('a'),
+          component('b'),
+          rel('a', 'b', { isBidirectional: true, tail: 'normal' } as any),
+        )
+      )
+    const test = TestHelper.from(builder)
+
+    expect(
+      test.computeView(
+        $include('*'),
+        $exclude('-> a'),
+      ).edges.map(edge => edge.id),
+    ).toEqual([])
+  })
+
   describe('top level', () => {
     it('include -> amazon.*', () => {
       const { nodeIds, edgeIds } = computeView([$include('-> amazon.*')])

--- a/packages/core/src/compute-view/element-view/__test__/incoming-expr.spec.ts
+++ b/packages/core/src/compute-view/element-view/__test__/incoming-expr.spec.ts
@@ -38,7 +38,7 @@ describe('incoming-expr', () => {
         _(
           component('a'),
           database('b'),
-          rel('a', 'b', { isBidirectional: true, tail: 'normal' } as any),
+          rel('a', 'b', { isBidirectional: true, tail: 'normal' }),
         )
       )
     const test = TestHelper.from(builder)
@@ -69,7 +69,7 @@ describe('incoming-expr', () => {
         _(
           component('a', { tags: ['source'] }),
           database('b'),
-          rel('a', 'b', { isBidirectional: true, tail: 'normal' } as any),
+          rel('a', 'b', { isBidirectional: true, tail: 'normal' }),
         )
       )
     const test = TestHelper.from(builder)
@@ -96,7 +96,7 @@ describe('incoming-expr', () => {
         _(
           component('a'),
           component('b'),
-          rel('a', 'b', { isBidirectional: true, tail: 'diamond' } as any),
+          rel('a', 'b', { isBidirectional: true, tail: 'diamond' }),
         )
       )
     const test = TestHelper.from(builder)
@@ -116,7 +116,7 @@ describe('incoming-expr', () => {
         _(
           component('a'),
           component('b'),
-          rel('a', 'b', { isBidirectional: true, tail: 'normal' } as any),
+          rel('a', 'b', { isBidirectional: true, tail: 'normal' }),
         )
       )
     const test = TestHelper.from(builder)
@@ -127,6 +127,86 @@ describe('incoming-expr', () => {
         $exclude('-> a'),
       ).edges.map(edge => edge.id),
     ).toEqual([])
+  })
+
+  it('includes only bidirectional relations from a mixed parallel connection to the declared source', () => {
+    const { $include } = TestHelper
+    const builder = Builder
+      .specification({
+        elements: {
+          component: {},
+        },
+      })
+      .model(({ component, rel }, _) =>
+        _(
+          component('a'),
+          component('b'),
+          rel('a', 'b', { title: 'bidirectional', isBidirectional: true, tail: 'normal' }),
+          rel('a', 'b', { title: 'directed' }),
+        )
+      )
+    const test = TestHelper.from(builder)
+
+    const edges = test.computeView($include('-> a')).edges
+
+    expect(edges).toHaveLength(1)
+    expect(edges[0]!.label).toBe('bidirectional')
+    expect(edges[0]!.relations).toHaveLength(1)
+  })
+
+  it('does not let a directed parallel relation match a reverse bidirectional incoming predicate', () => {
+    const { $include } = TestHelper
+    const builder = Builder
+      .specification({
+        elements: {
+          component: {},
+        },
+        tags: {
+          bidirectional: {},
+          directed: {},
+        },
+      })
+      .model(({ component, rel }, _) =>
+        _(
+          component('a'),
+          component('b'),
+          rel('a', 'b', { title: 'bidirectional', tags: ['bidirectional'], isBidirectional: true, tail: 'normal' }),
+          rel('a', 'b', { title: 'directed', tags: ['directed'] }),
+        )
+      )
+    const test = TestHelper.from(builder)
+
+    expect(
+      test.computeView($include('-> a', { where: 'tag is #directed' } as any)).edges,
+    ).toHaveLength(0)
+    expect(
+      test.computeView($include('-> a', { where: 'tag is #bidirectional' } as any)).edges.map(edge => edge.label),
+    ).toEqual(['bidirectional'])
+  })
+
+  it('preserves normal incoming behavior for mixed parallel relations to the declared target', () => {
+    const { $include } = TestHelper
+    const builder = Builder
+      .specification({
+        elements: {
+          component: {},
+        },
+      })
+      .model(({ component, rel }, _) =>
+        _(
+          component('a'),
+          component('b'),
+          rel('a', 'b', { title: 'bidirectional', isBidirectional: true, tail: 'normal' }),
+          rel('a', 'b', { title: 'directed' }),
+        )
+      )
+    const test = TestHelper.from(builder)
+
+    const edges = test.computeView($include('-> b')).edges
+
+    expect(edges).toHaveLength(1)
+    expect(edges[0]!.label).toBe('[...]')
+    expect(edges[0]!.relations).toHaveLength(2)
   })
 
   describe('top level', () => {

--- a/packages/core/src/compute-view/element-view/predicates/_utils.ts
+++ b/packages/core/src/compute-view/element-view/predicates/_utils.ts
@@ -21,9 +21,13 @@ export function findConnectionsFrom<A extends AnyAux>(
   source: ElementModel<A>,
   targets: Iterable<ElementModel<A>>,
 ): readonly ConnectionModel<A>[] {
-  return findConnectionsBetween(source, targets).filter(
-    connection => connection.source === source || [...connection.relations].some(isBidirectionalRelation),
-  )
+  return findConnectionsBetween(source, targets).flatMap(connection => {
+    if (connection.source === source) {
+      return [connection]
+    }
+    const bidirectionalRelations = new Set([...connection.relations].filter(isBidirectionalRelation))
+    return bidirectionalRelations.size > 0 ? [connection.update(bidirectionalRelations)] : []
+  })
 }
 
 /**

--- a/packages/core/src/compute-view/element-view/predicates/_utils.ts
+++ b/packages/core/src/compute-view/element-view/predicates/_utils.ts
@@ -1,11 +1,15 @@
 import { anyPass } from 'remeda'
-import type { ConnectionModel, ElementModel, LikeC4Model } from '../../../model'
+import type { ConnectionModel, ElementModel, LikeC4Model, RelationshipModel } from '../../../model'
 import { modelConnection } from '../../../model'
 import { type AnyAux, FqnRef, ModelFqnExpr } from '../../../types'
 import { ifilter, isDescendantOf, nonexhaustive, toArray } from '../../../utils'
 import type { Elem, Memory, PredicateCtx } from '../_types'
 
 export const { findConnection, findConnectionsBetween, findConnectionsWithin } = modelConnection
+
+export function isBidirectionalRelation<A extends AnyAux>(relation: RelationshipModel<A>): boolean {
+  return relation.isBidirectional || relation.tail === 'normal'
+}
 
 /**
  * Resolve connections that can originate at an element.
@@ -18,8 +22,7 @@ export function findConnectionsFrom<A extends AnyAux>(
   targets: Iterable<ElementModel<A>>,
 ): readonly ConnectionModel<A>[] {
   return findConnectionsBetween(source, targets).filter(
-    connection =>
-      connection.source === source || [...connection.relations].some(relation => relation.tail === 'normal'),
+    connection => connection.source === source || [...connection.relations].some(isBidirectionalRelation),
   )
 }
 

--- a/packages/core/src/compute-view/element-view/predicates/_utils.ts
+++ b/packages/core/src/compute-view/element-view/predicates/_utils.ts
@@ -1,11 +1,27 @@
 import { anyPass } from 'remeda'
-import type { ElementModel, LikeC4Model } from '../../../model'
+import type { ConnectionModel, ElementModel, LikeC4Model } from '../../../model'
 import { modelConnection } from '../../../model'
 import { type AnyAux, FqnRef, ModelFqnExpr } from '../../../types'
 import { ifilter, isDescendantOf, nonexhaustive, toArray } from '../../../utils'
 import type { Elem, Memory, PredicateCtx } from '../_types'
 
 export const { findConnection, findConnectionsBetween, findConnectionsWithin } = modelConnection
+
+/**
+ * Resolve connections that can originate at an element.
+ *
+ * Relationships with arrows at both ends can be selected from either endpoint,
+ * while their connection retains the direction declared in the model.
+ */
+export function findConnectionsFrom<A extends AnyAux>(
+  source: ElementModel<A>,
+  targets: Iterable<ElementModel<A>>,
+): readonly ConnectionModel<A>[] {
+  return findConnectionsBetween(source, targets).filter(
+    connection =>
+      connection.source === source || [...connection.relations].some(relation => relation.tail === 'normal'),
+  )
+}
 
 /**
  * Resolve elements from the model based on the given expression

--- a/packages/core/src/compute-view/element-view/predicates/relation-in.ts
+++ b/packages/core/src/compute-view/element-view/predicates/relation-in.ts
@@ -5,7 +5,7 @@ import { type AnyAux, FqnRef, ModelFqnExpr } from '../../../types'
 import { nonexhaustive } from '../../../utils'
 import { elementExprToPredicate } from '../../utils/elementExpressionToPredicate'
 import type { ConnectionWhere, PredicateExecutor } from '../_types'
-import { findConnection, findConnectionsBetween, resolveAndIncludeFromMemory, resolveElements } from './_utils'
+import { findConnectionsFrom, resolveAndIncludeFromMemory, resolveElements } from './_utils'
 
 export const IncomingExprPredicate: PredicateExecutor<ModelRelationExpr.Incoming<AnyAux>> = {
   include: ({ expr, scope, model, memory, stage, filterWhere }) => {
@@ -17,10 +17,9 @@ export const IncomingExprPredicate: PredicateExecutor<ModelRelationExpr.Incoming
       }
       for (const sibling of scope.ascendingSiblings()) {
         connections.push(
-          ...findConnection(
+          ...findConnectionsFrom(
             sibling,
-            scope,
-            'directed',
+            [scope],
           ),
         )
       }
@@ -37,10 +36,9 @@ export const IncomingExprPredicate: PredicateExecutor<ModelRelationExpr.Incoming
       const ensureIncoming = incomingConnectionPredicate(model, target)
       for (const visible of visibleElements) {
         connections.push(
-          ...findConnectionsBetween(
+          ...findConnectionsFrom(
             visible,
             targets,
-            'directed',
           ).filter(ensureIncoming),
         )
       }
@@ -75,6 +73,14 @@ export function incomingConnectionPredicate(
   model: LikeC4Model,
   expr: ModelFqnExpr.NonWildcard,
 ): ConnectionWhere {
+  const isIncomingOrBidirectional = (fqn: string): ConnectionWhere => {
+    const isIncoming = Connection.isIncoming(fqn)
+    const isOutgoing = Connection.isOutgoing(fqn)
+    return connection =>
+      isIncoming(connection)
+      || (isOutgoing(connection) && [...connection.relations].some(relation => relation.tail === 'normal'))
+  }
+
   switch (true) {
     case ModelFqnExpr.isElementKindExpr(expr):
     case ModelFqnExpr.isElementTagExpr(expr): {
@@ -85,7 +91,7 @@ export function incomingConnectionPredicate(
       const fqn = FqnRef.flatten(expr.ref)
       return anyPass(
         [...model.children(fqn)].map(
-          el => Connection.isIncoming(el.id),
+          el => isIncomingOrBidirectional(el.id),
         ),
       )
     }
@@ -94,20 +100,20 @@ export function incomingConnectionPredicate(
       return anyPass([
         Connection.isInside(fqn),
         ...[...model.children(fqn)].map(
-          el => Connection.isIncoming(el.id),
+          el => isIncomingOrBidirectional(el.id),
         ),
       ])
     }
     case ModelFqnExpr.isModelRef(expr) && expr.selector === 'expanded': {
       const fqn = FqnRef.flatten(expr.ref)
       return anyPass([
-        Connection.isIncoming(fqn),
+        isIncomingOrBidirectional(fqn),
         Connection.isInside(fqn),
       ])
     }
     case ModelFqnExpr.isModelRef(expr): {
       const fqn = FqnRef.flatten(expr.ref)
-      return Connection.isIncoming(fqn)
+      return isIncomingOrBidirectional(fqn)
     }
     default:
       nonexhaustive(expr)

--- a/packages/core/src/compute-view/element-view/predicates/relation-in.ts
+++ b/packages/core/src/compute-view/element-view/predicates/relation-in.ts
@@ -5,7 +5,7 @@ import { type AnyAux, FqnRef, ModelFqnExpr } from '../../../types'
 import { nonexhaustive } from '../../../utils'
 import { elementExprToPredicate } from '../../utils/elementExpressionToPredicate'
 import type { ConnectionWhere, PredicateExecutor } from '../_types'
-import { findConnectionsFrom, resolveAndIncludeFromMemory, resolveElements } from './_utils'
+import { findConnectionsFrom, isBidirectionalRelation, resolveAndIncludeFromMemory, resolveElements } from './_utils'
 
 export const IncomingExprPredicate: PredicateExecutor<ModelRelationExpr.Incoming<AnyAux>> = {
   include: ({ expr, scope, model, memory, stage, filterWhere }) => {
@@ -56,11 +56,11 @@ export const IncomingExprPredicate: PredicateExecutor<ModelRelationExpr.Incoming
       if (!scope) {
         return
       }
-      excluded.push(...scope.allIncoming)
+      excluded.push(...incomingRelations(scope))
     } else {
       const elements = resolveElements(model, incoming)
       excluded.push(
-        ...elements.flatMap(e => [...e.allIncoming]),
+        ...elements.flatMap(incomingRelations),
       )
     }
     stage.excludeRelations(new Set(excluded.filter(where)))
@@ -78,14 +78,16 @@ export function incomingConnectionPredicate(
     const isOutgoing = Connection.isOutgoing(fqn)
     return connection =>
       isIncoming(connection)
-      || (isOutgoing(connection) && [...connection.relations].some(relation => relation.tail === 'normal'))
+      || (isOutgoing(connection) && [...connection.relations].some(isBidirectionalRelation))
   }
 
   switch (true) {
     case ModelFqnExpr.isElementKindExpr(expr):
     case ModelFqnExpr.isElementTagExpr(expr): {
       const isElement = elementExprToPredicate(expr)
-      return (connection) => isElement(connection.target)
+      return (connection) =>
+        isElement(connection.target)
+        || (isElement(connection.source) && [...connection.relations].some(isBidirectionalRelation))
     }
     case ModelFqnExpr.isModelRef(expr) && expr.selector === 'children': {
       const fqn = FqnRef.flatten(expr.ref)
@@ -118,4 +120,13 @@ export function incomingConnectionPredicate(
     default:
       nonexhaustive(expr)
   }
+}
+
+function incomingRelations(
+  element: { allIncoming: ReadonlySet<RelationshipModel>; allOutgoing: ReadonlySet<RelationshipModel> },
+) {
+  return [
+    ...element.allIncoming,
+    ...[...element.allOutgoing].filter(isBidirectionalRelation),
+  ]
 }

--- a/packages/core/src/model/RelationModel.ts
+++ b/packages/core/src/model/RelationModel.ts
@@ -147,6 +147,10 @@ export class RelationshipModel<A extends AnyAux = AnyAux> implements AnyRelation
     return this.$relationship.tail
   }
 
+  get isBidirectional(): boolean {
+    return this.$relationship.isBidirectional === true
+  }
+
   /**
    * Iterate over all views that include this relationship.
    */

--- a/packages/core/src/types/model-logical.ts
+++ b/packages/core/src/types/model-logical.ts
@@ -121,6 +121,7 @@ export interface AbstractRelationship<A extends AnyAux>
 export interface Relationship<A extends AnyAux = AnyAux> extends AbstractRelationship<A> {
   readonly source: FqnRef.ModelRef<A>
   readonly target: FqnRef.ModelRef<A>
+  readonly isBidirectional?: boolean
 }
 
 /**

--- a/packages/language-server/src/__tests__/model-relation.spec.ts
+++ b/packages/language-server/src/__tests__/model-relation.spec.ts
@@ -1,4 +1,12 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { describe, test } from 'vitest'
+import { createTestServices } from '../test'
 import { invalid, valid } from './asserts'
 
 describe('model relation', () => {
@@ -15,6 +23,64 @@ describe('model relation', () => {
       }
       `,
   )
+
+  test(
+    'valid bidirectional relation',
+    valid`
+      specification {
+        element component
+      }
+      model {
+        component frontend
+        component backend
+        frontend <-> backend
+      }
+      `,
+  )
+
+  test(
+    'valid bidirectional extend relation',
+    valid`
+      specification {
+        element component
+      }
+      model {
+        component frontend
+        component backend
+        frontend <-> backend
+        extend frontend <-> backend {
+          link https://example.com/sync
+        }
+      }
+      `,
+  )
+
+  test('builds bidirectional relation with a tail arrow', async ({ expect }) => {
+    const { validate, buildModel } = createTestServices()
+    const { diagnostics } = await validate(`
+      specification {
+        element component
+      }
+      model {
+        component frontend
+        component backend
+        frontend <-> backend
+      }
+    `)
+    expect(diagnostics).toHaveLength(0)
+
+    const model = await buildModel()
+    const relation = Object.values(model.relations)[0]
+    expect(relation).toMatchObject({
+      source: {
+        model: 'frontend',
+      },
+      target: {
+        model: 'backend',
+      },
+      tail: 'normal',
+    })
+  })
 
   test(
     'fail if defined in model without source',

--- a/packages/language-server/src/__tests__/model-relation.spec.ts
+++ b/packages/language-server/src/__tests__/model-relation.spec.ts
@@ -65,6 +65,54 @@ describe('model relation', () => {
     })
   })
 
+  it('builds a kinded bidirectional relation', async ({ expect, t }) => {
+    const { diagnostics } = await t.validate(`
+      specification {
+        element component
+        relationship sync
+      }
+      model {
+        component frontend
+        component backend
+        frontend -[sync]<-> backend
+      }
+    `)
+    expect(diagnostics).toHaveLength(0)
+
+    const model = await t.buildModel()
+    const relation = Object.values(model.relations)[0]
+    expect(relation).toMatchObject({
+      kind: 'sync',
+      isBidirectional: true,
+      tail: 'normal',
+    })
+  })
+
+  it('keeps semantic bidirectionality when tail style is customized', async ({ expect, t }) => {
+    const { diagnostics } = await t.validate(`
+      specification {
+        element component
+      }
+      model {
+        component frontend
+        component backend
+        frontend <-> backend {
+          style {
+            tail diamond
+          }
+        }
+      }
+    `)
+    expect(diagnostics).toHaveLength(0)
+
+    const model = await t.buildModel()
+    const relation = Object.values(model.relations)[0]
+    expect(relation).toMatchObject({
+      isBidirectional: true,
+      tail: 'diamond',
+    })
+  })
+
   test('fail if defined in model without source').invalid`
       specification {
         element person

--- a/packages/language-server/src/__tests__/model-relation.spec.ts
+++ b/packages/language-server/src/__tests__/model-relation.spec.ts
@@ -1,4 +1,5 @@
 import { describe } from 'vitest'
+import { testFileScope as it } from '../test'
 import { test } from './asserts'
 
 describe('model relation', () => {
@@ -12,6 +13,57 @@ describe('model relation', () => {
         user1 -> user2
       }
       `
+
+  test('valid bidirectional relation').valid`
+      specification {
+        element component
+      }
+      model {
+        component frontend
+        component backend
+        frontend <-> backend
+      }
+      `
+
+  test('valid bidirectional extend relation').valid`
+      specification {
+        element component
+      }
+      model {
+        component frontend
+        component backend
+        frontend <-> backend
+        extend frontend <-> backend {
+          link https://example.com/sync
+        }
+      }
+      `
+
+  it('builds a bidirectional relation with a tail arrow', async ({ expect, t }) => {
+    const { diagnostics } = await t.validate(`
+      specification {
+        element component
+      }
+      model {
+        component frontend
+        component backend
+        frontend <-> backend
+      }
+    `)
+    expect(diagnostics).toHaveLength(0)
+
+    const model = await t.buildModel()
+    const relation = Object.values(model.relations)[0]
+    expect(relation).toMatchObject({
+      source: {
+        model: 'frontend',
+      },
+      target: {
+        model: 'backend',
+      },
+      tail: 'normal',
+    })
+  })
 
   test('fail if defined in model without source').invalid`
       specification {

--- a/packages/language-server/src/ast.ts
+++ b/packages/language-server/src/ast.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 //
 // Copyright (c) 2023-2026 Denis Davydkov
-// Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
 
@@ -128,6 +128,7 @@ export interface ParsedAstRelation {
   astPath: string
   source: c4.FqnRef.ModelRef
   target: c4.FqnRef.ModelRef
+  isBidirectional?: boolean
   kind?: c4.RelationshipKind
   tags?: c4.NonEmptyArray<c4.Tag>
   title: string

--- a/packages/language-server/src/ast.ts
+++ b/packages/language-server/src/ast.ts
@@ -108,6 +108,7 @@ export interface ParsedAstExtend {
 export interface ParsedAstExtendRelation {
   id: c4.RelationId
   astPath: string
+  isBidirectional?: boolean
   tags?: c4.NonEmptyArray<c4.Tag> | null
   links?: c4.NonEmptyArray<c4.Link> | null
   metadata?: { [key: string]: string | string[] }

--- a/packages/language-server/src/ast.ts
+++ b/packages/language-server/src/ast.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 //
 // Copyright (c) 2023-2026 Denis Davydkov
-// Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
 
@@ -118,6 +118,7 @@ export interface ParsedAstRelation {
   astPath: string
   source: c4.FqnRef.ModelRef
   target: c4.FqnRef.ModelRef
+  isBidirectional?: boolean
   kind?: c4.RelationshipKind
   tags?: c4.NonEmptyArray<c4.Tag>
   title: string

--- a/packages/language-server/src/formatting/LikeC4Formatter.ts
+++ b/packages/language-server/src/formatting/LikeC4Formatter.ts
@@ -162,7 +162,7 @@ export class LikeC4Formatter extends AbstractFormatter {
         const sourceNodes = n?.source?.$cstNode ? [n?.source?.$cstNode] : []
 
         f.cst(sourceNodes).append(FormattingOptions.oneSpace)
-        f.keywords(']->').prepend(FormattingOptions.noSpace)
+        f.keywords(']->', ']<->').prepend(FormattingOptions.noSpace)
         f.keywords('-[').append(FormattingOptions.noSpace)
 
         f.nodes(...filter([

--- a/packages/language-server/src/like-c4.langium
+++ b/packages/language-server/src/like-c4.langium
@@ -164,7 +164,7 @@ ExtendElementOrRelation:
       source=FqnRef
       (
         dotKind=RelationKindDotRef |
-        '-[' kind=[RelationshipKind] ']->' |
+        '-[' kind=[RelationshipKind] (isBidirectional?=']<->' | ']->') |
         isBidirectional?='<->' |
         '->'
       )
@@ -251,7 +251,7 @@ Relation<isExplicit>:
   (<isExplicit> source=FqnRef | <!isExplicit> source=FqnRef?)
   (
     dotKind=RelationKindDotRef |
-    '-[' kind=[RelationshipKind] ']->' |
+    '-[' kind=[RelationshipKind] (isBidirectional?=']<->' | ']->') |
     isBidirectional?='<->' |
     '->'
   )

--- a/packages/language-server/src/like-c4.langium
+++ b/packages/language-server/src/like-c4.langium
@@ -162,12 +162,7 @@ ExtendElementOrRelation:
   'extend' (
     {infer ExtendRelation}
       source=FqnRef
-      (
-        dotKind=RelationKindDotRef |
-        '-[' kind=[RelationshipKind] (isBidirectional?=']<->' | ']->') |
-        isBidirectional?='<->' |
-        '->'
-      )
+      RelationConnector
       target=FqnRef
       title=String?
       body=ExtendRelationBody |
@@ -249,12 +244,7 @@ StrictFqnRef returns StrictFqnRef:
 
 Relation<isExplicit>:
   (<isExplicit> source=FqnRef | <!isExplicit> source=FqnRef?)
-  (
-    dotKind=RelationKindDotRef |
-    '-[' kind=[RelationshipKind] (isBidirectional?=']<->' | ']->') |
-    isBidirectional?='<->' |
-    '->'
-  )
+  RelationConnector
   target=FqnRef
   (title=String  // title
     (description=String  // description
@@ -263,6 +253,13 @@ Relation<isExplicit>:
   )?
   tags=Tags?
   body=RelationBody?
+;
+
+fragment RelationConnector:
+  dotKind=RelationKindDotRef |
+  '-[' kind=[RelationshipKind] (isBidirectional?=']<->' | ']->') |
+  isBidirectional?='<->' |
+  '->'
 ;
 
 RelationBody: '{'

--- a/packages/language-server/src/like-c4.langium
+++ b/packages/language-server/src/like-c4.langium
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 grammar LikeC4
 
 entry LikeC4Grammar:
@@ -171,6 +178,7 @@ ExtendRelation:
   (
     dotKind=RelationKindDotRef |
     '-[' kind=[RelationshipKind] ']->' |
+    isBidirectional?='<->' |
     '->'
   )
   target=FqnRef
@@ -216,6 +224,7 @@ Relation<isExplicit>:
   (
     dotKind=RelationKindDotRef |
     '-[' kind=[RelationshipKind] ']->' |
+    isBidirectional?='<->' |
     '->'
   )
   target=FqnRef

--- a/packages/language-server/src/like-c4.langium
+++ b/packages/language-server/src/like-c4.langium
@@ -165,6 +165,7 @@ ExtendElementOrRelation:
       (
         dotKind=RelationKindDotRef |
         '-[' kind=[RelationshipKind] ']->' |
+        isBidirectional?='<->' |
         '->'
       )
       target=FqnRef
@@ -251,6 +252,7 @@ Relation<isExplicit>:
   (
     dotKind=RelationKindDotRef |
     '-[' kind=[RelationshipKind] ']->' |
+    isBidirectional?='<->' |
     '->'
   )
   target=FqnRef

--- a/packages/language-server/src/model/__tests__/model-builder-extend-relation.spec.ts
+++ b/packages/language-server/src/model/__tests__/model-builder-extend-relation.spec.ts
@@ -74,6 +74,132 @@ describe('Model Builder - Extend Relation', () => {
     expect(relation?.metadata).toBeUndefined()
   })
 
+  it('extends bidirectional relation from either endpoint order', async ({ expect }) => {
+    const { validate, buildLikeC4Model } = createTestServices()
+    await validate(`
+      specification {
+        element component
+      }
+      model {
+        component sourceNode
+        component targetNode
+        sourceNode <-> targetNode
+      }
+    `)
+    await validate(`
+      model {
+        extend targetNode <-> sourceNode {
+          metadata {
+            protocol 'sync'
+          }
+        }
+      }
+    `)
+
+    const model = await buildLikeC4Model()
+    const relations = values(model.$data.relations)
+    expect(relations).toHaveLength(1)
+    const relation = relations[0]
+    expect(relation?.isBidirectional).toBe(true)
+    expect(relation?.metadata).toEqual({
+      protocol: 'sync',
+    })
+  })
+
+  it('extends kinded bidirectional relation from either endpoint order', async ({ expect }) => {
+    const { validate, buildLikeC4Model } = createTestServices()
+    await validate(`
+      specification {
+        element component
+        relationship sync
+      }
+      model {
+        component sourceNode
+        component targetNode
+        sourceNode -[sync]<-> targetNode
+      }
+    `)
+    await validate(`
+      model {
+        extend targetNode -[sync]<-> sourceNode {
+          metadata {
+            protocol 'sync'
+          }
+        }
+      }
+    `)
+
+    const model = await buildLikeC4Model()
+    const relations = values(model.$data.relations)
+    expect(relations).toHaveLength(1)
+    const relation = relations[0]
+    expect(relation?.kind).toBe('sync')
+    expect(relation?.isBidirectional).toBe(true)
+    expect(relation?.metadata).toEqual({
+      protocol: 'sync',
+    })
+  })
+
+  it('does not extend directed relation with bidirectional matcher', async ({ expect }) => {
+    const { validate, buildLikeC4Model } = createTestServices()
+    await validate(`
+      specification {
+        element component
+      }
+      model {
+        component sourceNode
+        component targetNode
+        sourceNode -> targetNode
+      }
+    `)
+    await validate(`
+      model {
+        extend sourceNode <-> targetNode {
+          metadata {
+            protocol 'sync'
+          }
+        }
+      }
+    `)
+
+    const model = await buildLikeC4Model()
+    const relations = values(model.$data.relations)
+    expect(relations).toHaveLength(1)
+    const relation = relations[0]
+    expect(relation?.isBidirectional).toBeUndefined()
+    expect(relation?.metadata).toBeUndefined()
+  })
+
+  it('does not extend bidirectional relation with directed matcher', async ({ expect }) => {
+    const { validate, buildLikeC4Model } = createTestServices()
+    await validate(`
+      specification {
+        element component
+      }
+      model {
+        component sourceNode
+        component targetNode
+        sourceNode <-> targetNode
+      }
+    `)
+    await validate(`
+      model {
+        extend sourceNode -> targetNode {
+          metadata {
+            protocol 'sync'
+          }
+        }
+      }
+    `)
+
+    const model = await buildLikeC4Model()
+    const relations = values(model.$data.relations)
+    expect(relations).toHaveLength(1)
+    const relation = relations[0]
+    expect(relation?.isBidirectional).toBe(true)
+    expect(relation?.metadata).toBeUndefined()
+  })
+
   it('deduplicates links with same URL and title from multiple extends', async ({ expect }) => {
     const { validate, buildLikeC4Model } = createTestServices()
     await validate(`

--- a/packages/language-server/src/model/builder/MergedSpecification.ts
+++ b/packages/language-server/src/model/builder/MergedSpecification.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import type * as c4 from '@likec4/core'
 import { assignTagColors } from '@likec4/core/styles'
 import { exact, FqnRef } from '@likec4/core/types'
@@ -188,8 +195,14 @@ export class MergedSpecification {
     id,
     title,
     tags,
+    isBidirectional,
     ...model
   }: ParsedAstRelation): c4.Relationship | null => {
+    const bidirectionalTail = (relationship: c4.Relationship): c4.Relationship =>
+      isBidirectional && !relationship.tail
+        ? { ...relationship, tail: relationship.head ?? 'normal' }
+        : relationship
+
     if (isNonNullish(kind) && this.specs.relationships[kind]) {
       const { multiple: _multiple, tags: specTags, ...spec } = this.specs.relationships[kind]
       if (specTags && isNonEmptyArray(specTags)) {
@@ -200,28 +213,32 @@ export class MergedSpecification {
           ])
           : specTags
       }
-      return {
-        ...spec,
-        ...model,
+      return bidirectionalTail(
+        {
+          ...spec,
+          ...model,
+          ...(links && { links }),
+          ...(tags && { tags }),
+          // Relation has no own title -> inherit from specification (if any)
+          title: isEmptyish(title) ? (spec.title ?? title) : title,
+          source,
+          target,
+          kind,
+          id,
+        } satisfies c4.Relationship,
+      )
+    }
+    return bidirectionalTail(
+      {
         ...(links && { links }),
+        ...model,
         ...(tags && { tags }),
-        // Relation has no own title -> inherit from specification (if any)
-        title: isEmptyish(title) ? (spec.title ?? title) : title,
         source,
         target,
-        kind,
         id,
-      } satisfies c4.Relationship
-    }
-    return {
-      ...(links && { links }),
-      ...model,
-      ...(tags && { tags }),
-      title,
-      source,
-      target,
-      id,
-    } satisfies c4.Relationship
+        title,
+      } satisfies c4.Relationship,
+    )
   }
 
   /**

--- a/packages/language-server/src/model/builder/MergedSpecification.ts
+++ b/packages/language-server/src/model/builder/MergedSpecification.ts
@@ -198,9 +198,13 @@ export class MergedSpecification {
     isBidirectional,
     ...model
   }: ParsedAstRelation): c4.Relationship | null => {
-    const bidirectionalTail = (relationship: c4.Relationship): c4.Relationship =>
-      isBidirectional && !relationship.tail
-        ? { ...relationship, tail: relationship.head ?? 'normal' }
+    const bidirectionalRelationship = (relationship: c4.Relationship): c4.Relationship =>
+      isBidirectional
+        ? {
+          ...relationship,
+          isBidirectional,
+          tail: relationship.tail ?? relationship.head ?? 'normal',
+        }
         : relationship
 
     if (isNonNullish(kind) && this.specs.relationships[kind]) {
@@ -213,7 +217,7 @@ export class MergedSpecification {
           ])
           : specTags
       }
-      return bidirectionalTail(
+      return bidirectionalRelationship(
         {
           ...spec,
           ...model,
@@ -228,7 +232,7 @@ export class MergedSpecification {
         } satisfies c4.Relationship,
       )
     }
-    return bidirectionalTail(
+    return bidirectionalRelationship(
       {
         ...(links && { links }),
         ...model,

--- a/packages/language-server/src/model/builder/MergedSpecification.ts
+++ b/packages/language-server/src/model/builder/MergedSpecification.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import type * as c4 from '@likec4/core'
 import { assignTagColors } from '@likec4/core/styles'
 import { exact, FqnRef } from '@likec4/core/types'
@@ -186,26 +193,36 @@ export class MergedSpecification {
     kind,
     links,
     id,
+    isBidirectional,
     ...model
   }: ParsedAstRelation): c4.Relationship | null => {
+    const bidirectionalTail = (relationship: c4.Relationship): c4.Relationship =>
+      isBidirectional && !relationship.tail
+        ? { ...relationship, tail: relationship.head ?? 'normal' }
+        : relationship
+
     if (isNonNullish(kind) && this.specs.relationships[kind]) {
-      return {
-        ...this.specs.relationships[kind],
-        ...model,
+      return bidirectionalTail(
+        {
+          ...this.specs.relationships[kind],
+          ...model,
+          ...(links && { links }),
+          source,
+          target,
+          kind,
+          id,
+        } satisfies c4.Relationship,
+      )
+    }
+    return bidirectionalTail(
+      {
         ...(links && { links }),
+        ...model,
         source,
         target,
-        kind,
         id,
-      } satisfies c4.Relationship
-    }
-    return {
-      ...(links && { links }),
-      ...model,
-      source,
-      target,
-      id,
-    } satisfies c4.Relationship
+      } satisfies c4.Relationship,
+    )
   }
 
   /**

--- a/packages/language-server/src/model/builder/buildModel.ts
+++ b/packages/language-server/src/model/builder/buildModel.ts
@@ -46,8 +46,8 @@ import type {
 } from '../../ast'
 import { logger } from '../../logger'
 import type { LikeC4Services } from '../../module'
-import { stringHash } from '../../utils/stringHash'
 import type { Project } from '../../workspace/ProjectsManager'
+import { relationFingerprint } from '../relationFingerprint'
 import { MergedExtends } from './MergedExtends'
 import { MergedSpecification } from './MergedSpecification'
 
@@ -140,15 +140,8 @@ export function buildModelData(
       return true
     }),
     map(rel => {
-      // Apply relation extends by matching source, target, kind, and title
-      // Generate a stable match key for this relation
-      const matchKey = stringHash(
-        'extend-relation',
-        FqnRef.flatten(rel.source),
-        FqnRef.flatten(rel.target),
-        rel.kind ?? 'default',
-        rel.title ?? '',
-      )
+      // Apply relation extends by matching source, target, kind, title, and directionality.
+      const matchKey = relationFingerprint(rel)
 
       // Find all extends that match this relation
       const relExtends = relationExtends.filter(ext => ext.id === matchKey)

--- a/packages/language-server/src/model/parser/ModelParser.ts
+++ b/packages/language-server/src/model/parser/ModelParser.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 //
 // Copyright (c) 2023-2026 Denis Davydkov
-// Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
 
@@ -244,6 +244,7 @@ export function ModelParser<TBase extends WithExpressionV2>(B: TBase) {
         astPath,
         source,
         target,
+        isBidirectional: astNode.isBidirectional || undefined,
         title,
         metadata,
         kind,

--- a/packages/language-server/src/model/parser/ModelParser.ts
+++ b/packages/language-server/src/model/parser/ModelParser.ts
@@ -19,6 +19,7 @@ import {
   toRelationshipStyle,
 } from '../../ast'
 import { stringHash } from '../../utils/stringHash'
+import { relationFingerprint } from '../relationFingerprint'
 import type { WithExpressionV2 } from './FqnRefParser'
 
 export type WithModel = ReturnType<typeof ModelParser>
@@ -163,17 +164,18 @@ export function ModelParser<TBase extends WithExpressionV2>(B: TBase) {
       // Normalize title the same way as parseRelation does
       const { title = '' } = this.parseBaseProps({}, { title: astNode.title })
 
-      const id = stringHash(
-        'extend-relation',
-        FqnRef.flatten(source),
-        FqnRef.flatten(target),
-        kind ?? 'default',
+      const id = relationFingerprint({
+        source,
+        target,
+        kind,
         title,
-      ) as c4.RelationId
+        isBidirectional: astNode.isBidirectional || undefined,
+      }) as c4.RelationId
 
       return exact({
         id,
         astPath,
+        isBidirectional: astNode.isBidirectional || undefined,
         metadata,
         tags,
         links,

--- a/packages/language-server/src/model/relationFingerprint.ts
+++ b/packages/language-server/src/model/relationFingerprint.ts
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
+import type { Relationship } from '@likec4/core'
+import { FqnRef } from '@likec4/core/types'
+import { stringHash } from '../utils/stringHash'
+
+type FingerprintSource = {
+  source: Relationship['source']
+  target: Relationship['target']
+  kind?: Relationship['kind'] | undefined
+  title?: Relationship['title'] | undefined
+  isBidirectional?: Relationship['isBidirectional'] | undefined
+}
+
+export function relationFingerprint({
+  source,
+  target,
+  kind,
+  title,
+  isBidirectional,
+}: FingerprintSource): Relationship['id'] {
+  let sourceKey = FqnRef.flatten(source)
+  let targetKey = FqnRef.flatten(target)
+  if (isBidirectional && targetKey < sourceKey) {
+    const normalizedSource = targetKey
+    targetKey = sourceKey
+    sourceKey = normalizedSource
+  }
+  return stringHash(
+    'extend-relation',
+    sourceKey,
+    targetKey,
+    kind ?? 'default',
+    title ?? '',
+    isBidirectional ? 'bidirectional' : 'directed',
+  ) as Relationship['id']
+}

--- a/packages/language-server/src/validation/relation.ts
+++ b/packages/language-server/src/validation/relation.ts
@@ -5,13 +5,13 @@
 //
 // Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
 
-import { type ProjectId, type Relationship, FqnRef, isSameHierarchy } from '@likec4/core'
+import { type ProjectId, FqnRef, isSameHierarchy } from '@likec4/core'
 import { type ValidationCheck, AstUtils, DocumentState, WorkspaceCache } from 'langium'
 import { flatMap, map, pipe } from 'remeda'
 import { ast } from '../ast'
+import { relationFingerprint } from '../model/relationFingerprint'
 import type { LikeC4Services } from '../module'
 import { projectIdFrom, safeCall } from '../utils'
-import { stringHash } from '../utils/stringHash'
 import { tryOrLog } from './_shared'
 
 export const relationChecks = (services: LikeC4Services): ValidationCheck<ast.Relation> => {
@@ -74,23 +74,13 @@ export const extendRelationChecks = (services: LikeC4Services): ValidationCheck<
 
   const cache = new WorkspaceCache<ProjectId, Set<string>>(services.shared, DocumentState.Linked)
 
-  type KeySource = Pick<Relationship, 'source' | 'target' | 'kind' | 'title'>
-  const calcFingerprint = ({ source, target, kind, title }: KeySource) =>
-    stringHash(
-      'extend-relation',
-      FqnRef.flatten(source),
-      FqnRef.flatten(target),
-      kind ?? 'default',
-      title ?? '',
-    )
-
   function getProjectFingerprints(projectId: ProjectId): Set<string> {
     return cache.get(projectId, () =>
       new Set(
         pipe(
           services.shared.workspace.LangiumDocuments.projectDocuments(projectId).toArray(),
           flatMap(doc => doc.c4Relations ?? []),
-          map(rel => calcFingerprint(rel)),
+          map(rel => relationFingerprint(rel)),
         ),
       ))
   }
@@ -140,7 +130,13 @@ export const extendRelationChecks = (services: LikeC4Services): ValidationCheck<
     // Normalize title using the same parser helper
     const { title = '' } = parser.parseBaseProps({}, { title: el.title })
 
-    const extendKey = calcFingerprint({ source, target, kind, title })
+    const extendKey = relationFingerprint({
+      source,
+      target,
+      kind,
+      title,
+      isBidirectional: el.isBidirectional || undefined,
+    })
 
     const hasMatch = getProjectFingerprints(projectId).has(extendKey)
     if (!hasMatch) {

--- a/packages/language-server/src/validation/relation.ts
+++ b/packages/language-server/src/validation/relation.ts
@@ -140,9 +140,13 @@ export const extendRelationChecks = (services: LikeC4Services): ValidationCheck<
 
     const hasMatch = getProjectFingerprints(projectId).has(extendKey)
     if (!hasMatch) {
-      accept('warning', 'This extend does not match any relation (by source, kind, target, title)', {
-        node: el,
-      })
+      accept(
+        'warning',
+        'This extend does not match any relation (by source, kind, target, title, and directionality)',
+        {
+          node: el,
+        },
+      )
     }
   })
 }

--- a/skills/likec4-dsl/references/model.md
+++ b/skills/likec4-dsl/references/model.md
@@ -33,7 +33,7 @@ model {
     <-> TARGET "title"                      // bidirectional relationship
     -[REL_KIND]-> TARGET "title"            // typed directed relationship
     -[REL_KIND]<-> TARGET "title"           // typed bidirectional relationship
-    .REL_KIND -> TARGET "title"             // alternative typed syntax
+    .REL_KIND TARGET "title"                // alternative typed syntax
     SOURCE -> it                            // TARGET = current element (alias)
     this -> TARGET                          // SOURCE = current element (alias)
   }
@@ -55,7 +55,7 @@ model {
 
   // Extend existing relationship — anti-ambiguity matcher contract:
   // 1) SOURCE and TARGET always required.
-  // 2) Include KIND when typed relationships exist between source+target pair.
+  // 2) Include KIND when extending a typed relationship.
   // 3) Include TITLE when multiple relationships share SOURCE/TARGET/KIND.
   // Omitting KIND is WRONG (not merely ambiguous) when a typed relation exists.
   extend SOURCE -> TARGET { TAGS; PROPERTIES }

--- a/skills/likec4-dsl/references/model.md
+++ b/skills/likec4-dsl/references/model.md
@@ -53,15 +53,18 @@ model {
     NESTED_ELEMENTS | RELATIONSHIPS         // additional children or edges
   }
 
-  // Extend existing relationship — anti-ambiguity matcher contract:
+  // Extend existing relationship — matcher contract:
   // 1) SOURCE and TARGET always required.
   // 2) Include KIND when extending a typed relationship.
-  // 3) Include TITLE when multiple relationships share SOURCE/TARGET/KIND.
+  // 3) Include TITLE when extending a titled relationship.
   // Omitting KIND is WRONG (not merely ambiguous) when a typed relation exists.
-  extend SOURCE -> TARGET { TAGS; PROPERTIES }
-  extend SOURCE <-> TARGET { TAGS; PROPERTIES }
-  extend SOURCE -[REL_KIND]-> TARGET "title" { TAGS; PROPERTIES }
-  extend SOURCE -[REL_KIND]<-> TARGET "title" { TAGS; PROPERTIES }
+  // Omitting TITLE is WRONG when the matched relation is titled.
+  extend SOURCE -> TARGET { TAGS; PROPERTIES }                  // untitled directed relationship
+  extend SOURCE -> TARGET "title" { TAGS; PROPERTIES }          // titled directed relationship
+  extend SOURCE <-> TARGET { TAGS; PROPERTIES }                 // untitled bidirectional relationship
+  extend SOURCE <-> TARGET "title" { TAGS; PROPERTIES }         // titled bidirectional relationship
+  extend SOURCE -[REL_KIND]-> TARGET "title" { TAGS; PROPERTIES } // typed titled relationship
+  extend SOURCE -[REL_KIND]<-> TARGET "title" { TAGS; PROPERTIES } // typed titled bidirectional
 }
 ```
 

--- a/skills/likec4-dsl/references/model.md
+++ b/skills/likec4-dsl/references/model.md
@@ -3,6 +3,7 @@
 The `model` block defines the logical architecture: elements (systems, containers, components, actors) organized in a hierarchy, with relationships between them. Views project from this model.
 
 **Key rules:**
+
 - Elements MUST have a kind (from specification) and an identifier unique within their parent.
 - Relationships cannot exist directly between parent and child — move them outside the parent element.
 - `this` and `it` are aliases for the current element inside a nested relationship.
@@ -29,7 +30,9 @@ model {
     SOURCE -> TARGET                        // explicit, both sides named
     -> TARGET "title"                       // implicit source (current element)
     -> TARGET "title" { TAGS; PROPERTIES }
-    -[REL_KIND]-> TARGET "title"            // typed relationship
+    <-> TARGET "title"                      // bidirectional relationship
+    -[REL_KIND]-> TARGET "title"            // typed directed relationship
+    -[REL_KIND]<-> TARGET "title"           // typed bidirectional relationship
     .REL_KIND -> TARGET "title"             // alternative typed syntax
     SOURCE -> it                            // TARGET = current element (alias)
     this -> TARGET                          // SOURCE = current element (alias)
@@ -37,8 +40,10 @@ model {
 
   // Top-level relationships (outside element body): SOURCE is required
   SOURCE -> TARGET "title"
+  SOURCE <-> TARGET "title"
   SOURCE -> TARGET "title" { TAGS; PROPERTIES }
   SOURCE -[REL_KIND]-> TARGET
+  SOURCE -[REL_KIND]<-> TARGET
   SOURCE .REL_KIND TARGET
 
   // Extend existing element (by FQN, from any file)
@@ -54,7 +59,9 @@ model {
   // 3) Include TITLE when multiple relationships share SOURCE/TARGET/KIND.
   // Omitting KIND is WRONG (not merely ambiguous) when a typed relation exists.
   extend SOURCE -> TARGET { TAGS; PROPERTIES }
+  extend SOURCE <-> TARGET { TAGS; PROPERTIES }
   extend SOURCE -[REL_KIND]-> TARGET "title" { TAGS; PROPERTIES }
+  extend SOURCE -[REL_KIND]<-> TARGET "title" { TAGS; PROPERTIES }
 }
 ```
 
@@ -101,17 +108,17 @@ model {
 
 ## Element Properties
 
-| Property | Values |
-|---|---|
-| **title** | String, single line |
-| **description** | String, prefer Markdown. If > 150 chars, also add `summary`. |
-| **summary** | String, max 150 characters |
-| **technology** | String, no multi-line |
-| **style** | `style { ... }` — see `references/style-tokens-colors.md` |
-| **icon** | Shortcut for `style { icon ... }`, takes precedence over the style block |
-| **metadata** | `metadata { KEY VALUE }` — key is identifier format; value is string or array of strings |
-| **link** | `link URL "Optional title"` — repeatable; URL can be relative to the document |
-| **navigateTo** | ID of a dynamic view to navigate to on click |
+| Property        | Values                                                                                   |
+| --------------- | ---------------------------------------------------------------------------------------- |
+| **title**       | String, single line                                                                      |
+| **description** | String, prefer Markdown. If > 150 chars, also add `summary`.                             |
+| **summary**     | String, max 150 characters                                                               |
+| **technology**  | String, no multi-line                                                                    |
+| **style**       | `style { ... }` — see `references/style-tokens-colors.md`                                |
+| **icon**        | Shortcut for `style { icon ... }`, takes precedence over the style block                 |
+| **metadata**    | `metadata { KEY VALUE }` — key is identifier format; value is string or array of strings |
+| **link**        | `link URL "Optional title"` — repeatable; URL can be relative to the document            |
+| **navigateTo**  | ID of a dynamic view to navigate to on click                                             |
 
 ## Relationship Properties
 

--- a/skills/likec4-dsl/references/relationships-bidirectional.md
+++ b/skills/likec4-dsl/references/relationships-bidirectional.md
@@ -9,6 +9,9 @@ LikeC4 supports `<->` in two places with related but different meanings:
 
 ## Declaring relationships in the model
 
+The short snippets in this reference are fragments unless they include their own element declarations. Declare the
+referenced elements in your model before using them.
+
 Use `->` when one element initiates the relationship:
 
 ```likec4
@@ -47,7 +50,7 @@ model {
 }
 ```
 
-The relationship kind participates in extension matching. When extending a kinded relationship, include the kind in `extend`; also include the title when multiple relationships share the same endpoints and kind.
+The relationship kind participates in extension matching. When extending a kinded relationship, include the kind in `extend`; also include the title whenever the relationship is titled.
 
 ## Extending bidirectional relationships
 

--- a/skills/likec4-dsl/references/relationships-bidirectional.md
+++ b/skills/likec4-dsl/references/relationships-bidirectional.md
@@ -2,105 +2,140 @@
 
 ## Key distinction: model relationships vs. view predicates
 
-The `<->` operator is **only** a relationship-inclusion predicate used inside views.
-It is **not** valid in the `model { ... }` block — relationships are always declared
-with the directed `->` operator. Writing `frontend <-> backend` in the model throws a
-parsing error.
+LikeC4 supports `<->` in two places with related but different meanings:
 
-To represent a bidirectional/mutual interaction in the model, declare two directed
-relationships.
+- In `model { ... }`, `<->` declares one semantic bidirectional relationship.
+- In `views { ... }`, `A <-> B` is a binary predicate that includes relationships between two element sets in either direction.
 
-### Declaring relationships in the model (`->` only)
+## Declaring relationships in the model
 
-```likec4
-model {
-  frontend -> backend
-  backend -> database
-}
-```
-
-**Use `->` when:**
-
-- One element sends a request or message to another _without_ an explicit return path.
-- Example: frontend **calls** API (backend responds, but the call is primarily one-way from frontend's perspective).
-- Example: worker **processes** job from queue (job flows in one direction).
-- Example: service **publishes** event to event bus (unidirectional publish).
-
-### Modeling a bidirectional/mutual interaction
-
-There is no `<->` operator in the model. Declare two directed relationships when both
-elements actively drive the interaction:
+Use `->` when one element initiates the relationship:
 
 ```likec4
 model {
-  frontend -> backend "request"
-  backend -> frontend "response"
-
-  microservice1 -> microservice2 "RPC sync"
-  microservice2 -> microservice1 "RPC sync"
+  frontend -> api "REST call"
 }
 ```
 
-**Use two relationships when:**
-
-- Both elements actively communicate with each other _in both directions_ as part of the same logical interaction.
-- Example: service A and service B (service A calls B _and_ B calls A, not just a request-response pair).
-- Example: two databases synchronized (bidirectional replication).
-
-> Rendering note: by default LikeC4 merges two opposite relationships between the same
-> two elements into a single **bidirectional edge**. Set `multiple true` (in the
-> specification for a relationship kind, or per-view with `with { multiple true }`) to
-> render each direction as its own edge with its own label.
-
-### When a request-response is one-way
-
-In most REST APIs, even though the server responds, we still model it as a single `->` because:
+Use `<->` when both elements actively communicate as one mutual interaction:
 
 ```likec4
-frontend -> api "REST call"
+model {
+  frontend <-> backend "synchronizes"
+}
 ```
 
-The **relationship itself** is directional: frontend initiates. The response is implicit in the interaction model.
+Bidirectional model relationships render with arrows at both ends by default. Style can still override the rendered arrow tail, but the relationship remains semantically bidirectional for view predicates such as `include -> frontend`.
 
-**Exception:** If the system model emphasizes that _both elements drive interaction_, declare two relationships as shown above.
+## Kinded bidirectional relationships
 
-## Relationship predicates in views (`->` and `<->`)
-
-Inside views, `<->` _is_ a valid operator — the **"Any relationship"** predicate. It is
-**binary** (between two element sets) and matches relationships between the two sides in
-either direction. Because both endpoints are known, this predicate is also customizable
-(e.g. `cloud.* <-> amazon.* with { color red }`), unlike an open-ended `cloud.* ->`:
+Use `-[kind]->` for a directed kinded relationship and `-[kind]<->` for a bidirectional kinded relationship:
 
 ```likec4
-views {
-  view backend-detail of cloud.backend {
-    include *
-    include -> cloud.backend         // incoming: relationships pointing TO the scope
-    include cloud.backend ->         // outgoing: relationships FROM the scope
-    include -> cloud.backend ->      // both incoming and outgoing of the scope
-    include cloud.backend <-> cloud.frontend  // relationships between the two, either direction
+specification {
+  element component
+  relationship sync
+  relationship async
+}
+
+model {
+  component frontend
+  component backend
+
+  frontend -[async]-> backend "publishes events"
+  frontend -[sync]<-> backend "replicates state"
+}
+```
+
+The relationship kind participates in extension matching. If multiple relationships share the same source, target, and title, include the kind in `extend` to target the intended one.
+
+## Extending bidirectional relationships
+
+Bidirectional relationship extensions are matched by source, target, kind, title, and bidirectionality. Endpoint order is normalized for bidirectional relationships, so these match the same relationship:
+
+```likec4
+model {
+  frontend <-> backend "sync"
+
+  extend backend <-> frontend "sync" {
+    metadata {
+      protocol "websocket"
+    }
   }
 }
 ```
 
-- `-> X` — _inbound_ relationships from outside pointing into `X`.
-- `X ->` — _outbound_ relationships from `X` pointing out.
-- `-> X ->` — _both_ inbound and outbound relationships of `X`.
-- `A <-> B` — "Any relationship": relationships between `A` and `B` in **either** direction.
+Directed and bidirectional matchers are not interchangeable:
 
-> Note: there is no prefix `<-> X` predicate. To capture both directions of a single
-> scope, use `-> X ->`. The `<->` operator is always binary (`A <-> B`).
+```likec4
+model {
+  frontend -> backend "calls"
+  frontend <-> backend "sync"
+
+  // Matches only the directed relationship.
+  extend frontend -> backend "calls" { metadata { protocol "https" } }
+
+  // Matches only the bidirectional relationship.
+  extend frontend <-> backend "sync" { metadata { protocol "websocket" } }
+}
+```
+
+## When to use one bidirectional relation vs. two directed relations
+
+Use one `<->` relationship when the model has one mutual interaction:
+
+```likec4
+model {
+  primaryDb <-> replicaDb "replicates"
+}
+```
+
+Use two directed relationships when each direction has separate meaning, labels, technology, or lifecycle:
+
+```likec4
+model {
+  frontend -> backend "request"
+  backend -> frontend "callback"
+}
+```
+
+By default LikeC4 may merge opposite relationships into one bidirectional-looking edge. Set `multiple true` in the relationship kind or view style when each direction must render as a separate edge.
+
+## Relationship predicates in views
+
+Inside views, `<->` is the "any relationship between both sides" predicate. It is binary and matches relationships between the two sides in either direction:
+
+```likec4
+views {
+  view backend-detail of backend {
+    include *
+    include -> backend
+    include backend ->
+    include -> backend ->
+    include backend <-> frontend
+  }
+}
+```
+
+- `-> X` includes incoming relationships to `X`; semantic bidirectional relationships involving `X` are also included.
+- `X ->` includes outgoing relationships from `X`.
+- `-> X ->` includes both incoming and outgoing relationships of `X`.
+- `A <-> B` includes relationships between `A` and `B` in either direction.
+
+There is no prefix `<-> X` predicate. Use `-> X ->` when you need both incoming and outgoing relationships around one scope.
 
 ## Summary
 
-| Syntax              | Where          | Meaning                                                   |
-| ------------------- | -------------- | --------------------------------------------------------- |
-| `A -> B`            | model          | Directed relationship: A initiates/calls/sends to B       |
-| `A -> B` + `B -> A` | model          | Mutual interaction modeled as two directed relationships  |
-| `A <-> B`           | model          | ⛔️ Invalid — parsing error; `<->` is not a model operator |
-| `-> X` (in view)    | view predicate | Inbound: relationships pointing to X                      |
-| `X ->` (in view)    | view predicate | Outbound: relationships from X                            |
-| `-> X ->` (in view) | view predicate | Both inbound and outbound relationships of X              |
-| `A <-> B` (in view) | view predicate | Relationships between A and B in either direction         |
+| Syntax              | Where          | Meaning                                                     |
+| ------------------- | -------------- | ----------------------------------------------------------- |
+| `A -> B`            | model          | Directed relationship: A initiates/calls/sends to B         |
+| `A <-> B`           | model          | One bidirectional relationship between A and B              |
+| `A -[kind]-> B`     | model          | Directed relationship with relationship kind                |
+| `A -[kind]<-> B`    | model          | Bidirectional relationship with relationship kind           |
+| `A -> B` + `B -> A` | model          | Two separate directed relationships                         |
+| `-> X`              | view predicate | Incoming relationships to X, plus bidirectional involving X |
+| `X ->`              | view predicate | Outgoing relationships from X                               |
+| `-> X ->`           | view predicate | Both incoming and outgoing relationships of X               |
+| `A <-> B`           | view predicate | Relationships between A and B in either direction           |
 
-**When in doubt:** use `->` in the model for request-response patterns (REST, async jobs, events) and model mutual interactions as two directed relationships. Use `<->` only as a binary `A <-> B` predicate inside views.
+When in doubt, use `->` for request-response patterns where one side initiates. Use `<->` for one mutual interaction, and use two `->` relationships when each direction should be modeled independently.

--- a/skills/likec4-dsl/references/relationships-bidirectional.md
+++ b/skills/likec4-dsl/references/relationships-bidirectional.md
@@ -47,7 +47,7 @@ model {
 }
 ```
 
-The relationship kind participates in extension matching. If multiple relationships share the same source, target, and title, include the kind in `extend` to target the intended one.
+The relationship kind participates in extension matching. When extending a kinded relationship, include the kind in `extend`; also include the title when multiple relationships share the same endpoints and kind.
 
 ## Extending bidirectional relationships
 


### PR DESCRIPTION
Fixes #2927.

## Summary

- Allow model and extend relationships to use `<->` and `-[kind]<->`.
- Preserve bidirectional semantics through styling and relationship extension matching.
- Include and exclude bidirectional model relationships from either endpoint in view predicates.
- Keep mixed parallel connections precise: a reverse incoming bidirectional match no longer pulls in a same-direction directed relation by accident.
- Update public docs and the LikeC4 DSL skill references.

## Examples / screenshots

All screenshots below were generated from minimal LikeC4 projects on this branch with `likec4 gen dot` and Graphviz.

### 1. Model relationship with `<->`

```likec4
model {
  component frontend 'Frontend'
  component api 'API'

  frontend <-> api 'Bidirectional sync'
}

views {
  view bidirectional_model {
    include frontend -> api
  }
}
```

![Model relationship with <->](https://gist.githubusercontent.com/ckeller42/8dd132dd5be492abaccdeda6312fb069/raw/dad92040393e2d7022ff234c4e813ca2ec1d71a7/bidirectional_model.svg)

### 2. Incoming predicate from the declared target

```likec4
views {
  view incoming_api {
    include -> api
  }
}
```

The bidirectional `frontend <-> api` relationship is included when `api` is the incoming target.

![include -> api includes the bidirectional relationship](https://gist.githubusercontent.com/ckeller42/8dd132dd5be492abaccdeda6312fb069/raw/8ac5b32ef7c9b47aa99a57097c0343818bb1616c/incoming_api.svg)

### 3. Incoming predicate from the reverse endpoint

```likec4
views {
  view incoming_frontend {
    include -> frontend
  }
}
```

The same bidirectional relationship is also included when `frontend` is selected from the reverse endpoint.

![include -> frontend includes the same bidirectional relationship](https://gist.githubusercontent.com/ckeller42/8dd132dd5be492abaccdeda6312fb069/raw/dad92040393e2d7022ff234c4e813ca2ec1d71a7/incoming_frontend.svg)

### 4. Mixed parallel regression guard

```likec4
model {
  component a 'Component A'
  component b 'Component B'

  a <-> b 'Bidirectional sync'
  a -> b 'Directed command'
}

views {
  view mixed_reverse_incoming {
    include -> a
  }
}
```

This must include only `Bidirectional sync`; the parallel one-way `Directed command` must not be pulled in by the reverse bidirectional match.

![mixed parallel reverse incoming includes only the bidirectional relationship](https://gist.githubusercontent.com/ckeller42/8dd132dd5be492abaccdeda6312fb069/raw/603c3e96154e37dcaf55e14031ffd7e63cb924eb/mixed_reverse_incoming.svg)

## Testing

- `npx -y pnpm@11.5.1 generate`
- `npx -y pnpm@11.5.1 --filter @likec4/core test`
- `npx -y pnpm@11.5.1 --filter @likec4/language-server test`
- `npx -y pnpm@11.5.1 --filter @likec4/core typecheck`
- `npx -y pnpm@11.5.1 --filter @likec4/language-server typecheck`
- `npx -y pnpm@11.5.1 --filter @likec4/core test -- incoming-expr.spec.ts`
- `npx -y pnpm@11.5.1 exec dprint check apps/docs/src/content/docs/dsl/relationships.mdx packages/core/src/builder/Builder.deploymentModel.ts packages/core/src/builder/Builder.ts packages/core/src/builder/_types.ts packages/core/src/compute-view/element-view/__test__/incoming-expr.spec.ts packages/core/src/compute-view/element-view/predicates/_utils.ts skills/likec4-dsl/references/relationships-bidirectional.md`
- `npx -y pnpm@11.5.1 --filter likec4 cli gen dot -o /tmp/likec4-pr2949-mixed/dot /tmp/likec4-pr2949-mixed/src`
- `git diff --check`

## Checklist

- [ ] I've thoroughly read the latest [contribution guidelines](https://github.com/likec4/likec4/blob/main/CONTRIBUTING.md).
- [ ] I've rebased my branch onto `main` **before** creating this PR.
- [x] I've added tests to cover my changes (if applicable).
- [x] I've verified `pnpm typecheck` and `pnpm test`.
- [x] I've added [changesets](https://changesets-docs.vercel.app/) (you can use `/changeset-generator` SKILL).
- [x] My change requires documentation updates.
- [x] I've updated the documentation accordingly (or will do in follow-up PR).
