### PR TITLE
feat(webcomponent): add color-scheme attribute

### DIFF
--- a/.changeset/webcomponent-color-scheme.md
+++ b/.changeset/webcomponent-color-scheme.md
@@ -1,0 +1,5 @@
+---
+'@likec4/spa': patch
+---
+
+Add `color-scheme` attribute to web component to force light or dark mode

--- a/apps/docs/src/content/docs/tooling/Code generation/webcomponent.mdx
+++ b/apps/docs/src/content/docs/tooling/Code generation/webcomponent.mdx
@@ -77,6 +77,7 @@ And in HTML:
 | `view-id`         | Your view id                                                                                          |
 | `browser`         | Whether to show views browser popup (default `true`)                                                  |
 | `dynamic-variant` | How dynamic view should be rendered<br />Possible values: `diagram` or `sequence` (default `diagram`) |
+| `color-scheme`    | Force light or dark color scheme<br />Possible values: `light` or `dark` (default: follows system)    |
 
 :::note
 CLI command [build](/tooling/cli/#build-static-website) always generates javascript with web components.  

--- a/packages/likec4-spa/codegen/webcomponent.tsx
+++ b/packages/likec4-spa/codegen/webcomponent.tsx
@@ -15,6 +15,7 @@ const propsSchema = zObject({
   viewId: zDefault(zString(), 'index'),
   browser: zDefault(zStringBoolean(), true),
   dynamicViewVariant: zOptional(zLiteral(['diagram', 'sequence'])),
+  colorScheme: zOptional(zLiteral(['light', 'dark'])),
 })
 
 export class LikeC4View extends HTMLElement {
@@ -67,7 +68,7 @@ export class LikeC4View extends HTMLElement {
     this.hostCss = undefined
   }
 
-  static observedAttributes = ['view-id', 'browser', 'dynamic-variant']
+  static observedAttributes = ['view-id', 'browser', 'dynamic-variant', 'color-scheme']
 
   protected getProps() {
     const props = propsSchema.safeParse(
@@ -75,6 +76,7 @@ export class LikeC4View extends HTMLElement {
         viewId: this.getAttribute('view-id'),
         browser: this.getAttribute('browser') ?? undefined,
         dynamicViewVariant: this.getAttribute('dynamic-variant') ?? undefined,
+        colorScheme: this.getAttribute('color-scheme') ?? undefined,
       },
     )
     if (!props.success) {


### PR DESCRIPTION
## Summary

Add `color-scheme` as an observed attribute on the `<likec4-view>` web component, allowing users to force `light` or `dark` color scheme explicitly.

## Problem

The `<likec4-view>` web component only exposes `view-id`, `browser`, and `dynamic-variant` as attributes. The underlying React `LikeC4View` component supports a `colorScheme` prop, but it's not wired through the web component. This means users embedding diagrams in light-themed pages (e.g. Quarto books) get dark backgrounds with no way to override.

## Solution

- Added `color-scheme` to `observedAttributes`
- Added `colorScheme` to the Zod props schema as an optional literal `['light', 'dark']`
- Parse and pass `color-scheme` attribute through to the React component
- Updated documentation table

## Usage

```html
<likec4-view view-id="index" color-scheme="light"></likec4-view>
```

When omitted, behavior is unchanged (follows system preference).

Fixes #2954