### PR TITLE
feat(cli): export view notation in screenshots

### DIFF
--- a/.changeset/export-image-description.md
+++ b/.changeset/export-image-description.md
@@ -1,0 +1,5 @@
+---
+'likec4': patch
+---
+
+Add `--description` to PNG and JPEG exports to include the view title and Markdown description in generated images.

--- a/.changeset/export-image-notation.md
+++ b/.changeset/export-image-notation.md
@@ -1,0 +1,5 @@
+---
+'likec4': patch
+---
+
+Add `--notation` to PNG and JPEG exports to include non-overlapping view notation in generated images.

--- a/apps/docs/src/content/docs/tooling/cli.mdx
+++ b/apps/docs/src/content/docs/tooling/cli.mdx
@@ -24,7 +24,7 @@ The `likec4` CLI is a tool for various operations and automation tasks, such as:
 
 - Start development server to preview diagrams (with hot-reload)
 - Build a static website for sharing and embedding diagrams
-- Export to PNG, JSON, Mermaid, Dot, D2, DrawIO
+- Export to PNG, JPEG, JSON, Mermaid, Dot, D2, DrawIO
 - Generate [source code artifacts](/tooling/code-generation/react/):
   - React components
   - Web Components
@@ -151,20 +151,23 @@ For example, this command can be used in CI to compare diagrams with ones from t
 
 ```sh
 likec4 export png -o ./assets
+likec4 export jpg -o ./assets --quality 90
 ```
 
 This command starts local web server and uses Playwright to take screenshots.  
 If you plan to use it in CI, refer to the [Playwright documentation](https://playwright.dev/docs/ci) for details
 or consider [LikeC4 GitHub Actions](/tooling/github)
 
+Use `likec4 export jpg` to export JPEG files. It supports the same screenshot options, plus `--quality`.
+
 :::note
-Exporting to PNG requires Playwright.  
+Exporting to PNG or JPEG requires Playwright.
 You will be prompted with a command to install if it's not found.
 :::
 
 | Option                  | Description                                                                                                   |
 | ----------------------- | ------------------------------------------------------------------------------------------------------------- |
-| `--outdir, -o`          | Output directory for PNG files; if not specified, images are saved next to sources. `--output` is accepted as alias for compatibility. |
+| `--outdir, -o`          | Output directory for PNG/JPEG files; if not specified, images are saved next to sources. `--output` is accepted as alias for compatibility. |
 | `--project`             | select LikeC4 project to export from by name (e.g. "my-project") or by path<br/>If not specified, exports all |
 | `--theme`               | color-scheme to use, "light" (default), "dark"                                                                |
 | `--dark`                | use dark theme, shortcut for --theme=dark                                                                     |
@@ -173,11 +176,13 @@ You will be prompted with a command to install if it's not found.
 | `--seq, --sequence`     | use sequence layout for dynamic views                                                                         |
 | `--flat, --flatten`     | Flatten all images in outdir, ignoring source structure                                                       |
 | `-f, --filter`          | include views with ids matching given patterns<br/>(multiple patterns are combined with OR)                   |
+| `--quality, -q`         | JPEG quality from 1 to 100 (default is 80); only used by `likec4 export jpg`                                  |
 | `-i, --ignore`          | continue if export fails for some views                                                                       |
 | `-t, --timeout`         | timeout for playwright in seconds, default is 15                                                              |
 | `--max-attempts`        | max attempts to export failing view, 1 means no retry (default is 3)                                          |
 | `--server-url`          | use this url instead of starting new likec4 server                                                            |
 | `--chromium-sandbox`    | enable chromium sandbox (see Playwright docs)                                                                 |
+| `--notation`            | include view notation in exported PNG/JPEG files                                                              |
 
 ### Export to JSON
 

--- a/apps/docs/src/content/docs/tooling/cli.mdx
+++ b/apps/docs/src/content/docs/tooling/cli.mdx
@@ -183,6 +183,7 @@ You will be prompted with a command to install if it's not found.
 | `--server-url`          | use this url instead of starting new likec4 server                                                            |
 | `--chromium-sandbox`    | enable chromium sandbox (see Playwright docs)                                                                 |
 | `--notation`            | include view notation in exported PNG/JPEG files                                                              |
+| `--description`         | include the view title and Markdown description in exported PNG/JPEG files                                     |
 
 ### Export to JSON
 

--- a/packages/likec4-spa/src/pages/ExportPage.tsx
+++ b/packages/likec4-spa/src/pages/ExportPage.tsx
@@ -5,16 +5,25 @@
 //
 // Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
 
-import type { LayoutedView, NodeNotation } from '@likec4/core'
+import { type LayoutedView, type NodeNotation, type RichTextOrEmpty, RichText } from '@likec4/core'
 import { LikeC4Diagram, pickViewBounds, useLikeC4Styles } from '@likec4/diagram'
-import { ElementShape } from '@likec4/diagram/custom'
+import { ElementShape, Markdown } from '@likec4/diagram/custom'
 import { Box } from '@likec4/styles/jsx'
 import { LoadingOverlay } from '@mantine/core'
 import { useSearch } from '@tanstack/react-router'
 import type { CSSProperties } from 'react'
 import { useRef } from 'react'
 import { useCurrentView, useTransparentBackground } from '../hooks'
-import { computeExportPageLayout, EXPORT_NOTATION_ITEM_HEIGHT } from './export-layout'
+import {
+  computeExportPageLayout,
+  EXPORT_DESCRIPTION_BODY_TOP_GAP,
+  EXPORT_DESCRIPTION_BOTTOM_PADDING,
+  EXPORT_DESCRIPTION_INSET,
+  EXPORT_DESCRIPTION_TITLE_LINE_HEIGHT,
+  EXPORT_DESCRIPTION_TOP_PADDING,
+  EXPORT_NOTATION_ITEM_HEIGHT,
+} from './export-layout'
+import { isExportSearchFlagEnabled } from './export-page-params'
 
 type PaletteCssVars =
   & CSSProperties
@@ -23,6 +32,9 @@ type PaletteCssVars =
     string
   >
 
+/**
+ * Downloads a generated object URL or data URL through a temporary browser link.
+ */
 function triggerDownload(url: string, filename: string) {
   const link = document.createElement('a')
   link.setAttribute('download', filename)
@@ -38,6 +50,9 @@ function triggerDownload(url: string, filename: string) {
   )
 }
 
+/**
+ * Converts the export viewport into a PNG file and starts a browser download.
+ */
 async function downloadAsPng({
   pngFilename,
   viewport,
@@ -65,6 +80,9 @@ async function downloadAsPng({
   }
 }
 
+/**
+ * Converts the export viewport into a JPEG file and starts a browser download.
+ */
 async function downloadAsJpeg({
   filename,
   viewport,
@@ -92,6 +110,9 @@ async function downloadAsJpeg({
   }
 }
 
+/**
+ * Renders the single-view export page used by browser downloads and CLI screenshots.
+ */
 export function ExportPage() {
   const [diagram] = useCurrentView()
   const { format } = useSearch({ strict: false })
@@ -106,10 +127,14 @@ export function ExportPage() {
   return <GuardedExportPage diagram={diagram} isJpeg={isJpeg} />
 }
 
+/**
+ * Renders the measured export viewport for a loaded diagram.
+ */
 function GuardedExportPage({ diagram, isJpeg }: { diagram: LayoutedView; isJpeg: boolean }) {
   const {
     padding = 20,
     download = false,
+    description = false,
     quality,
     dynamic,
     notation = false,
@@ -123,11 +148,15 @@ function GuardedExportPage({ diagram, isJpeg }: { diagram: LayoutedView; isJpeg:
   const downloadedRef = useRef(false)
 
   const bounds = pickViewBounds(diagram, dynamic)
+  const viewDescription = RichText.from(diagram.description)
+  const showDescription = isExportSearchFlagEnabled(description) && viewDescription.nonEmpty
+  const viewTitle = diagram.title ?? diagram.id
   const notationEntries = diagram.notation?.nodes ?? []
-  const showNotation = notation === true && notationEntries.length > 0
+  const showNotation = isExportSearchFlagEnabled(notation) && notationEntries.length > 0
   const layout = computeExportPageLayout({
     bounds,
     padding,
+    description: showDescription ? { title: viewTitle, text: viewDescription.text } : null,
     notationEntries: showNotation ? notationEntries.length : 0,
   })
 
@@ -182,13 +211,13 @@ function GuardedExportPage({ diagram, isJpeg }: { diagram: LayoutedView; isJpeg:
         data-testid="export-diagram-area"
         css={{
           position: 'absolute',
-          top: '0',
-          left: '0',
           overflow: 'hidden',
         }}
         style={{
+          top: layout.diagram.top,
+          left: layout.diagram.left,
           width: layout.diagram.width,
-          height: layout.height,
+          height: layout.height - layout.diagram.top,
         }}>
         <LikeC4Diagram
           view={diagram}
@@ -234,6 +263,13 @@ function GuardedExportPage({ diagram, isJpeg }: { diagram: LayoutedView; isJpeg:
           }}
         />
       </Box>
+      {layout.description && (
+        <ExportDescriptionPanel
+          title={viewTitle}
+          description={viewDescription}
+          layout={layout.description}
+        />
+      )}
       {layout.notation && (
         <ExportNotationPanel
           entries={notationEntries}
@@ -244,6 +280,72 @@ function GuardedExportPage({ diagram, isJpeg }: { diagram: LayoutedView; isJpeg:
   )
 }
 
+/**
+ * Renders the optional Markdown description panel above the exported diagram.
+ */
+function ExportDescriptionPanel({
+  title,
+  description,
+  layout,
+}: Readonly<{
+  title: string
+  description: RichTextOrEmpty
+  layout: NonNullable<ReturnType<typeof computeExportPageLayout>['description']>
+}>) {
+  const panelStyle: CSSProperties = {
+    ...layout,
+    position: 'absolute',
+    boxSizing: 'border-box',
+    overflow: 'hidden',
+    border: '1px solid var(--mantine-color-default-border)',
+    borderRadius: 6,
+    background: 'var(--mantine-color-body)',
+    boxShadow: '0 4px 18px rgb(0 0 0 / 14%)',
+    color: 'var(--mantine-color-text)',
+  }
+  const titleStyle: CSSProperties = {
+    paddingTop: EXPORT_DESCRIPTION_TOP_PADDING,
+    paddingBottom: EXPORT_DESCRIPTION_BODY_TOP_GAP,
+    paddingLeft: EXPORT_DESCRIPTION_INSET,
+    paddingRight: EXPORT_DESCRIPTION_INSET,
+    fontSize: 15,
+    fontWeight: 600,
+    lineHeight: `${EXPORT_DESCRIPTION_TITLE_LINE_HEIGHT}px`,
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+  }
+  const descriptionStyle: CSSProperties = {
+    maxHeight: layout.height
+      - EXPORT_DESCRIPTION_TOP_PADDING
+      - EXPORT_DESCRIPTION_TITLE_LINE_HEIGHT
+      - EXPORT_DESCRIPTION_BODY_TOP_GAP
+      - EXPORT_DESCRIPTION_BOTTOM_PADDING,
+    overflow: 'hidden',
+    paddingLeft: EXPORT_DESCRIPTION_INSET,
+    paddingRight: EXPORT_DESCRIPTION_INSET,
+    paddingBottom: EXPORT_DESCRIPTION_BOTTOM_PADDING,
+  }
+
+  return (
+    <Box
+      data-testid="export-description"
+      style={panelStyle}>
+      <Box style={titleStyle}>{title}</Box>
+      <Markdown
+        value={description}
+        hideIfEmpty
+        fontSize="sm"
+        textScale={0.9}
+        style={descriptionStyle}
+      />
+    </Box>
+  )
+}
+
+/**
+ * Renders the optional notation panel next to the exported diagram.
+ */
 function ExportNotationPanel({
   entries,
   layout,
@@ -288,6 +390,9 @@ function ExportNotationPanel({
   )
 }
 
+/**
+ * Renders one notation entry with its representative element shape and labels.
+ */
 function ExportNotationItem({ entry }: Readonly<{ entry: NodeNotation }>) {
   const styles = useLikeC4Styles()
   const elementColors = styles.colors(entry.color).elements

--- a/packages/likec4-spa/src/pages/ExportPage.tsx
+++ b/packages/likec4-spa/src/pages/ExportPage.tsx
@@ -1,10 +1,27 @@
-import type { LayoutedView } from '@likec4/core'
-import { LikeC4Diagram, pickViewBounds } from '@likec4/diagram'
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
+import type { LayoutedView, NodeNotation } from '@likec4/core'
+import { LikeC4Diagram, pickViewBounds, useLikeC4Styles } from '@likec4/diagram'
+import { ElementShape } from '@likec4/diagram/custom'
 import { Box } from '@likec4/styles/jsx'
 import { LoadingOverlay } from '@mantine/core'
 import { useSearch } from '@tanstack/react-router'
+import type { CSSProperties } from 'react'
 import { useRef } from 'react'
 import { useCurrentView, useTransparentBackground } from '../hooks'
+import { computeExportPageLayout, EXPORT_NOTATION_ITEM_HEIGHT } from './export-layout'
+
+type PaletteCssVars =
+  & CSSProperties
+  & Record<
+    '--likec4-palette-fill' | '--likec4-palette-stroke' | '--likec4-palette-hiContrast' | '--likec4-palette-loContrast',
+    string
+  >
 
 function triggerDownload(url: string, filename: string) {
   const link = document.createElement('a')
@@ -95,6 +112,7 @@ function GuardedExportPage({ diagram, isJpeg }: { diagram: LayoutedView; isJpeg:
     download = false,
     quality,
     dynamic,
+    notation = false,
   } = useSearch({
     strict: false,
   })
@@ -105,6 +123,13 @@ function GuardedExportPage({ diagram, isJpeg }: { diagram: LayoutedView; isJpeg:
   const downloadedRef = useRef(false)
 
   const bounds = pickViewBounds(diagram, dynamic)
+  const notationEntries = diagram.notation?.nodes ?? []
+  const showNotation = notation === true && notationEntries.length > 0
+  const layout = computeExportPageLayout({
+    bounds,
+    padding,
+    notationEntries: showNotation ? notationEntries.length : 0,
+  })
 
   const downloadDiagram = () => {
     const viewport = viewportRef.current
@@ -130,11 +155,6 @@ function GuardedExportPage({ diagram, isJpeg }: { diagram: LayoutedView; isJpeg:
     }
   }
 
-  // @see https://github.com/likec4/likec4/issues/1857
-  const extraPadding = 16
-  const width = bounds.width + padding * 2 + extraPadding
-  const height = bounds.height + padding * 2 + extraPadding
-
   return (
     <Box
       ref={viewportRef}
@@ -151,56 +171,211 @@ function GuardedExportPage({ diagram, isJpeg }: { diagram: LayoutedView; isJpeg:
       style={{
         marginRight: 'auto',
         marginBottom: 'auto',
-        minWidth: width,
-        width: width,
-        minHeight: height,
-        height: height,
+        minWidth: layout.width,
+        width: layout.width,
+        minHeight: layout.height,
+        height: layout.height,
         background: isJpeg ? 'var(--mantine-color-body)' : 'transparent',
       }}>
       {download && <LoadingOverlay ref={loadingOverlayRef} visible />}
-      <LikeC4Diagram
-        view={diagram}
-        fitView={false}
-        fitViewPadding={{
-          top: '0px',
-          bottom: '0px',
-          left: '0px',
-          right: '0px',
+      <Box
+        data-testid="export-diagram-area"
+        css={{
+          position: 'absolute',
+          top: '0',
+          left: '0',
+          overflow: 'hidden',
         }}
-        background={isJpeg ? 'solid' : 'transparent'}
-        reduceGraphics={false}
-        dynamicViewVariant={dynamic}
-        className={'likec4-static-view'}
-        pannable={false}
-        zoomable={false}
-        controls={false}
-        enableNotations={false}
-        enableElementDetails={false}
-        enableRelationshipDetails={false}
-        enableRelationshipBrowser={false}
-        enableDynamicViewWalkthrough={false}
-        enableFocusMode={false}
-        enableSearch={false}
-        nodesSelectable={false}
-        enableElementTags={false}
-        onInitialized={() => {
-          if (!viewportRef.current) {
-            console.error('viewportRef.current is null')
-            return
-          }
-          const x = Math.round(-bounds.x + padding)
-          const y = Math.round(-bounds.y + padding)
+        style={{
+          width: layout.diagram.width,
+          height: layout.height,
+        }}>
+        <LikeC4Diagram
+          view={diagram}
+          fitView={false}
+          fitViewPadding={{
+            top: '0px',
+            bottom: '0px',
+            left: '0px',
+            right: '0px',
+          }}
+          background={isJpeg ? 'solid' : 'transparent'}
+          reduceGraphics={false}
+          dynamicViewVariant={dynamic}
+          className={'likec4-static-view'}
+          pannable={false}
+          zoomable={false}
+          controls={false}
+          enableNotations={false}
+          enableElementDetails={false}
+          enableRelationshipDetails={false}
+          enableRelationshipBrowser={false}
+          enableDynamicViewWalkthrough={false}
+          enableFocusMode={false}
+          enableSearch={false}
+          nodesSelectable={false}
+          enableElementTags={false}
+          onInitialized={() => {
+            if (!viewportRef.current) {
+              console.error('viewportRef.current is null')
+              return
+            }
+            const x = Math.round(-bounds.x + padding)
+            const y = Math.round(-bounds.y + padding)
 
-          const viewports = [...viewportRef.current.querySelectorAll<HTMLDivElement>('.react-flow__viewport')]
-          viewports.forEach((el) => {
-            el.style.transform = 'translate(' + x + 'px, ' + y + 'px)'
-          })
+            const viewports = [...viewportRef.current.querySelectorAll<HTMLDivElement>('.react-flow__viewport')]
+            viewports.forEach((el) => {
+              el.style.transform = 'translate(' + x + 'px, ' + y + 'px)'
+            })
 
-          if (download) {
-            window.setTimeout(downloadDiagram, 500)
-          }
-        }}
-      />
+            if (download) {
+              window.setTimeout(downloadDiagram, 500)
+            }
+          }}
+        />
+      </Box>
+      {layout.notation && (
+        <ExportNotationPanel
+          entries={notationEntries}
+          layout={layout.notation}
+        />
+      )}
+    </Box>
+  )
+}
+
+function ExportNotationPanel({
+  entries,
+  layout,
+}: Readonly<{
+  entries: readonly NodeNotation[]
+  layout: NonNullable<ReturnType<typeof computeExportPageLayout>['notation']>
+}>) {
+  const panelStyle: CSSProperties = {
+    ...layout,
+    position: 'absolute',
+    boxSizing: 'border-box',
+    overflow: 'hidden',
+    border: '1px solid var(--mantine-color-default-border)',
+    borderRadius: 6,
+    background: 'var(--mantine-color-body)',
+    boxShadow: '0 4px 18px rgb(0 0 0 / 14%)',
+    color: 'var(--mantine-color-text)',
+  }
+  const headerStyle: CSSProperties = {
+    height: 36,
+    display: 'flex',
+    alignItems: 'center',
+    paddingLeft: 12,
+    paddingRight: 12,
+    fontSize: 13,
+    fontWeight: 600,
+    borderBottom: '1px solid var(--mantine-color-default-border)',
+  }
+
+  return (
+    <Box
+      data-testid="export-notation"
+      style={panelStyle}>
+      <Box style={headerStyle}>Notation</Box>
+      <Box
+        style={{
+          padding: 12,
+        }}>
+        {entries.map((entry, index) => <ExportNotationItem key={`${entry.title}-${index}`} entry={entry} />)}
+      </Box>
+    </Box>
+  )
+}
+
+function ExportNotationItem({ entry }: Readonly<{ entry: NodeNotation }>) {
+  const styles = useLikeC4Styles()
+  const elementColors = styles.colors(entry.color).elements
+  const colorVars: PaletteCssVars = {
+    '--likec4-palette-fill': elementColors.fill,
+    '--likec4-palette-stroke': elementColors.stroke,
+    '--likec4-palette-hiContrast': elementColors.hiContrast,
+    '--likec4-palette-loContrast': elementColors.loContrast,
+  }
+  const itemStyle: CSSProperties = {
+    ...colorVars,
+    display: 'grid',
+    gridTemplateColumns: '64px 1fr',
+    columnGap: 10,
+    alignItems: 'center',
+    height: EXPORT_NOTATION_ITEM_HEIGHT,
+    overflow: 'hidden',
+  }
+  const kindsStyle: CSSProperties = {
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: 3,
+    marginBottom: 5,
+    maxHeight: 31,
+    overflow: 'hidden',
+  }
+  const kindStyle: CSSProperties = {
+    display: 'inline-flex',
+    alignItems: 'center',
+    height: 14,
+    maxWidth: '100%',
+    paddingLeft: 4,
+    paddingRight: 4,
+    borderRadius: 2,
+    background: 'var(--likec4-palette-fill)',
+    color: 'var(--likec4-palette-hiContrast)',
+    fontSize: 9.5,
+    fontWeight: 500,
+    lineHeight: 1,
+    textTransform: 'lowercase',
+    whiteSpace: 'nowrap',
+  }
+  const titleStyle: CSSProperties = {
+    overflow: 'hidden',
+    display: '-webkit-box',
+    WebkitBoxOrient: 'vertical',
+    WebkitLineClamp: 2,
+    fontSize: 13,
+    fontWeight: 500,
+    lineHeight: 1.2,
+  }
+
+  return (
+    <Box
+      data-likec4-color={entry.color}
+      style={itemStyle}>
+      <Box
+        style={{
+          position: 'relative',
+          width: 56,
+          height: 38,
+        }}>
+        <ElementShape
+          data={{
+            shape: entry.shape,
+            width: 300,
+            height: 200,
+          }}
+          showSelectionOutline={false}
+        />
+      </Box>
+      <Box
+        css={{
+          minWidth: 0,
+        }}>
+        <Box
+          style={kindsStyle}>
+          {entry.kinds.map(kind => (
+            <Box
+              key={kind}
+              as="span"
+              style={kindStyle}>
+              {kind}
+            </Box>
+          ))}
+        </Box>
+        <Box style={titleStyle}>{entry.title}</Box>
+      </Box>
     </Box>
   )
 }

--- a/packages/likec4-spa/src/pages/export-layout.spec.ts
+++ b/packages/likec4-spa/src/pages/export-layout.spec.ts
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import { describe, expect, it } from 'vitest'
+import {
+  computeExportPageLayout,
+  EXPORT_EXTRA_PADDING,
+  EXPORT_NOTATION_GAP,
+  EXPORT_NOTATION_WIDTH,
+  exportNotationHeight,
+} from './export-layout'
+
+describe('computeExportPageLayout', () => {
+  const bounds = {
+    x: -100,
+    y: 20,
+    width: 640,
+    height: 360,
+  }
+
+  it('keeps dimensions unchanged when there is no notation', () => {
+    const layout = computeExportPageLayout({
+      bounds,
+      padding: 20,
+      notationEntries: 0,
+    })
+
+    expect(layout).toEqual({
+      width: bounds.width + 20 * 2 + EXPORT_EXTRA_PADDING,
+      height: bounds.height + 20 * 2 + EXPORT_EXTRA_PADDING,
+      diagram: {
+        width: bounds.width + 20 * 2 + EXPORT_EXTRA_PADDING,
+        height: bounds.height + 20 * 2 + EXPORT_EXTRA_PADDING,
+      },
+      notation: null,
+    })
+  })
+
+  it('reserves a right-side notation column outside the diagram area', () => {
+    const layout = computeExportPageLayout({
+      bounds,
+      padding: 20,
+      notationEntries: 2,
+    })
+
+    expect(layout.notation).toEqual({
+      left: layout.diagram.width + EXPORT_NOTATION_GAP,
+      top: 20,
+      width: EXPORT_NOTATION_WIDTH,
+      height: exportNotationHeight(2),
+    })
+    expect(layout.width).toBe(layout.diagram.width + EXPORT_NOTATION_GAP + EXPORT_NOTATION_WIDTH + 20)
+    expect(layout.notation!.left).toBeGreaterThan(layout.diagram.width)
+  })
+
+  it('grows export height when the notation is taller than the diagram', () => {
+    const layout = computeExportPageLayout({
+      bounds: {
+        ...bounds,
+        height: 50,
+      },
+      padding: 20,
+      notationEntries: 5,
+    })
+
+    expect(layout.height).toBe(exportNotationHeight(5) + 20 * 2)
+    expect(layout.height).toBeGreaterThan(layout.diagram.height)
+  })
+})

--- a/packages/likec4-spa/src/pages/export-layout.spec.ts
+++ b/packages/likec4-spa/src/pages/export-layout.spec.ts
@@ -5,9 +5,13 @@
 import { describe, expect, it } from 'vitest'
 import {
   computeExportPageLayout,
+  EXPORT_DESCRIPTION_GAP,
+  EXPORT_DESCRIPTION_MAX_HEIGHT,
+  EXPORT_DESCRIPTION_MIN_HEIGHT,
   EXPORT_EXTRA_PADDING,
   EXPORT_NOTATION_GAP,
   EXPORT_NOTATION_WIDTH,
+  exportDescriptionHeight,
   exportNotationHeight,
 } from './export-layout'
 
@@ -23,6 +27,7 @@ describe('computeExportPageLayout', () => {
     const layout = computeExportPageLayout({
       bounds,
       padding: 20,
+      description: null,
       notationEntries: 0,
     })
 
@@ -30,17 +35,76 @@ describe('computeExportPageLayout', () => {
       width: bounds.width + 20 * 2 + EXPORT_EXTRA_PADDING,
       height: bounds.height + 20 * 2 + EXPORT_EXTRA_PADDING,
       diagram: {
+        left: 0,
+        top: 0,
         width: bounds.width + 20 * 2 + EXPORT_EXTRA_PADDING,
         height: bounds.height + 20 * 2 + EXPORT_EXTRA_PADDING,
       },
+      description: null,
       notation: null,
     })
+  })
+
+  it('reserves a top description banner outside the diagram area', () => {
+    const description = {
+      title: 'Cloud System',
+      text: 'The overview of the cloud system',
+    }
+    const layout = computeExportPageLayout({
+      bounds,
+      padding: 20,
+      description,
+      notationEntries: 0,
+    })
+    const descriptionHeight = exportDescriptionHeight({
+      ...description,
+      width: layout.diagram.width,
+    })
+
+    expect(layout.description).toEqual({
+      left: 0,
+      top: 0,
+      width: layout.diagram.width,
+      height: descriptionHeight,
+    })
+    expect(descriptionHeight).toBe(EXPORT_DESCRIPTION_MIN_HEIGHT)
+    expect(layout.diagram.top).toBe(descriptionHeight + EXPORT_DESCRIPTION_GAP)
+    expect(layout.height).toBe(layout.diagram.top + layout.diagram.height)
+  })
+
+  it('grows and caps the description banner based on content length', () => {
+    const layout = computeExportPageLayout({
+      bounds: {
+        ...bounds,
+        width: 160,
+      },
+      padding: 20,
+      description: {
+        title: 'Long description',
+        text: Array.from({ length: 20 }, () => 'This sentence should wrap into several rendered lines.').join(' '),
+      },
+      notationEntries: 0,
+    })
+
+    expect(layout.description!.height).toBe(EXPORT_DESCRIPTION_MAX_HEIGHT)
+    expect(layout.diagram.top).toBe(EXPORT_DESCRIPTION_MAX_HEIGHT + EXPORT_DESCRIPTION_GAP)
+  })
+
+  it('treats long titles as a single ellipsized line', () => {
+    const descriptionHeight = exportDescriptionHeight({
+      title: 'A very long title that is intentionally much wider than the exported image and must be ellipsized',
+      text: 'Brief',
+      width: 120,
+    })
+
+    expect(descriptionHeight).toBe(EXPORT_DESCRIPTION_MIN_HEIGHT)
   })
 
   it('reserves a right-side notation column outside the diagram area', () => {
     const layout = computeExportPageLayout({
       bounds,
       padding: 20,
+      description: null,
       notationEntries: 2,
     })
 
@@ -54,6 +118,35 @@ describe('computeExportPageLayout', () => {
     expect(layout.notation!.left).toBeGreaterThan(layout.diagram.width)
   })
 
+  it('places notation below the description banner when both are enabled', () => {
+    const description = {
+      title: 'Checkout Service',
+      text: 'Retrieves user cart, prepares order and orchestrates payments, shipping and notification.',
+    }
+    const layout = computeExportPageLayout({
+      bounds,
+      padding: 20,
+      description,
+      notationEntries: 2,
+    })
+
+    const descriptionHeight = exportDescriptionHeight({
+      ...description,
+      width: layout.width,
+    })
+
+    expect(layout.description).toMatchObject({
+      top: 0,
+      width: layout.width,
+      height: descriptionHeight,
+    })
+    expect(layout.diagram.top).toBe(descriptionHeight + EXPORT_DESCRIPTION_GAP)
+    expect(layout.notation).toMatchObject({
+      top: layout.diagram.top + 20,
+      left: layout.diagram.width + EXPORT_NOTATION_GAP,
+    })
+  })
+
   it('grows export height when the notation is taller than the diagram', () => {
     const layout = computeExportPageLayout({
       bounds: {
@@ -61,6 +154,7 @@ describe('computeExportPageLayout', () => {
         height: 50,
       },
       padding: 20,
+      description: null,
       notationEntries: 5,
     })
 

--- a/packages/likec4-spa/src/pages/export-layout.ts
+++ b/packages/likec4-spa/src/pages/export-layout.ts
@@ -5,19 +5,49 @@
 import type { BBox } from '@likec4/core/types'
 
 export const EXPORT_EXTRA_PADDING = 16
+export const EXPORT_DESCRIPTION_GAP = 16
+export const EXPORT_DESCRIPTION_INSET = 16
+export const EXPORT_DESCRIPTION_MIN_HEIGHT = 84
+export const EXPORT_DESCRIPTION_MAX_HEIGHT = 240
 export const EXPORT_NOTATION_GAP = 24
 export const EXPORT_NOTATION_WIDTH = 320
 export const EXPORT_NOTATION_INSET = 12
 export const EXPORT_NOTATION_HEADER_HEIGHT = 36
 export const EXPORT_NOTATION_ITEM_HEIGHT = 68
 
+export const EXPORT_DESCRIPTION_TITLE_LINE_HEIGHT = 20
+const EXPORT_DESCRIPTION_BODY_LINE_HEIGHT = 19
+export const EXPORT_DESCRIPTION_TOP_PADDING = 10
+export const EXPORT_DESCRIPTION_BODY_TOP_GAP = 4
+export const EXPORT_DESCRIPTION_BOTTOM_PADDING = 16
+const EXPORT_DESCRIPTION_AVERAGE_CHARACTER_WIDTH = 7.5
+
+/**
+ * Text content shown in the optional description panel of an exported image.
+ */
+export type ExportDescriptionContent = {
+  title: string
+  text: string
+}
+
+/**
+ * Pixel bounds reserved for each area of the export canvas.
+ */
 export type ExportPageLayout = {
   width: number
   height: number
   diagram: {
+    left: number
+    top: number
     width: number
     height: number
   }
+  description: {
+    left: number
+    top: number
+    width: number
+    height: number
+  } | null
   notation: {
     left: number
     top: number
@@ -26,43 +56,118 @@ export type ExportPageLayout = {
   } | null
 }
 
+/**
+ * Calculates the reserved height for the notation panel in exported images.
+ */
 export function exportNotationHeight(entries: number): number {
   return EXPORT_NOTATION_INSET * 2 + EXPORT_NOTATION_HEADER_HEIGHT + entries * EXPORT_NOTATION_ITEM_HEIGHT
 }
 
+/**
+ * Estimates the description panel height for exported images and clamps it to export-friendly bounds.
+ */
+export function exportDescriptionHeight({
+  title,
+  text,
+  width,
+}: ExportDescriptionContent & {
+  width: number
+}): number {
+  const availableWidth = Math.max(80, width - EXPORT_DESCRIPTION_INSET * 2)
+  const charactersPerLine = Math.max(12, Math.floor(availableWidth / EXPORT_DESCRIPTION_AVERAGE_CHARACTER_WIDTH))
+  const titleLines = title.trim().length > 0 ? 1 : 0
+  const bodyLines = estimateWrappedLines(text, charactersPerLine)
+  const bodyTopGap = bodyLines > 0 ? EXPORT_DESCRIPTION_BODY_TOP_GAP : 0
+  const preferredHeight = EXPORT_DESCRIPTION_TOP_PADDING
+    + titleLines * EXPORT_DESCRIPTION_TITLE_LINE_HEIGHT
+    + bodyTopGap
+    + bodyLines * EXPORT_DESCRIPTION_BODY_LINE_HEIGHT
+    + EXPORT_DESCRIPTION_BOTTOM_PADDING
+
+  return Math.min(
+    EXPORT_DESCRIPTION_MAX_HEIGHT,
+    Math.max(EXPORT_DESCRIPTION_MIN_HEIGHT, Math.ceil(preferredHeight)),
+  )
+}
+
+/**
+ * Estimates wrapped text lines from plain text using an average character width.
+ */
+function estimateWrappedLines(text: string, charactersPerLine: number): number {
+  const lines = text
+    .split('\n')
+    .map(line => line.trim())
+    .filter(line => line.length > 0)
+  if (lines.length === 0) {
+    return 0
+  }
+  return lines.reduce((sum, line) => sum + Math.max(1, Math.ceil(line.length / charactersPerLine)), 0)
+}
+
+/**
+ * Computes the export canvas size and non-overlapping bounds for the diagram, description, and notation areas.
+ */
 export function computeExportPageLayout({
   bounds,
   padding,
+  description,
   notationEntries,
 }: {
   bounds: BBox
   padding: number
+  description: ExportDescriptionContent | null
   notationEntries: number
 }): ExportPageLayout {
+  const diagramWidth = bounds.width + padding * 2 + EXPORT_EXTRA_PADDING
+  const diagramHeight = bounds.height + padding * 2 + EXPORT_EXTRA_PADDING
+  const hasNotation = notationEntries > 0
+  const width = hasNotation
+    ? diagramWidth + EXPORT_NOTATION_GAP + EXPORT_NOTATION_WIDTH + padding
+    : diagramWidth
+  const descriptionHeight = description ? exportDescriptionHeight({ ...description, width }) : 0
+  const contentTop = descriptionHeight > 0 ? descriptionHeight + EXPORT_DESCRIPTION_GAP : 0
   const diagram = {
-    width: bounds.width + padding * 2 + EXPORT_EXTRA_PADDING,
-    height: bounds.height + padding * 2 + EXPORT_EXTRA_PADDING,
+    left: 0,
+    top: contentTop,
+    width: diagramWidth,
+    height: diagramHeight,
   }
 
-  if (notationEntries <= 0) {
+  if (!hasNotation) {
     return {
-      width: diagram.width,
-      height: diagram.height,
+      width,
+      height: contentTop + diagram.height,
       diagram,
+      description: description
+        ? {
+          left: 0,
+          top: 0,
+          width,
+          height: descriptionHeight,
+        }
+        : null,
       notation: null,
     }
   }
 
   const notationHeight = exportNotationHeight(notationEntries)
-  const height = Math.max(diagram.height, notationHeight + padding * 2)
+  const contentHeight = Math.max(diagram.height, notationHeight + padding * 2)
 
   return {
-    width: diagram.width + EXPORT_NOTATION_GAP + EXPORT_NOTATION_WIDTH + padding,
-    height,
+    width,
+    height: contentTop + contentHeight,
     diagram,
+    description: description
+      ? {
+        left: 0,
+        top: 0,
+        width,
+        height: descriptionHeight,
+      }
+      : null,
     notation: {
       left: diagram.width + EXPORT_NOTATION_GAP,
-      top: padding,
+      top: contentTop + padding,
       width: EXPORT_NOTATION_WIDTH,
       height: notationHeight,
     },

--- a/packages/likec4-spa/src/pages/export-layout.ts
+++ b/packages/likec4-spa/src/pages/export-layout.ts
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import type { BBox } from '@likec4/core/types'
+
+export const EXPORT_EXTRA_PADDING = 16
+export const EXPORT_NOTATION_GAP = 24
+export const EXPORT_NOTATION_WIDTH = 320
+export const EXPORT_NOTATION_INSET = 12
+export const EXPORT_NOTATION_HEADER_HEIGHT = 36
+export const EXPORT_NOTATION_ITEM_HEIGHT = 68
+
+export type ExportPageLayout = {
+  width: number
+  height: number
+  diagram: {
+    width: number
+    height: number
+  }
+  notation: {
+    left: number
+    top: number
+    width: number
+    height: number
+  } | null
+}
+
+export function exportNotationHeight(entries: number): number {
+  return EXPORT_NOTATION_INSET * 2 + EXPORT_NOTATION_HEADER_HEIGHT + entries * EXPORT_NOTATION_ITEM_HEIGHT
+}
+
+export function computeExportPageLayout({
+  bounds,
+  padding,
+  notationEntries,
+}: {
+  bounds: BBox
+  padding: number
+  notationEntries: number
+}): ExportPageLayout {
+  const diagram = {
+    width: bounds.width + padding * 2 + EXPORT_EXTRA_PADDING,
+    height: bounds.height + padding * 2 + EXPORT_EXTRA_PADDING,
+  }
+
+  if (notationEntries <= 0) {
+    return {
+      width: diagram.width,
+      height: diagram.height,
+      diagram,
+      notation: null,
+    }
+  }
+
+  const notationHeight = exportNotationHeight(notationEntries)
+  const height = Math.max(diagram.height, notationHeight + padding * 2)
+
+  return {
+    width: diagram.width + EXPORT_NOTATION_GAP + EXPORT_NOTATION_WIDTH + padding,
+    height,
+    diagram,
+    notation: {
+      left: diagram.width + EXPORT_NOTATION_GAP,
+      top: padding,
+      width: EXPORT_NOTATION_WIDTH,
+      height: notationHeight,
+    },
+  }
+}

--- a/packages/likec4-spa/src/pages/export-page-params.spec.ts
+++ b/packages/likec4-spa/src/pages/export-page-params.spec.ts
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import { describe, expect, it } from 'vitest'
+import { isExportSearchFlagEnabled } from './export-page-params'
+
+describe('isExportSearchFlagEnabled', () => {
+  it('accepts boolean and URL string true values', () => {
+    expect(isExportSearchFlagEnabled(true)).toBe(true)
+    expect(isExportSearchFlagEnabled('true')).toBe(true)
+  })
+
+  it('rejects missing, false, and unrelated values', () => {
+    expect(isExportSearchFlagEnabled(false)).toBe(false)
+    expect(isExportSearchFlagEnabled('false')).toBe(false)
+    expect(isExportSearchFlagEnabled(undefined)).toBe(false)
+    expect(isExportSearchFlagEnabled('')).toBe(false)
+  })
+})

--- a/packages/likec4-spa/src/pages/export-page-params.ts
+++ b/packages/likec4-spa/src/pages/export-page-params.ts
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+/**
+ * Normalizes boolean export search params that can arrive from TanStack Router or URL strings.
+ */
+export function isExportSearchFlagEnabled(value: unknown): boolean {
+  return value === true || value === 'true'
+}

--- a/packages/likec4-spa/src/routes/_single/export.$viewId.tsx
+++ b/packages/likec4-spa/src/routes/_single/export.$viewId.tsx
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { createFileRoute, stripSearchParams } from '@tanstack/react-router'
 import { z } from 'zod'
 import { ExportPage } from '../../pages/ExportPage'
@@ -6,6 +13,7 @@ export const Route = createFileRoute('/_single/export/$viewId')({
   validateSearch: z.object({
     download: z.boolean().optional().catch(false),
     format: z.enum(['png', 'jpeg']).optional().catch('png'),
+    notation: z.boolean().optional().catch(false),
     quality: z.number().min(0).max(1).optional().catch(undefined),
   }),
   search: {
@@ -13,6 +21,7 @@ export const Route = createFileRoute('/_single/export/$viewId')({
       stripSearchParams({
         download: false,
         format: 'png',
+        notation: false,
         quality: undefined,
       }),
     ],

--- a/packages/likec4-spa/src/routes/_single/export.$viewId.tsx
+++ b/packages/likec4-spa/src/routes/_single/export.$viewId.tsx
@@ -11,6 +11,7 @@ import { ExportPage } from '../../pages/ExportPage'
 
 export const Route = createFileRoute('/_single/export/$viewId')({
   validateSearch: z.object({
+    description: z.boolean().optional().catch(false),
     download: z.boolean().optional().catch(false),
     format: z.enum(['png', 'jpeg']).optional().catch('png'),
     notation: z.boolean().optional().catch(false),
@@ -19,6 +20,7 @@ export const Route = createFileRoute('/_single/export/$viewId')({
   search: {
     middlewares: [
       stripSearchParams({
+        description: false,
         download: false,
         format: 'png',
         notation: false,

--- a/packages/likec4-spa/src/routes/project.$projectId/export.$viewId.tsx
+++ b/packages/likec4-spa/src/routes/project.$projectId/export.$viewId.tsx
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { createFileRoute, stripSearchParams } from '@tanstack/react-router'
 import { z } from 'zod'
 import { ExportPage } from '../../pages/ExportPage'
@@ -6,6 +13,7 @@ export const Route = createFileRoute('/project/$projectId/export/$viewId')({
   validateSearch: z.object({
     download: z.boolean().optional().catch(false),
     format: z.enum(['png', 'jpeg']).optional().catch('png'),
+    notation: z.boolean().optional().catch(false),
     quality: z.number().min(0).max(1).optional().catch(undefined),
   }),
   search: {
@@ -13,6 +21,7 @@ export const Route = createFileRoute('/project/$projectId/export/$viewId')({
       stripSearchParams({
         download: false,
         format: 'png',
+        notation: false,
         quality: undefined,
       }),
     ],

--- a/packages/likec4-spa/src/routes/project.$projectId/export.$viewId.tsx
+++ b/packages/likec4-spa/src/routes/project.$projectId/export.$viewId.tsx
@@ -11,6 +11,7 @@ import { ExportPage } from '../../pages/ExportPage'
 
 export const Route = createFileRoute('/project/$projectId/export/$viewId')({
   validateSearch: z.object({
+    description: z.boolean().optional().catch(false),
     download: z.boolean().optional().catch(false),
     format: z.enum(['png', 'jpeg']).optional().catch('png'),
     notation: z.boolean().optional().catch(false),
@@ -19,6 +20,7 @@ export const Route = createFileRoute('/project/$projectId/export/$viewId')({
   search: {
     middlewares: [
       stripSearchParams({
+        description: false,
         download: false,
         format: 'png',
         notation: false,

--- a/packages/likec4/src/cli/export/jpg/handler.ts
+++ b/packages/likec4/src/cli/export/jpg/handler.ts
@@ -114,6 +114,11 @@ export function jpgCmd(yargs: Argv) {
             desc: 'include view notation in exported JPEG files',
             default: false,
           },
+          'description': {
+            boolean: true,
+            desc: 'include view description in exported JPEG files',
+            default: false,
+          },
         })
         .epilog(`${k.bold('Examples:')}
   ${k.green('$0 export jpg')}
@@ -153,6 +158,7 @@ export function jpgCmd(yargs: Argv) {
           format: 'jpeg',
           quality: args.quality,
           notation: args.notation,
+          description: args.description,
         } satisfies PngExportArgs,
       )
       showSupportUsMessage()

--- a/packages/likec4/src/cli/export/jpg/handler.ts
+++ b/packages/likec4/src/cli/export/jpg/handler.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { invariant } from '@likec4/core'
 import { resolve } from 'node:path'
 import k from 'tinyrainbow'
@@ -102,6 +109,11 @@ export function jpgCmd(yargs: Argv) {
             desc: 'enable chromium sandbox (see Playwright docs)',
             default: false,
           },
+          'notation': {
+            boolean: true,
+            desc: 'include view notation in exported JPEG files',
+            default: false,
+          },
         })
         .epilog(`${k.bold('Examples:')}
   ${k.green('$0 export jpg')}
@@ -140,6 +152,7 @@ export function jpgCmd(yargs: Argv) {
           chromiumSandbox: args['chromium-sandbox'],
           format: 'jpeg',
           quality: args.quality,
+          notation: args.notation,
         } satisfies PngExportArgs,
       )
       showSupportUsMessage()

--- a/packages/likec4/src/cli/export/png/handler.ts
+++ b/packages/likec4/src/cli/export/png/handler.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { type DiagramView, type NonEmptyArray, invariant } from '@likec4/core'
 import { fromWorkspace } from '@likec4/language-services/node'
 import { resolve } from 'node:path'
@@ -42,6 +49,8 @@ export type PngExportArgs = {
   format?: 'png' | 'jpeg'
   /** JPEG quality (1-100). Only used when format is 'jpeg'. Defaults to 80. */
   quality?: number
+  /** Include view notation in exported images. */
+  notation?: boolean
 }
 
 /** Launch headless Chromium, capture each view as PNG to output dir; returns list of succeeded view ids. */
@@ -59,6 +68,7 @@ export async function exportViewsToPNG(
     sequence = false,
     format = 'png',
     quality,
+    notation = false,
   }: {
     logger: ViteLogger
     serverUrl: string
@@ -72,6 +82,7 @@ export async function exportViewsToPNG(
     sequence?: boolean
     format?: 'png' | 'jpeg'
     quality?: number | undefined
+    notation?: boolean
   },
 ) {
   logger.info(`${k.dim('output')} ${output}`)
@@ -107,6 +118,7 @@ export async function exportViewsToPNG(
       theme,
       format,
       quality,
+      notation,
     })
   } finally {
     logger.info(k.cyan(`close chromium`))
@@ -133,6 +145,7 @@ export async function runExportPng(args: PngExportArgs, logger: ViteLogger): Pro
     chromiumSandbox = false,
     format = 'png',
     quality,
+    notation = false,
   } = args
 
   await using likec4 = await fromWorkspace(workspacePath, {
@@ -216,6 +229,7 @@ export async function runExportPng(args: PngExportArgs, logger: ViteLogger): Pro
         chromiumSandbox,
         format,
         quality,
+        notation,
       })
       const { pretty } = inMillis(startTakeScreenshot)
 
@@ -331,6 +345,11 @@ export function pngCmd(yargs: Argv) {
             desc: 'enable chromium sandbox (see Playwright docs)',
             default: false,
           },
+          'notation': {
+            boolean: true,
+            desc: 'include view notation in exported PNG files',
+            default: false,
+          },
         })
         .epilog(`${k.bold('Examples:')}
   ${k.green('$0 export png')}
@@ -366,6 +385,7 @@ export function pngCmd(yargs: Argv) {
           filter: args.filter,
           sequence: args.seq,
           chromiumSandbox: args['chromium-sandbox'],
+          notation: args.notation,
         } satisfies PngExportArgs,
       )
       showSupportUsMessage()

--- a/packages/likec4/src/cli/export/png/handler.ts
+++ b/packages/likec4/src/cli/export/png/handler.ts
@@ -51,6 +51,8 @@ export type PngExportArgs = {
   quality?: number
   /** Include view notation in exported images. */
   notation?: boolean
+  /** Include view description in exported images. */
+  description?: boolean
 }
 
 /** Launch headless Chromium, capture each view as PNG to output dir; returns list of succeeded view ids. */
@@ -69,6 +71,7 @@ export async function exportViewsToPNG(
     format = 'png',
     quality,
     notation = false,
+    description = false,
   }: {
     logger: ViteLogger
     serverUrl: string
@@ -83,6 +86,7 @@ export async function exportViewsToPNG(
     format?: 'png' | 'jpeg'
     quality?: number | undefined
     notation?: boolean
+    description?: boolean
   },
 ) {
   logger.info(`${k.dim('output')} ${output}`)
@@ -119,6 +123,7 @@ export async function exportViewsToPNG(
       format,
       quality,
       notation,
+      description,
     })
   } finally {
     logger.info(k.cyan(`close chromium`))
@@ -146,6 +151,7 @@ export async function runExportPng(args: PngExportArgs, logger: ViteLogger): Pro
     format = 'png',
     quality,
     notation = false,
+    description = false,
   } = args
 
   await using likec4 = await fromWorkspace(workspacePath, {
@@ -230,6 +236,7 @@ export async function runExportPng(args: PngExportArgs, logger: ViteLogger): Pro
         format,
         quality,
         notation,
+        description,
       })
       const { pretty } = inMillis(startTakeScreenshot)
 
@@ -350,6 +357,11 @@ export function pngCmd(yargs: Argv) {
             desc: 'include view notation in exported PNG files',
             default: false,
           },
+          'description': {
+            boolean: true,
+            desc: 'include view description in exported PNG files',
+            default: false,
+          },
         })
         .epilog(`${k.bold('Examples:')}
   ${k.green('$0 export png')}
@@ -386,6 +398,7 @@ export function pngCmd(yargs: Argv) {
           sequence: args.seq,
           chromiumSandbox: args['chromium-sandbox'],
           notation: args.notation,
+          description: args.description,
         } satisfies PngExportArgs,
       )
       showSupportUsMessage()

--- a/packages/likec4/src/cli/export/png/takeScreenshot.spec.ts
+++ b/packages/likec4/src/cli/export/png/takeScreenshot.spec.ts
@@ -10,7 +10,7 @@ function parseExportUrl(url: string): URL {
 }
 
 describe('createExportViewUrl', () => {
-  it('omits notation query parameter by default', () => {
+  it('omits optional decoration query parameters by default', () => {
     const url = parseExportUrl(createExportViewUrl({
       viewId: 'customer view',
       padding: 20,
@@ -21,6 +21,7 @@ describe('createExportViewUrl', () => {
     expect(url.searchParams.get('padding')).toBe('20')
     expect(url.searchParams.get('theme')).toBe('light')
     expect(url.searchParams.has('notation')).toBe(false)
+    expect(url.searchParams.has('description')).toBe(false)
   })
 
   it('adds notation query parameter when requested', () => {
@@ -35,7 +36,19 @@ describe('createExportViewUrl', () => {
     expect(url.searchParams.get('notation')).toBe('true')
   })
 
-  it('keeps JPEG and dynamic export query parameters with notation', () => {
+  it('adds description query parameter when requested', () => {
+    const url = parseExportUrl(createExportViewUrl({
+      viewId: 'orders',
+      padding: 20,
+      theme: 'dark',
+      description: true,
+    }))
+
+    expect(url.pathname).toBe('/export/orders/')
+    expect(url.searchParams.get('description')).toBe('true')
+  })
+
+  it('keeps JPEG and dynamic export query parameters with decorations', () => {
     const url = parseExportUrl(createExportViewUrl({
       viewId: 'checkout',
       padding: 24,
@@ -43,6 +56,7 @@ describe('createExportViewUrl', () => {
       dynamicVariant: 'sequence',
       format: 'jpeg',
       notation: true,
+      description: true,
     }))
 
     expect(url.searchParams.get('padding')).toBe('24')
@@ -50,5 +64,6 @@ describe('createExportViewUrl', () => {
     expect(url.searchParams.get('dynamic')).toBe('sequence')
     expect(url.searchParams.get('format')).toBe('jpeg')
     expect(url.searchParams.get('notation')).toBe('true')
+    expect(url.searchParams.get('description')).toBe('true')
   })
 })

--- a/packages/likec4/src/cli/export/png/takeScreenshot.spec.ts
+++ b/packages/likec4/src/cli/export/png/takeScreenshot.spec.ts
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import { describe, expect, it } from 'vitest'
+import { createExportViewUrl } from './takeScreenshot'
+
+function parseExportUrl(url: string): URL {
+  return new URL(url, 'http://likec4.test/')
+}
+
+describe('createExportViewUrl', () => {
+  it('omits notation query parameter by default', () => {
+    const url = parseExportUrl(createExportViewUrl({
+      viewId: 'customer view',
+      padding: 20,
+      theme: 'light',
+    }))
+
+    expect(url.pathname).toBe('/export/customer%20view/')
+    expect(url.searchParams.get('padding')).toBe('20')
+    expect(url.searchParams.get('theme')).toBe('light')
+    expect(url.searchParams.has('notation')).toBe(false)
+  })
+
+  it('adds notation query parameter when requested', () => {
+    const url = parseExportUrl(createExportViewUrl({
+      viewId: 'orders',
+      padding: 20,
+      theme: 'dark',
+      notation: true,
+    }))
+
+    expect(url.pathname).toBe('/export/orders/')
+    expect(url.searchParams.get('notation')).toBe('true')
+  })
+
+  it('keeps JPEG and dynamic export query parameters with notation', () => {
+    const url = parseExportUrl(createExportViewUrl({
+      viewId: 'checkout',
+      padding: 24,
+      theme: 'dark',
+      dynamicVariant: 'sequence',
+      format: 'jpeg',
+      notation: true,
+    }))
+
+    expect(url.searchParams.get('padding')).toBe('24')
+    expect(url.searchParams.get('theme')).toBe('dark')
+    expect(url.searchParams.get('dynamic')).toBe('sequence')
+    expect(url.searchParams.get('format')).toBe('jpeg')
+    expect(url.searchParams.get('notation')).toBe('true')
+  })
+})

--- a/packages/likec4/src/cli/export/png/takeScreenshot.ts
+++ b/packages/likec4/src/cli/export/png/takeScreenshot.ts
@@ -28,13 +28,14 @@ type TakeScreenshotParams = {
   format?: 'png' | 'jpeg'
   quality?: number | undefined
   notation?: boolean
+  description?: boolean
 }
 
 /**
  * Builds the SPA export URL for a view screenshot, encoding the view id and export query parameters.
  *
- * @param params - View id, padding, theme, and optional dynamic layout, image format, and notation settings.
- * @returns Relative URL containing `padding`, `theme`, optional `dynamic`, `format`, and `notation` query parameters.
+ * @param params - View id, padding, theme, and optional dynamic layout, image format, notation, and description settings.
+ * @returns Relative URL containing `padding`, `theme`, optional `dynamic`, `format`, `notation`, and `description`.
  */
 export function createExportViewUrl({
   viewId,
@@ -43,6 +44,7 @@ export function createExportViewUrl({
   dynamicVariant,
   format = 'png',
   notation = false,
+  description = false,
 }: {
   viewId: string
   padding: number
@@ -50,12 +52,14 @@ export function createExportViewUrl({
   dynamicVariant?: DynamicViewDisplayVariant | undefined
   format?: 'png' | 'jpeg'
   notation?: boolean
+  description?: boolean
 }): string {
   return withQuery(`export/${encodeURIComponent(viewId)}/`, {
     padding,
     theme,
     dynamic: dynamicVariant,
     ...(notation ? { notation: true } : {}),
+    ...(description ? { description: true } : {}),
     ...(format === 'jpeg' ? { format: 'jpeg' } : {}),
   })
 }
@@ -78,6 +82,7 @@ export async function takeScreenshot({
   format = 'png',
   quality,
   notation = false,
+  description = false,
 }: TakeScreenshotParams) {
   const padding = 20
 
@@ -141,6 +146,7 @@ export async function takeScreenshot({
         dynamicVariant,
         format,
         notation,
+        description,
       }))
 
       logger.info(k.cyan(url) + k.dim(` -> ${relative(output, path)}`))
@@ -190,7 +196,9 @@ export async function takeScreenshot({
 }
 
 /**
- * https://stackoverflow.com/questions/77287441/how-to-wait-for-full-rendered-image-in-playwright
+ * Waits for images in the export page to either load or fail before the screenshot is captured.
+ *
+ * Based on https://stackoverflow.com/questions/77287441/how-to-wait-for-full-rendered-image-in-playwright.
  */
 async function waitAllImages(page: Page, timeout: number) {
   // Trigger loading of all images

--- a/packages/likec4/src/cli/export/png/takeScreenshot.ts
+++ b/packages/likec4/src/cli/export/png/takeScreenshot.ts
@@ -1,4 +1,11 @@
 /// <reference lib="DOM" />
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import type { DiagramView, DynamicViewDisplayVariant, NonEmptyArray } from '@likec4/core'
 import { relative, resolve } from 'node:path'
 import { setTimeout as sleep } from 'node:timers/promises'
@@ -20,6 +27,37 @@ type TakeScreenshotParams = {
   theme: 'light' | 'dark'
   format?: 'png' | 'jpeg'
   quality?: number | undefined
+  notation?: boolean
+}
+
+/**
+ * Builds the SPA export URL for a view screenshot, encoding the view id and export query parameters.
+ *
+ * @param params - View id, padding, theme, and optional dynamic layout, image format, and notation settings.
+ * @returns Relative URL containing `padding`, `theme`, optional `dynamic`, `format`, and `notation` query parameters.
+ */
+export function createExportViewUrl({
+  viewId,
+  padding,
+  theme,
+  dynamicVariant,
+  format = 'png',
+  notation = false,
+}: {
+  viewId: string
+  padding: number
+  theme: 'light' | 'dark'
+  dynamicVariant?: DynamicViewDisplayVariant | undefined
+  format?: 'png' | 'jpeg'
+  notation?: boolean
+}): string {
+  return withQuery(`export/${encodeURIComponent(viewId)}/`, {
+    padding,
+    theme,
+    dynamic: dynamicVariant,
+    ...(notation ? { notation: true } : {}),
+    ...(format === 'jpeg' ? { format: 'jpeg' } : {}),
+  })
 }
 
 /**
@@ -39,6 +77,7 @@ export async function takeScreenshot({
   theme,
   format = 'png',
   quality,
+  notation = false,
 }: TakeScreenshotParams) {
   const padding = 20
 
@@ -95,23 +134,35 @@ export async function takeScreenshot({
         width: bounds.width + padding * 2 + extraPadding,
         height: bounds.height + padding * 2 + extraPadding,
       })
-      await page.goto(withQuery(url, {
+      await page.goto(createExportViewUrl({
+        viewId: view.id,
         padding,
         theme,
-        dynamic: dynamicVariant,
-        ...(format === 'jpeg' ? { format: 'jpeg' } : {}),
+        dynamicVariant,
+        format,
+        notation,
       }))
 
       logger.info(k.cyan(url) + k.dim(` -> ${relative(output, path)}`))
 
       await page.waitForSelector('.react-flow.initialized')
+      const exportPage = page.getByTestId('export-page')
+      const exportBox = await exportPage.boundingBox()
+      if (exportBox) {
+        const width = Math.ceil(exportBox.width)
+        const height = Math.ceil(exportBox.height)
+        const viewport = page.viewportSize()
+        if (!viewport || width > viewport.width || height > viewport.height) {
+          await page.setViewportSize({ width, height })
+        }
+      }
 
       const hasImages = view.nodes.some(n => isTruthy(n.icon) && n.icon.toLowerCase().startsWith('http'))
       if (hasImages) {
         await waitAllImages(page, timeout)
       }
 
-      await page.getByTestId('export-page').screenshot({
+      await exportPage.screenshot({
         animations: 'disabled',
         path,
         type: format === 'jpeg' ? 'jpeg' : 'png',


### PR DESCRIPTION
## Summary
- Add `--notation` to PNG/JPEG exports.
- Render view notation beside the diagram without covering nodes.
- Document the new CLI option.

## Example
![notations_example.png](https://github.com/likec4/likec4/raw/refs/heads/gh-attach-assets/5197e910-a698-4e0c-8dd3-e0fd8d61b7d0/notations_example.png)

## Checks
- Focused Vitest suites
- Focused typechecks
- `likec4...` build