### PR TITLE
feat(cli): export view descriptions in screenshots

### DIFF
--- a/.changeset/export-image-description.md
+++ b/.changeset/export-image-description.md
@@ -1,0 +1,5 @@
+---
+'likec4': patch
+---
+
+Add `--description` to PNG and JPEG exports to include the view title and Markdown description in generated images.

--- a/apps/docs/src/content/docs/tooling/cli.mdx
+++ b/apps/docs/src/content/docs/tooling/cli.mdx
@@ -183,6 +183,7 @@ You will be prompted with a command to install if it's not found.
 | `--server-url`          | use this url instead of starting new likec4 server                                                            |
 | `--chromium-sandbox`    | enable chromium sandbox (see Playwright docs)                                                                 |
 | `--notation`            | include view notation in exported PNG/JPEG files                                                              |
+| `--description`         | include the view title and Markdown description in exported PNG/JPEG files                                     |
 
 ### Export to JSON
 

--- a/packages/likec4-spa/src/pages/ExportPage.tsx
+++ b/packages/likec4-spa/src/pages/ExportPage.tsx
@@ -5,16 +5,25 @@
 //
 // Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
 
-import type { LayoutedView, NodeNotation } from '@likec4/core'
+import { type LayoutedView, type NodeNotation, type RichTextOrEmpty, RichText } from '@likec4/core'
 import { LikeC4Diagram, pickViewBounds, useLikeC4Styles } from '@likec4/diagram'
-import { ElementShape } from '@likec4/diagram/custom'
+import { ElementShape, Markdown } from '@likec4/diagram/custom'
 import { Box } from '@likec4/styles/jsx'
 import { LoadingOverlay } from '@mantine/core'
 import { useSearch } from '@tanstack/react-router'
 import type { CSSProperties } from 'react'
 import { useRef } from 'react'
 import { useCurrentView, useTransparentBackground } from '../hooks'
-import { computeExportPageLayout, EXPORT_NOTATION_ITEM_HEIGHT } from './export-layout'
+import {
+  computeExportPageLayout,
+  EXPORT_DESCRIPTION_BODY_TOP_GAP,
+  EXPORT_DESCRIPTION_BOTTOM_PADDING,
+  EXPORT_DESCRIPTION_INSET,
+  EXPORT_DESCRIPTION_TITLE_LINE_HEIGHT,
+  EXPORT_DESCRIPTION_TOP_PADDING,
+  EXPORT_NOTATION_ITEM_HEIGHT,
+} from './export-layout'
+import { isExportSearchFlagEnabled } from './export-page-params'
 
 type PaletteCssVars =
   & CSSProperties
@@ -23,6 +32,9 @@ type PaletteCssVars =
     string
   >
 
+/**
+ * Downloads a generated object URL or data URL through a temporary browser link.
+ */
 function triggerDownload(url: string, filename: string) {
   const link = document.createElement('a')
   link.setAttribute('download', filename)
@@ -38,6 +50,9 @@ function triggerDownload(url: string, filename: string) {
   )
 }
 
+/**
+ * Converts the export viewport into a PNG file and starts a browser download.
+ */
 async function downloadAsPng({
   pngFilename,
   viewport,
@@ -65,6 +80,9 @@ async function downloadAsPng({
   }
 }
 
+/**
+ * Converts the export viewport into a JPEG file and starts a browser download.
+ */
 async function downloadAsJpeg({
   filename,
   viewport,
@@ -92,6 +110,9 @@ async function downloadAsJpeg({
   }
 }
 
+/**
+ * Renders the single-view export page used by browser downloads and CLI screenshots.
+ */
 export function ExportPage() {
   const [diagram] = useCurrentView()
   const { format } = useSearch({ strict: false })
@@ -106,10 +127,14 @@ export function ExportPage() {
   return <GuardedExportPage diagram={diagram} isJpeg={isJpeg} />
 }
 
+/**
+ * Renders the measured export viewport for a loaded diagram.
+ */
 function GuardedExportPage({ diagram, isJpeg }: { diagram: LayoutedView; isJpeg: boolean }) {
   const {
     padding = 20,
     download = false,
+    description = false,
     quality,
     dynamic,
     notation = false,
@@ -123,11 +148,15 @@ function GuardedExportPage({ diagram, isJpeg }: { diagram: LayoutedView; isJpeg:
   const downloadedRef = useRef(false)
 
   const bounds = pickViewBounds(diagram, dynamic)
+  const viewDescription = RichText.from(diagram.description)
+  const showDescription = isExportSearchFlagEnabled(description) && viewDescription.nonEmpty
+  const viewTitle = diagram.title ?? diagram.id
   const notationEntries = diagram.notation?.nodes ?? []
-  const showNotation = notation === true && notationEntries.length > 0
+  const showNotation = isExportSearchFlagEnabled(notation) && notationEntries.length > 0
   const layout = computeExportPageLayout({
     bounds,
     padding,
+    description: showDescription ? { title: viewTitle, text: viewDescription.text } : null,
     notationEntries: showNotation ? notationEntries.length : 0,
   })
 
@@ -182,13 +211,13 @@ function GuardedExportPage({ diagram, isJpeg }: { diagram: LayoutedView; isJpeg:
         data-testid="export-diagram-area"
         css={{
           position: 'absolute',
-          top: '0',
-          left: '0',
           overflow: 'hidden',
         }}
         style={{
+          top: layout.diagram.top,
+          left: layout.diagram.left,
           width: layout.diagram.width,
-          height: layout.height,
+          height: layout.height - layout.diagram.top,
         }}>
         <LikeC4Diagram
           view={diagram}
@@ -234,6 +263,13 @@ function GuardedExportPage({ diagram, isJpeg }: { diagram: LayoutedView; isJpeg:
           }}
         />
       </Box>
+      {layout.description && (
+        <ExportDescriptionPanel
+          title={viewTitle}
+          description={viewDescription}
+          layout={layout.description}
+        />
+      )}
       {layout.notation && (
         <ExportNotationPanel
           entries={notationEntries}
@@ -244,6 +280,72 @@ function GuardedExportPage({ diagram, isJpeg }: { diagram: LayoutedView; isJpeg:
   )
 }
 
+/**
+ * Renders the optional Markdown description panel above the exported diagram.
+ */
+function ExportDescriptionPanel({
+  title,
+  description,
+  layout,
+}: Readonly<{
+  title: string
+  description: RichTextOrEmpty
+  layout: NonNullable<ReturnType<typeof computeExportPageLayout>['description']>
+}>) {
+  const panelStyle: CSSProperties = {
+    ...layout,
+    position: 'absolute',
+    boxSizing: 'border-box',
+    overflow: 'hidden',
+    border: '1px solid var(--mantine-color-default-border)',
+    borderRadius: 6,
+    background: 'var(--mantine-color-body)',
+    boxShadow: '0 4px 18px rgb(0 0 0 / 14%)',
+    color: 'var(--mantine-color-text)',
+  }
+  const titleStyle: CSSProperties = {
+    paddingTop: EXPORT_DESCRIPTION_TOP_PADDING,
+    paddingBottom: EXPORT_DESCRIPTION_BODY_TOP_GAP,
+    paddingLeft: EXPORT_DESCRIPTION_INSET,
+    paddingRight: EXPORT_DESCRIPTION_INSET,
+    fontSize: 15,
+    fontWeight: 600,
+    lineHeight: `${EXPORT_DESCRIPTION_TITLE_LINE_HEIGHT}px`,
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+  }
+  const descriptionStyle: CSSProperties = {
+    maxHeight: layout.height
+      - EXPORT_DESCRIPTION_TOP_PADDING
+      - EXPORT_DESCRIPTION_TITLE_LINE_HEIGHT
+      - EXPORT_DESCRIPTION_BODY_TOP_GAP
+      - EXPORT_DESCRIPTION_BOTTOM_PADDING,
+    overflow: 'hidden',
+    paddingLeft: EXPORT_DESCRIPTION_INSET,
+    paddingRight: EXPORT_DESCRIPTION_INSET,
+    paddingBottom: EXPORT_DESCRIPTION_BOTTOM_PADDING,
+  }
+
+  return (
+    <Box
+      data-testid="export-description"
+      style={panelStyle}>
+      <Box style={titleStyle}>{title}</Box>
+      <Markdown
+        value={description}
+        hideIfEmpty
+        fontSize="sm"
+        textScale={0.9}
+        style={descriptionStyle}
+      />
+    </Box>
+  )
+}
+
+/**
+ * Renders the optional notation panel next to the exported diagram.
+ */
 function ExportNotationPanel({
   entries,
   layout,
@@ -288,6 +390,9 @@ function ExportNotationPanel({
   )
 }
 
+/**
+ * Renders one notation entry with its representative element shape and labels.
+ */
 function ExportNotationItem({ entry }: Readonly<{ entry: NodeNotation }>) {
   const styles = useLikeC4Styles()
   const elementColors = styles.colors(entry.color).elements

--- a/packages/likec4-spa/src/pages/export-layout.spec.ts
+++ b/packages/likec4-spa/src/pages/export-layout.spec.ts
@@ -5,9 +5,13 @@
 import { describe, expect, it } from 'vitest'
 import {
   computeExportPageLayout,
+  EXPORT_DESCRIPTION_GAP,
+  EXPORT_DESCRIPTION_MAX_HEIGHT,
+  EXPORT_DESCRIPTION_MIN_HEIGHT,
   EXPORT_EXTRA_PADDING,
   EXPORT_NOTATION_GAP,
   EXPORT_NOTATION_WIDTH,
+  exportDescriptionHeight,
   exportNotationHeight,
 } from './export-layout'
 
@@ -23,6 +27,7 @@ describe('computeExportPageLayout', () => {
     const layout = computeExportPageLayout({
       bounds,
       padding: 20,
+      description: null,
       notationEntries: 0,
     })
 
@@ -30,17 +35,76 @@ describe('computeExportPageLayout', () => {
       width: bounds.width + 20 * 2 + EXPORT_EXTRA_PADDING,
       height: bounds.height + 20 * 2 + EXPORT_EXTRA_PADDING,
       diagram: {
+        left: 0,
+        top: 0,
         width: bounds.width + 20 * 2 + EXPORT_EXTRA_PADDING,
         height: bounds.height + 20 * 2 + EXPORT_EXTRA_PADDING,
       },
+      description: null,
       notation: null,
     })
+  })
+
+  it('reserves a top description banner outside the diagram area', () => {
+    const description = {
+      title: 'Cloud System',
+      text: 'The overview of the cloud system',
+    }
+    const layout = computeExportPageLayout({
+      bounds,
+      padding: 20,
+      description,
+      notationEntries: 0,
+    })
+    const descriptionHeight = exportDescriptionHeight({
+      ...description,
+      width: layout.diagram.width,
+    })
+
+    expect(layout.description).toEqual({
+      left: 0,
+      top: 0,
+      width: layout.diagram.width,
+      height: descriptionHeight,
+    })
+    expect(descriptionHeight).toBe(EXPORT_DESCRIPTION_MIN_HEIGHT)
+    expect(layout.diagram.top).toBe(descriptionHeight + EXPORT_DESCRIPTION_GAP)
+    expect(layout.height).toBe(layout.diagram.top + layout.diagram.height)
+  })
+
+  it('grows and caps the description banner based on content length', () => {
+    const layout = computeExportPageLayout({
+      bounds: {
+        ...bounds,
+        width: 160,
+      },
+      padding: 20,
+      description: {
+        title: 'Long description',
+        text: Array.from({ length: 20 }, () => 'This sentence should wrap into several rendered lines.').join(' '),
+      },
+      notationEntries: 0,
+    })
+
+    expect(layout.description!.height).toBe(EXPORT_DESCRIPTION_MAX_HEIGHT)
+    expect(layout.diagram.top).toBe(EXPORT_DESCRIPTION_MAX_HEIGHT + EXPORT_DESCRIPTION_GAP)
+  })
+
+  it('treats long titles as a single ellipsized line', () => {
+    const descriptionHeight = exportDescriptionHeight({
+      title: 'A very long title that is intentionally much wider than the exported image and must be ellipsized',
+      text: 'Brief',
+      width: 120,
+    })
+
+    expect(descriptionHeight).toBe(EXPORT_DESCRIPTION_MIN_HEIGHT)
   })
 
   it('reserves a right-side notation column outside the diagram area', () => {
     const layout = computeExportPageLayout({
       bounds,
       padding: 20,
+      description: null,
       notationEntries: 2,
     })
 
@@ -54,6 +118,35 @@ describe('computeExportPageLayout', () => {
     expect(layout.notation!.left).toBeGreaterThan(layout.diagram.width)
   })
 
+  it('places notation below the description banner when both are enabled', () => {
+    const description = {
+      title: 'Checkout Service',
+      text: 'Retrieves user cart, prepares order and orchestrates payments, shipping and notification.',
+    }
+    const layout = computeExportPageLayout({
+      bounds,
+      padding: 20,
+      description,
+      notationEntries: 2,
+    })
+
+    const descriptionHeight = exportDescriptionHeight({
+      ...description,
+      width: layout.width,
+    })
+
+    expect(layout.description).toMatchObject({
+      top: 0,
+      width: layout.width,
+      height: descriptionHeight,
+    })
+    expect(layout.diagram.top).toBe(descriptionHeight + EXPORT_DESCRIPTION_GAP)
+    expect(layout.notation).toMatchObject({
+      top: layout.diagram.top + 20,
+      left: layout.diagram.width + EXPORT_NOTATION_GAP,
+    })
+  })
+
   it('grows export height when the notation is taller than the diagram', () => {
     const layout = computeExportPageLayout({
       bounds: {
@@ -61,6 +154,7 @@ describe('computeExportPageLayout', () => {
         height: 50,
       },
       padding: 20,
+      description: null,
       notationEntries: 5,
     })
 

--- a/packages/likec4-spa/src/pages/export-layout.ts
+++ b/packages/likec4-spa/src/pages/export-layout.ts
@@ -5,19 +5,49 @@
 import type { BBox } from '@likec4/core/types'
 
 export const EXPORT_EXTRA_PADDING = 16
+export const EXPORT_DESCRIPTION_GAP = 16
+export const EXPORT_DESCRIPTION_INSET = 16
+export const EXPORT_DESCRIPTION_MIN_HEIGHT = 84
+export const EXPORT_DESCRIPTION_MAX_HEIGHT = 240
 export const EXPORT_NOTATION_GAP = 24
 export const EXPORT_NOTATION_WIDTH = 320
 export const EXPORT_NOTATION_INSET = 12
 export const EXPORT_NOTATION_HEADER_HEIGHT = 36
 export const EXPORT_NOTATION_ITEM_HEIGHT = 68
 
+export const EXPORT_DESCRIPTION_TITLE_LINE_HEIGHT = 20
+const EXPORT_DESCRIPTION_BODY_LINE_HEIGHT = 19
+export const EXPORT_DESCRIPTION_TOP_PADDING = 10
+export const EXPORT_DESCRIPTION_BODY_TOP_GAP = 4
+export const EXPORT_DESCRIPTION_BOTTOM_PADDING = 16
+const EXPORT_DESCRIPTION_AVERAGE_CHARACTER_WIDTH = 7.5
+
+/**
+ * Text content shown in the optional description panel of an exported image.
+ */
+export type ExportDescriptionContent = {
+  title: string
+  text: string
+}
+
+/**
+ * Pixel bounds reserved for each area of the export canvas.
+ */
 export type ExportPageLayout = {
   width: number
   height: number
   diagram: {
+    left: number
+    top: number
     width: number
     height: number
   }
+  description: {
+    left: number
+    top: number
+    width: number
+    height: number
+  } | null
   notation: {
     left: number
     top: number
@@ -26,43 +56,118 @@ export type ExportPageLayout = {
   } | null
 }
 
+/**
+ * Calculates the reserved height for the notation panel in exported images.
+ */
 export function exportNotationHeight(entries: number): number {
   return EXPORT_NOTATION_INSET * 2 + EXPORT_NOTATION_HEADER_HEIGHT + entries * EXPORT_NOTATION_ITEM_HEIGHT
 }
 
+/**
+ * Estimates the description panel height for exported images and clamps it to export-friendly bounds.
+ */
+export function exportDescriptionHeight({
+  title,
+  text,
+  width,
+}: ExportDescriptionContent & {
+  width: number
+}): number {
+  const availableWidth = Math.max(80, width - EXPORT_DESCRIPTION_INSET * 2)
+  const charactersPerLine = Math.max(12, Math.floor(availableWidth / EXPORT_DESCRIPTION_AVERAGE_CHARACTER_WIDTH))
+  const titleLines = title.trim().length > 0 ? 1 : 0
+  const bodyLines = estimateWrappedLines(text, charactersPerLine)
+  const bodyTopGap = bodyLines > 0 ? EXPORT_DESCRIPTION_BODY_TOP_GAP : 0
+  const preferredHeight = EXPORT_DESCRIPTION_TOP_PADDING
+    + titleLines * EXPORT_DESCRIPTION_TITLE_LINE_HEIGHT
+    + bodyTopGap
+    + bodyLines * EXPORT_DESCRIPTION_BODY_LINE_HEIGHT
+    + EXPORT_DESCRIPTION_BOTTOM_PADDING
+
+  return Math.min(
+    EXPORT_DESCRIPTION_MAX_HEIGHT,
+    Math.max(EXPORT_DESCRIPTION_MIN_HEIGHT, Math.ceil(preferredHeight)),
+  )
+}
+
+/**
+ * Estimates wrapped text lines from plain text using an average character width.
+ */
+function estimateWrappedLines(text: string, charactersPerLine: number): number {
+  const lines = text
+    .split('\n')
+    .map(line => line.trim())
+    .filter(line => line.length > 0)
+  if (lines.length === 0) {
+    return 0
+  }
+  return lines.reduce((sum, line) => sum + Math.max(1, Math.ceil(line.length / charactersPerLine)), 0)
+}
+
+/**
+ * Computes the export canvas size and non-overlapping bounds for the diagram, description, and notation areas.
+ */
 export function computeExportPageLayout({
   bounds,
   padding,
+  description,
   notationEntries,
 }: {
   bounds: BBox
   padding: number
+  description: ExportDescriptionContent | null
   notationEntries: number
 }): ExportPageLayout {
+  const diagramWidth = bounds.width + padding * 2 + EXPORT_EXTRA_PADDING
+  const diagramHeight = bounds.height + padding * 2 + EXPORT_EXTRA_PADDING
+  const hasNotation = notationEntries > 0
+  const width = hasNotation
+    ? diagramWidth + EXPORT_NOTATION_GAP + EXPORT_NOTATION_WIDTH + padding
+    : diagramWidth
+  const descriptionHeight = description ? exportDescriptionHeight({ ...description, width }) : 0
+  const contentTop = descriptionHeight > 0 ? descriptionHeight + EXPORT_DESCRIPTION_GAP : 0
   const diagram = {
-    width: bounds.width + padding * 2 + EXPORT_EXTRA_PADDING,
-    height: bounds.height + padding * 2 + EXPORT_EXTRA_PADDING,
+    left: 0,
+    top: contentTop,
+    width: diagramWidth,
+    height: diagramHeight,
   }
 
-  if (notationEntries <= 0) {
+  if (!hasNotation) {
     return {
-      width: diagram.width,
-      height: diagram.height,
+      width,
+      height: contentTop + diagram.height,
       diagram,
+      description: description
+        ? {
+          left: 0,
+          top: 0,
+          width,
+          height: descriptionHeight,
+        }
+        : null,
       notation: null,
     }
   }
 
   const notationHeight = exportNotationHeight(notationEntries)
-  const height = Math.max(diagram.height, notationHeight + padding * 2)
+  const contentHeight = Math.max(diagram.height, notationHeight + padding * 2)
 
   return {
-    width: diagram.width + EXPORT_NOTATION_GAP + EXPORT_NOTATION_WIDTH + padding,
-    height,
+    width,
+    height: contentTop + contentHeight,
     diagram,
+    description: description
+      ? {
+        left: 0,
+        top: 0,
+        width,
+        height: descriptionHeight,
+      }
+      : null,
     notation: {
       left: diagram.width + EXPORT_NOTATION_GAP,
-      top: padding,
+      top: contentTop + padding,
       width: EXPORT_NOTATION_WIDTH,
       height: notationHeight,
     },

--- a/packages/likec4-spa/src/pages/export-page-params.spec.ts
+++ b/packages/likec4-spa/src/pages/export-page-params.spec.ts
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import { describe, expect, it } from 'vitest'
+import { isExportSearchFlagEnabled } from './export-page-params'
+
+describe('isExportSearchFlagEnabled', () => {
+  it('accepts boolean and URL string true values', () => {
+    expect(isExportSearchFlagEnabled(true)).toBe(true)
+    expect(isExportSearchFlagEnabled('true')).toBe(true)
+  })
+
+  it('rejects missing, false, and unrelated values', () => {
+    expect(isExportSearchFlagEnabled(false)).toBe(false)
+    expect(isExportSearchFlagEnabled('false')).toBe(false)
+    expect(isExportSearchFlagEnabled(undefined)).toBe(false)
+    expect(isExportSearchFlagEnabled('')).toBe(false)
+  })
+})

--- a/packages/likec4-spa/src/pages/export-page-params.ts
+++ b/packages/likec4-spa/src/pages/export-page-params.ts
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+/**
+ * Normalizes boolean export search params that can arrive from TanStack Router or URL strings.
+ */
+export function isExportSearchFlagEnabled(value: unknown): boolean {
+  return value === true || value === 'true'
+}

--- a/packages/likec4-spa/src/routes/_single/export.$viewId.tsx
+++ b/packages/likec4-spa/src/routes/_single/export.$viewId.tsx
@@ -11,6 +11,7 @@ import { ExportPage } from '../../pages/ExportPage'
 
 export const Route = createFileRoute('/_single/export/$viewId')({
   validateSearch: z.object({
+    description: z.boolean().optional().catch(false),
     download: z.boolean().optional().catch(false),
     format: z.enum(['png', 'jpeg']).optional().catch('png'),
     notation: z.boolean().optional().catch(false),
@@ -19,6 +20,7 @@ export const Route = createFileRoute('/_single/export/$viewId')({
   search: {
     middlewares: [
       stripSearchParams({
+        description: false,
         download: false,
         format: 'png',
         notation: false,

--- a/packages/likec4-spa/src/routes/project.$projectId/export.$viewId.tsx
+++ b/packages/likec4-spa/src/routes/project.$projectId/export.$viewId.tsx
@@ -11,6 +11,7 @@ import { ExportPage } from '../../pages/ExportPage'
 
 export const Route = createFileRoute('/project/$projectId/export/$viewId')({
   validateSearch: z.object({
+    description: z.boolean().optional().catch(false),
     download: z.boolean().optional().catch(false),
     format: z.enum(['png', 'jpeg']).optional().catch('png'),
     notation: z.boolean().optional().catch(false),
@@ -19,6 +20,7 @@ export const Route = createFileRoute('/project/$projectId/export/$viewId')({
   search: {
     middlewares: [
       stripSearchParams({
+        description: false,
         download: false,
         format: 'png',
         notation: false,

--- a/packages/likec4/src/cli/export/jpg/handler.ts
+++ b/packages/likec4/src/cli/export/jpg/handler.ts
@@ -114,6 +114,11 @@ export function jpgCmd(yargs: Argv) {
             desc: 'include view notation in exported JPEG files',
             default: false,
           },
+          'description': {
+            boolean: true,
+            desc: 'include view description in exported JPEG files',
+            default: false,
+          },
         })
         .epilog(`${k.bold('Examples:')}
   ${k.green('$0 export jpg')}
@@ -153,6 +158,7 @@ export function jpgCmd(yargs: Argv) {
           format: 'jpeg',
           quality: args.quality,
           notation: args.notation,
+          description: args.description,
         } satisfies PngExportArgs,
       )
       showSupportUsMessage()

--- a/packages/likec4/src/cli/export/png/handler.ts
+++ b/packages/likec4/src/cli/export/png/handler.ts
@@ -51,6 +51,8 @@ export type PngExportArgs = {
   quality?: number
   /** Include view notation in exported images. */
   notation?: boolean
+  /** Include view description in exported images. */
+  description?: boolean
 }
 
 /** Launch headless Chromium, capture each view as PNG to output dir; returns list of succeeded view ids. */
@@ -69,6 +71,7 @@ export async function exportViewsToPNG(
     format = 'png',
     quality,
     notation = false,
+    description = false,
   }: {
     logger: ViteLogger
     serverUrl: string
@@ -83,6 +86,7 @@ export async function exportViewsToPNG(
     format?: 'png' | 'jpeg'
     quality?: number | undefined
     notation?: boolean
+    description?: boolean
   },
 ) {
   logger.info(`${k.dim('output')} ${output}`)
@@ -119,6 +123,7 @@ export async function exportViewsToPNG(
       format,
       quality,
       notation,
+      description,
     })
   } finally {
     logger.info(k.cyan(`close chromium`))
@@ -146,6 +151,7 @@ export async function runExportPng(args: PngExportArgs, logger: ViteLogger): Pro
     format = 'png',
     quality,
     notation = false,
+    description = false,
   } = args
 
   await using likec4 = await fromWorkspace(workspacePath, {
@@ -230,6 +236,7 @@ export async function runExportPng(args: PngExportArgs, logger: ViteLogger): Pro
         format,
         quality,
         notation,
+        description,
       })
       const { pretty } = inMillis(startTakeScreenshot)
 
@@ -350,6 +357,11 @@ export function pngCmd(yargs: Argv) {
             desc: 'include view notation in exported PNG files',
             default: false,
           },
+          'description': {
+            boolean: true,
+            desc: 'include view description in exported PNG files',
+            default: false,
+          },
         })
         .epilog(`${k.bold('Examples:')}
   ${k.green('$0 export png')}
@@ -386,6 +398,7 @@ export function pngCmd(yargs: Argv) {
           sequence: args.seq,
           chromiumSandbox: args['chromium-sandbox'],
           notation: args.notation,
+          description: args.description,
         } satisfies PngExportArgs,
       )
       showSupportUsMessage()

--- a/packages/likec4/src/cli/export/png/takeScreenshot.spec.ts
+++ b/packages/likec4/src/cli/export/png/takeScreenshot.spec.ts
@@ -10,7 +10,7 @@ function parseExportUrl(url: string): URL {
 }
 
 describe('createExportViewUrl', () => {
-  it('omits notation query parameter by default', () => {
+  it('omits optional decoration query parameters by default', () => {
     const url = parseExportUrl(createExportViewUrl({
       viewId: 'customer view',
       padding: 20,
@@ -21,6 +21,7 @@ describe('createExportViewUrl', () => {
     expect(url.searchParams.get('padding')).toBe('20')
     expect(url.searchParams.get('theme')).toBe('light')
     expect(url.searchParams.has('notation')).toBe(false)
+    expect(url.searchParams.has('description')).toBe(false)
   })
 
   it('adds notation query parameter when requested', () => {
@@ -35,7 +36,19 @@ describe('createExportViewUrl', () => {
     expect(url.searchParams.get('notation')).toBe('true')
   })
 
-  it('keeps JPEG and dynamic export query parameters with notation', () => {
+  it('adds description query parameter when requested', () => {
+    const url = parseExportUrl(createExportViewUrl({
+      viewId: 'orders',
+      padding: 20,
+      theme: 'dark',
+      description: true,
+    }))
+
+    expect(url.pathname).toBe('/export/orders/')
+    expect(url.searchParams.get('description')).toBe('true')
+  })
+
+  it('keeps JPEG and dynamic export query parameters with decorations', () => {
     const url = parseExportUrl(createExportViewUrl({
       viewId: 'checkout',
       padding: 24,
@@ -43,6 +56,7 @@ describe('createExportViewUrl', () => {
       dynamicVariant: 'sequence',
       format: 'jpeg',
       notation: true,
+      description: true,
     }))
 
     expect(url.searchParams.get('padding')).toBe('24')
@@ -50,5 +64,6 @@ describe('createExportViewUrl', () => {
     expect(url.searchParams.get('dynamic')).toBe('sequence')
     expect(url.searchParams.get('format')).toBe('jpeg')
     expect(url.searchParams.get('notation')).toBe('true')
+    expect(url.searchParams.get('description')).toBe('true')
   })
 })

--- a/packages/likec4/src/cli/export/png/takeScreenshot.ts
+++ b/packages/likec4/src/cli/export/png/takeScreenshot.ts
@@ -28,13 +28,14 @@ type TakeScreenshotParams = {
   format?: 'png' | 'jpeg'
   quality?: number | undefined
   notation?: boolean
+  description?: boolean
 }
 
 /**
  * Builds the SPA export URL for a view screenshot, encoding the view id and export query parameters.
  *
- * @param params - View id, padding, theme, and optional dynamic layout, image format, and notation settings.
- * @returns Relative URL containing `padding`, `theme`, optional `dynamic`, `format`, and `notation` query parameters.
+ * @param params - View id, padding, theme, and optional dynamic layout, image format, notation, and description settings.
+ * @returns Relative URL containing `padding`, `theme`, optional `dynamic`, `format`, `notation`, and `description`.
  */
 export function createExportViewUrl({
   viewId,
@@ -43,6 +44,7 @@ export function createExportViewUrl({
   dynamicVariant,
   format = 'png',
   notation = false,
+  description = false,
 }: {
   viewId: string
   padding: number
@@ -50,12 +52,14 @@ export function createExportViewUrl({
   dynamicVariant?: DynamicViewDisplayVariant | undefined
   format?: 'png' | 'jpeg'
   notation?: boolean
+  description?: boolean
 }): string {
   return withQuery(`export/${encodeURIComponent(viewId)}/`, {
     padding,
     theme,
     dynamic: dynamicVariant,
     ...(notation ? { notation: true } : {}),
+    ...(description ? { description: true } : {}),
     ...(format === 'jpeg' ? { format: 'jpeg' } : {}),
   })
 }
@@ -78,6 +82,7 @@ export async function takeScreenshot({
   format = 'png',
   quality,
   notation = false,
+  description = false,
 }: TakeScreenshotParams) {
   const padding = 20
 
@@ -141,6 +146,7 @@ export async function takeScreenshot({
         dynamicVariant,
         format,
         notation,
+        description,
       }))
 
       logger.info(k.cyan(url) + k.dim(` -> ${relative(output, path)}`))
@@ -190,7 +196,9 @@ export async function takeScreenshot({
 }
 
 /**
- * https://stackoverflow.com/questions/77287441/how-to-wait-for-full-rendered-image-in-playwright
+ * Waits for images in the export page to either load or fail before the screenshot is captured.
+ *
+ * Based on https://stackoverflow.com/questions/77287441/how-to-wait-for-full-rendered-image-in-playwright.
  */
 async function waitAllImages(page: Page, timeout: number) {
   // Trigger loading of all images


### PR DESCRIPTION
## Summary
- Add `--description` to PNG/JPEG exports.
- Render the view title and Markdown description above the diagram.
- Keep description, notation, and diagram areas non-overlapping.

## Examples
Small description from `examples/overflow-test`:

<img src="https://github.com/user-attachments/assets/51cfaee2-f37c-43eb-af79-4a6644cc3208" alt="Small description export example" width="720">

Full Markdown description from `examples/multi-project/boutique`:

<img src="https://github.com/user-attachments/assets/3b62d752-603d-4dd1-be6a-91198a6073e0" alt="Markdown description export example" width="720">

## Checks
- Focused Vitest suites
- Focused typechecks
- SPA and CLI package builds
- Smoke JPEG exports with `--description --notation`

## Checklist
- [x] I've thoroughly read the latest [contribution guidelines](https://github.com/likec4/likec4/blob/main/CONTRIBUTING.md).
- [ ] I've rebased my branch onto `main` **before** creating this PR. Stacked on `cgk/export-legend` by design.
- [x] I've added tests to cover my changes (if applicable).
- [x] I've verified `pnpm typecheck` and `pnpm test`.
- [x] I've added [changesets](https://changesets-docs.vercel.app/).
- [x] My change requires documentation updates.
- [x] I've updated the documentation accordingly.
