### PR TITLE
Fix dynamic-views docs link

### DIFF
--- a/e2e/src/likec4/model.c4
+++ b/e2e/src/likec4/model.c4
@@ -142,7 +142,7 @@ views {
   dynamic view dynamic-view-1 {
     title 'Dynamic View Example'
 
-    link https://docs.likec4.dev/dsl/dynamic-views/ 'Docs'
+    link https://docs.likec4.dev/dsl/views/dynamic/ 'Docs'
 
     customer -> ui.mobile 'opens' {
       notes '

--- a/examples/cloud-system/model.c4
+++ b/examples/cloud-system/model.c4
@@ -135,7 +135,7 @@ views {
   dynamic view dynamic-view-1 {
     title 'Dynamic View Example'
 
-    link https://docs.likec4.dev/dsl/dynamic-views/ 'Docs'
+    link https://docs.likec4.dev/dsl/views/dynamic/ 'Docs'
 
     customer -> ui.dashboard 'opens' {
       notes '

--- a/examples/multi-project/projectA/model.c4
+++ b/examples/multi-project/projectA/model.c4
@@ -121,7 +121,7 @@ views {
   dynamic view dynamic-view-1 {
     title 'Use Cases / Dynamic View Example'
 
-    link https://docs.likec4.dev/dsl/dynamic-views/ 'Docs'
+    link https://docs.likec4.dev/dsl/views/dynamic/ 'Docs'
 
     customer -> ui.dashboard 'opens' {
       notes '''

--- a/packages/language-server/src/formatting/LikeC4Formatter.spec.ts
+++ b/packages/language-server/src/formatting/LikeC4Formatter.spec.ts
@@ -2011,7 +2011,7 @@ describe('formating', () => {
     dynamic view dynamic-view-1 {
       title 'Dynamic View Example'
 
-      link https://docs.likec4.dev/dsl/dynamic-views/ 'Docs'
+      link https://docs.likec4.dev/dsl/views/dynamic/ 'Docs'
 
       customer -> ui.dashboard 'opens'
       ui.dashboard -> cloud.graphql 'requests'


### PR DESCRIPTION
## Motivation

To avoid this:
<img width="954" height="505" alt="image" src="https://github.com/user-attachments/assets/9c44f768-ea2d-4f1e-9b09-0db17536ad4a" />

When running locally using e.g. `likec4 build -o ./build ./examples/cloud-system/` in the source tree
<img width="777" height="285" alt="image" src="https://github.com/user-attachments/assets/7c2f458f-fde1-43a2-8352-99a790e45849" />



## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask, and propose improvements. We're here to help. -->

- [x] I've thoroughly read the latest [contribution guidelines](https://github.com/likec4/likec4/blob/main/CONTRIBUTING.md).
- [x] I've rebased my branch onto `main` **before** creating this PR.
- [ ] I've added tests to cover my changes (if applicable).
- [ ] I've verified `pnpm typecheck` and `pnpm test`.
- [ ] I've added [changesets](https://changesets-docs.vercel.app/) (you can use `/changeset-generator` SKILL).
- [ ] My change requires documentation updates.
- [ ] I've updated the documentation accordingly (or will do in follow-up PR).
