### PR TITLE
feat: support AI chat for static builds

### DIFF
--- a/.changeset/ai-static-chat.md
+++ b/.changeset/ai-static-chat.md
@@ -1,0 +1,7 @@
+---
+"@likec4/vite-plugin": patch
+"likec4": patch
+"@likec4/spa": patch
+---
+
+Add proxy-backed AI chat for static builds without embedding provider credentials in generated assets.

--- a/apps/docs/src/content/docs/guides/static-website.mdx
+++ b/apps/docs/src/content/docs/guides/static-website.mdx
@@ -34,12 +34,41 @@ Available options:
 | `--use-dot`             | Use local binaries of Graphviz ("dot") instead of bundled WASM                                        |
 | `--title`               | Base title of the app pages (default is "LikeC4")                                                     |
 | `--output-single-file`  | Generates a single self-contained HTML file                                                           |
+| `--ai-endpoint`         | LikeC4 AI proxy endpoint used by the browser chat                                                     |
 
 To see all available options run:
 ```sh
 npx likec4 build -h
 ```
 
+## AI chat
+
+Static files cannot safely contain provider API keys. To enable the AI chat, run a LikeC4 AI proxy with the key in its server-side environment and build the site with the proxy URL:
+
+Terminal 1:
+```sh
+OPENAI_API_KEY=... \
+OPENAI_CHAT_MODEL=gpt-5.2 \
+npx likec4 ai-proxy
+```
+
+Terminal 2:
+```sh
+npx likec4 build -o ./dist --ai-endpoint /__likec4_ai
+```
+
+`--ai-endpoint` expects the LikeC4 proxy URL, not the raw provider API URL.
+The OpenAI adapter uses the Responses API; compatible provider endpoints must support `/v1/responses`.
+Set `OPENAI_BASE_URL` to the provider root when using an OpenAI SDK-compatible endpoint.
+For production, route the static files and `/__likec4_ai` through the same authenticated host when possible.
+If the static site and proxy use different browser origins, start the proxy with an explicit `--cors-origin https://your-site.example`.
+CORS only controls which browser origins may call the proxy; it is not authentication.
+Put production proxies behind authorization, rate limits, quotas, TLS, and an audit/logging policy that matches the data in your model.
+
+:::caution
+The AI proxy can spend tokens from the configured provider account. Do not expose it as an unauthenticated public endpoint; put it behind your normal authentication, network boundary, or gateway controls.
+Chat messages and selected LikeC4 context are sent to the configured provider or proxy. Review provider retention and compliance terms before using external or custom `OPENAI_BASE_URL` endpoints.
+:::
 
 ## Deploy
 

--- a/apps/docs/src/content/docs/tooling/ai-tools.mdx
+++ b/apps/docs/src/content/docs/tooling/ai-tools.mdx
@@ -12,6 +12,46 @@ import { Aside, CardGrid, LinkCard, TabItem as Tab, Tabs } from '@astrojs/starli
 
 LikeC4 provides two complementary tools for AI-powered development: **Agent Skills** for teaching AI assistants the DSL syntax, and an **MCP Server** for querying your architecture model.
 
+## AI chat
+
+The browser app can show an AI assistant when an AI provider is configured.
+`likec4 start` detects provider credentials from environment variables and serves the chat endpoint locally.
+For OpenAI, set `OPENAI_API_KEY` and optionally `OPENAI_CHAT_MODEL`.
+The OpenAI adapter uses the Responses API; compatible provider endpoints must support `/v1/responses`.
+Set `OPENAI_BASE_URL` when using an OpenAI SDK-compatible endpoint instead of the default OpenAI endpoint.
+
+```sh
+OPENAI_API_KEY=... \
+OPENAI_CHAT_MODEL=gpt-5.2 \
+likec4 start
+```
+
+For static builds, keep the provider key on a server-side proxy and point the static page at that proxy:
+
+Terminal 1:
+```sh
+OPENAI_API_KEY=... \
+OPENAI_CHAT_MODEL=gpt-5.2 \
+likec4 ai-proxy
+```
+
+Terminal 2:
+```sh
+likec4 build -o ./dist --ai-endpoint /__likec4_ai
+```
+
+Pass the LikeC4 proxy URL to `--ai-endpoint`, not the raw provider API URL.
+For OpenAI SDK-compatible endpoints, use the provider root URL in `OPENAI_BASE_URL`.
+The safest production setup is same-origin routing: serve the static files and proxy `/__likec4_ai` from the same authenticated host.
+If the proxy is on another browser origin, configure an explicit `--cors-origin`; do not use CORS as authentication.
+Production proxies should also enforce authorization, rate limits, quotas, TLS, and an audit/logging policy appropriate for architecture data.
+
+:::caution
+Chat messages and selected LikeC4 context are sent to the configured AI provider or proxy.
+Model metadata, links, relationships, and tool results may expose sensitive architecture or safety information.
+Review provider retention and compliance terms before using external or custom `OPENAI_BASE_URL` endpoints.
+:::
+
 ## Agent Skills
 
 Agent skills are DSL references that AI coding assistants load automatically when editing `.c4`/`.likec4` files.

--- a/apps/docs/src/content/docs/tooling/cli.mdx
+++ b/apps/docs/src/content/docs/tooling/cli.mdx
@@ -138,6 +138,7 @@ likec4 build -o ./dist
 | `--webcomponent-prefix` | Prefix for web components, e.g. "c4" generates `<c4-view ../>`                                        |
 | `--title`               | Base title of the app pages (default is "LikeC4")                                                     |
 | `--output-single-file`  | Generates a single self-contained HTML file                                                           |
+| `--ai-endpoint`         | LikeC4 AI proxy endpoint used by the browser chat                                                     |
 
 :::note
 Internally, CLI uses Vite to build the website, and `likec4 build` calls `vite build`.  
@@ -146,6 +147,32 @@ Vite [deploy documentation](https://vitejs.dev/guide/static-deploy.html) may als
 Repository [likec4/template](https://github.com/likec4/template) demonstrates how to deploy likec4 website to github pages.
 :::
 
+Static pages cannot safely contain provider API keys. To enable the AI chat in a static build, run a LikeC4 AI proxy and pass its browser-facing endpoint:
+
+Terminal 1:
+```sh
+OPENAI_API_KEY=... \
+OPENAI_CHAT_MODEL=gpt-5.2 \
+likec4 ai-proxy
+```
+
+Terminal 2:
+```sh
+likec4 build -o ./dist --ai-endpoint /__likec4_ai
+```
+
+The OpenAI adapter uses the Responses API; compatible provider endpoints must support `/v1/responses`.
+Set `OPENAI_BASE_URL` to the provider root when using an OpenAI SDK-compatible endpoint.
+Route the static files and `/__likec4_ai` through the same authenticated host when possible.
+If the proxy is on another browser origin, configure an explicit `--cors-origin https://your-site.example`.
+The proxy also supports `--max-body-size` to limit incoming chat request bodies.
+CORS only controls browser origins; it does not authenticate users.
+For production, enforce authorization, rate limits, quotas, TLS, and an audit/logging policy appropriate for architecture data.
+
+:::caution
+The AI proxy uses the configured provider credentials on behalf of browser users. Do not expose it as an unauthenticated public endpoint; protect it with your normal authentication, network boundary, or gateway controls.
+Chat messages and selected LikeC4 context are sent to the configured provider or proxy. Review provider retention and compliance terms before using external or custom `OPENAI_BASE_URL` endpoints.
+:::
 
 There is also a supplementary command to preview the build:
 

--- a/packages/likec4-spa/src/aichat/useChat.tsx
+++ b/packages/likec4-spa/src/aichat/useChat.tsx
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { type Fqn, nonexhaustive } from '@likec4/core'
 import { useDiagram } from '@likec4/diagram'
 import type { Types, XYStoreState } from '@likec4/diagram/custom'
@@ -8,6 +15,7 @@ import {
 } from '@tanstack/ai-client'
 import { type UseChatOptions, fetchServerSentEvents, useChat as useTanstackChat } from '@tanstack/ai-react'
 import { useNavigate } from '@tanstack/react-router'
+import { aiEndpoint } from 'likec4:rpc'
 import { useEffect, useMemo } from 'react'
 import { find, map, pipe } from 'remeda'
 import { parse, stringify } from 'superjson'
@@ -146,10 +154,15 @@ const storage = {
 }
 
 export function useChat(options: Omit<UseChatOptions, 'connection' | 'tools' | 'initialMessages'>) {
-  const memoProps = useMemo(() => ({
-    connection: fetchServerSentEvents('/__likec4_ai'),
-    initialMessages: storage.read(),
-  }), [])
+  const memoProps = useMemo(() => {
+    if (!aiEndpoint) {
+      throw new Error('AI chat endpoint is not configured')
+    }
+    return {
+      connection: fetchServerSentEvents(aiEndpoint),
+      initialMessages: storage.read(),
+    }
+  }, [])
   const chat = useTanstackChat({
     ...memoProps,
     ...options,

--- a/packages/likec4-spa/src/pages/ViewEditor.tsx
+++ b/packages/likec4-spa/src/pages/ViewEditor.tsx
@@ -9,7 +9,7 @@ import { LikeC4Diagram, LikeC4EditorProvider } from '@likec4/diagram'
 import { useCallbackRef } from '@mantine/hooks'
 import { useNavigate, useSearch } from '@tanstack/react-router'
 import { isDevelopment } from 'likec4:app-config'
-import { isAIAvailable, likec4rpc } from 'likec4:rpc'
+import { isAIAvailable, isLocalAIAvailable, likec4rpc } from 'likec4:rpc'
 import { AIChat, SemanticLayoutLog } from '../aichat'
 import { NotFound } from '../components/NotFound'
 import { useLikeC4ModelAtom } from '../context/safeCtx'
@@ -57,7 +57,7 @@ export function ViewEditor() {
           }
           return likec4rpc.updateView(event)
         },
-        ...(isAIAvailable && {
+        ...(isLocalAIAvailable && {
           applySemanticLayout: (viewId) => {
             return likec4rpc.applySemanticLayout({
               projectId: project.id,
@@ -99,12 +99,8 @@ export function ViewEditor() {
         <ListenForDynamicVariantChange />
         <OpenRelationshipBrowserFromUrl />
         <FocusElementFromUrl />
-        {isAIAvailable && (
-          <>
-            <AIChat />
-            <SemanticLayoutLog />
-          </>
-        )}
+        {isAIAvailable && <AIChat />}
+        {isLocalAIAvailable && <SemanticLayoutLog />}
       </LikeC4Diagram>
     </LikeC4EditorProvider>
   )

--- a/packages/likec4-spa/src/pages/ViewReact.tsx
+++ b/packages/likec4-spa/src/pages/ViewReact.tsx
@@ -18,7 +18,9 @@ import { useCallbackRef, useDocumentTitle } from '@mantine/hooks'
 import { useIsMounted } from '@react-hookz/web'
 import { useNavigate, useRouter, useSearch } from '@tanstack/react-router'
 import { pageTitle as defaultPageTitle } from 'likec4:app-config'
+import { isAIAvailable } from 'likec4:rpc'
 import { useRef } from 'react'
+import { AIChat } from '../aichat'
 import { NotFound } from '../components/NotFound'
 import { useCurrentView } from '../hooks'
 
@@ -88,6 +90,7 @@ export function ViewReact() {
       <ListenForDynamicVariantChange />
       <OpenRelationshipBrowserFromUrl />
       <FocusElementFromUrl />
+      {isAIAvailable && <AIChat />}
     </LikeC4Diagram>
   )
 }

--- a/packages/likec4-spa/start-dev.ts
+++ b/packages/likec4-spa/start-dev.ts
@@ -1,5 +1,12 @@
 #!/usr/bin/env -S pnpm tsx
 
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { LikeC4VitePlugin } from '@likec4/vite-plugin'
 import postcssPanda from '@pandacss/dev/postcss'
 import babel from '@rolldown/plugin-babel'
@@ -61,6 +68,7 @@ const main = defineCommand({
           '@tabler/icons-react': '@tabler/icons-react/dist/esm/icons/index.mjs',
           'react-dom/server': resolve(import.meta.dirname, 'src/react-dom-server-mock.ts'),
           // Local paths for dev
+          '@likec4/diagram/adhoc-editor': resolve(import.meta.dirname, '../diagram/src/adhoc-editor/index.ts'),
           '@likec4/diagram/custom': resolve(import.meta.dirname, '../diagram/src/custom/index.ts'),
           '@likec4/diagram': resolve(import.meta.dirname, '../diagram/src/index.ts'),
           'likec4/vite-plugin/internal': resolve(import.meta.dirname, '../vite-plugin/src/internal.ts'),

--- a/packages/likec4/package.json
+++ b/packages/likec4/package.json
@@ -124,6 +124,7 @@
     "@hpcc-js/wasm-graphviz": "catalog:externals",
     "@likec4/core": "workspace:*",
     "@likec4/icons": "workspace:*",
+    "@tanstack/ai": "catalog:ai",
     "@vitejs/plugin-react": "catalog:vite",
     "bundle-require": "catalog:externals",
     "esbuild": "catalog:esbuild",
@@ -139,7 +140,6 @@
     "nano-spawn": "catalog:externals"
   },
   "peerDependencies": {
-    "@tanstack/ai": "catalog:ai",
     "@tanstack/ai-anthropic": "catalog:ai",
     "@tanstack/ai-gemini": "catalog:ai",
     "@tanstack/ai-openai": "catalog:ai",
@@ -149,9 +149,6 @@
     "react-dom": "^18.x || ^19.x"
   },
   "peerDependenciesMeta": {
-    "@tanstack/ai": {
-      "optional": true
-    },
     "@tanstack/ai-anthropic": {
       "optional": true
     },

--- a/packages/likec4/src/cli/ai-proxy/index.spec.ts
+++ b/packages/likec4/src/cli/ai-proxy/index.spec.ts
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import { LIKEC4_AI_ENDPOINT_PATH } from '@likec4/vite-plugin/ai/server'
+import type { IncomingMessage } from 'node:http'
+import { createServer } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import { describe, expect, it } from 'vitest'
+import {
+  allowedCorsOrigin,
+  createAIProxyRequestHandler,
+  isLocalListenAddress,
+  validateAIProxyOptions,
+} from './index'
+
+function request(origin?: string): Pick<IncomingMessage, 'headers'> {
+  return {
+    headers: {
+      ...(origin && { origin }),
+    },
+  }
+}
+
+const fakeAI = {
+  adapter: {
+    name: 'test-adapter',
+  },
+} as Parameters<typeof createAIProxyRequestHandler>[0]['ai']
+
+async function withProxyServer(
+  callback: (baseUrl: string) => Promise<void>,
+  options: {
+    corsOrigin?: string
+    maxBodySize?: number
+  } = {},
+) {
+  const server = createServer(createAIProxyRequestHandler({
+    ai: fakeAI,
+    listen: '127.0.0.1',
+    port: 0,
+    maxBodySize: options.maxBodySize,
+    corsOrigin: options.corsOrigin,
+  }))
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', reject)
+      resolve()
+    })
+  })
+  const { port } = server.address() as AddressInfo
+  try {
+    await callback(`http://127.0.0.1:${port}`)
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close(error => error ? reject(error) : resolve())
+    })
+  }
+}
+
+describe('ai-proxy CORS options', () => {
+  it('does not enable cross-origin requests by default', () => {
+    expect(allowedCorsOrigin(request('https://site.example'), undefined)).toBeUndefined()
+  })
+
+  it('allows only explicitly configured origins', () => {
+    expect(
+      allowedCorsOrigin(request('https://site.example'), 'https://site.example, https://other.example'),
+    ).toBe('https://site.example')
+    expect(
+      allowedCorsOrigin(request('https://blocked.example'), 'https://site.example, https://other.example'),
+    ).toBeUndefined()
+  })
+
+  it('rejects wildcard CORS when listening on a public interface', () => {
+    expect(() =>
+      validateAIProxyOptions({
+        listen: '0.0.0.0',
+        corsOrigin: '*',
+        maxBodySize: 1024,
+      })
+    ).toThrow('Refusing --cors-origin "*"')
+  })
+
+  it('still allows wildcard CORS for local-only development', () => {
+    expect(isLocalListenAddress('localhost')).toBe(true)
+    expect(() =>
+      validateAIProxyOptions({
+        listen: 'localhost',
+        corsOrigin: '*',
+        maxBodySize: 1024,
+      })
+    ).not.toThrow()
+  })
+})
+
+describe('ai-proxy request handler', () => {
+  it('answers allowed CORS preflight requests', async () => {
+    await withProxyServer(async baseUrl => {
+      const response = await fetch(`${baseUrl}${LIKEC4_AI_ENDPOINT_PATH}`, {
+        method: 'OPTIONS',
+        headers: {
+          Origin: 'https://site.example',
+        },
+      })
+
+      expect(response.status).toBe(204)
+      expect(response.headers.get('access-control-allow-origin')).toBe('https://site.example')
+      expect(response.headers.get('access-control-allow-methods')).toBe('POST, OPTIONS')
+      expect(response.headers.get('access-control-allow-headers')).toBe('Content-Type')
+    }, { corsOrigin: 'https://site.example' })
+  })
+
+  it('does not advertise CORS methods for blocked origins', async () => {
+    await withProxyServer(async baseUrl => {
+      const response = await fetch(`${baseUrl}${LIKEC4_AI_ENDPOINT_PATH}`, {
+        method: 'OPTIONS',
+        headers: {
+          Origin: 'https://blocked.example',
+        },
+      })
+
+      expect(response.status).toBe(204)
+      expect(response.headers.get('access-control-allow-origin')).toBeNull()
+      expect(response.headers.get('access-control-allow-methods')).toBeNull()
+      expect(response.headers.get('access-control-allow-headers')).toBeNull()
+    }, { corsOrigin: 'https://site.example' })
+  })
+
+  it('exposes a health endpoint for GET and HEAD only', async () => {
+    await withProxyServer(async baseUrl => {
+      const getResponse = await fetch(`${baseUrl}/health`)
+      expect(getResponse.status).toBe(200)
+      await expect(getResponse.json()).resolves.toEqual({
+        ok: true,
+        adapter: 'test-adapter',
+      })
+
+      const headResponse = await fetch(`${baseUrl}/health`, { method: 'HEAD' })
+      expect(headResponse.status).toBe(200)
+      expect(await headResponse.text()).toBe('')
+
+      const postResponse = await fetch(`${baseUrl}/health`, { method: 'POST' })
+      expect(postResponse.status).toBe(405)
+      expect(postResponse.headers.get('allow')).toBe('GET, HEAD')
+    })
+  })
+
+  it('returns route and method errors with stable headers', async () => {
+    await withProxyServer(async baseUrl => {
+      const notFound = await fetch(`${baseUrl}/missing`)
+      expect(notFound.status).toBe(404)
+      await expect(notFound.json()).resolves.toEqual({ error: 'not found' })
+
+      const wrongMethod = await fetch(`${baseUrl}${LIKEC4_AI_ENDPOINT_PATH}`)
+      expect(wrongMethod.status).toBe(405)
+      expect(wrongMethod.headers.get('allow')).toBe('POST, OPTIONS')
+    })
+  })
+
+  it('rejects oversized request bodies before calling the AI provider', async () => {
+    await withProxyServer(async baseUrl => {
+      const response = await fetch(`${baseUrl}${LIKEC4_AI_ENDPOINT_PATH}`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ messages: [] }),
+      })
+
+      expect(response.status).toBe(413)
+      await expect(response.json()).resolves.toEqual({
+        error: 'LikeC4 AI request body exceeds 4 bytes',
+      })
+    }, { maxBodySize: 4 })
+  })
+
+  it('rejects invalid AI request body shapes', async () => {
+    await withProxyServer(async baseUrl => {
+      const response = await fetch(`${baseUrl}${LIKEC4_AI_ENDPOINT_PATH}`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ data: {} }),
+      })
+
+      expect(response.status).toBe(400)
+      await expect(response.json()).resolves.toEqual({
+        error: 'AI request body messages must be an array',
+      })
+    })
+  })
+})

--- a/packages/likec4/src/cli/ai-proxy/index.ts
+++ b/packages/likec4/src/cli/ai-proxy/index.ts
@@ -1,0 +1,281 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import { loggable } from '@likec4/log'
+import { detectAI } from '@likec4/vite-plugin/ai/detect'
+import {
+  createLikeC4AIResponse,
+  DEFAULT_LIKEC4_AI_REQUEST_MAX_BYTES,
+  LIKEC4_AI_ENDPOINT_PATH,
+  LikeC4AIRequestBodyTooLargeError,
+  LikeC4AIRequestBodyValidationError,
+  readLikeC4AIRequestBody,
+} from '@likec4/vite-plugin/ai/server'
+import { createServer } from 'node:http'
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import { Readable } from 'node:stream'
+import k from 'tinyrainbow'
+import type * as yargs from 'yargs'
+
+const DEFAULT_PORT = 33336
+
+type HandlerParams = {
+  listen?: string | undefined
+  port?: number | undefined
+  corsOrigin?: string | undefined
+  maxBodySize?: number | undefined
+}
+
+type AIOptions = NonNullable<Awaited<ReturnType<typeof detectAI>>>
+
+type AIProxyRequestHandlerParams = HandlerParams & {
+  ai: AIOptions
+}
+
+type ValidateAIProxyOptionsParams = Pick<HandlerParams, 'corsOrigin' | 'listen' | 'maxBodySize'>
+
+function splitCorsOrigins(corsOrigin: string | undefined): Array<string> {
+  return corsOrigin?.split(',').map(value => value.trim()).filter(Boolean) ?? []
+}
+
+export function isLocalListenAddress(listen: string | undefined): boolean {
+  const host = (listen ?? 'localhost').trim().toLowerCase()
+  return host === 'localhost' || host === '127.0.0.1' || host === '::1'
+}
+
+export function allowedCorsOrigin(
+  req: Pick<IncomingMessage, 'headers'>,
+  corsOrigin: string | undefined,
+): string | undefined {
+  const allowed = splitCorsOrigins(corsOrigin)
+  if (allowed.length === 0) {
+    return undefined
+  }
+  const origin = req.headers.origin
+  if (!origin) {
+    return allowed.includes('*') ? '*' : undefined
+  }
+  if (allowed.includes('*')) {
+    return '*'
+  }
+  return allowed.includes(origin) ? origin : undefined
+}
+
+export function validateAIProxyOptions({
+  listen,
+  corsOrigin,
+  maxBodySize = DEFAULT_LIKEC4_AI_REQUEST_MAX_BYTES,
+}: ValidateAIProxyOptionsParams): void {
+  if (!Number.isFinite(maxBodySize) || maxBodySize <= 0) {
+    throw new Error('--max-body-size must be a positive number of bytes')
+  }
+  if (!isLocalListenAddress(listen) && splitCorsOrigins(corsOrigin).includes('*')) {
+    throw new Error('Refusing --cors-origin "*" while listening on a public interface')
+  }
+}
+
+function setCorsHeaders(req: IncomingMessage, res: ServerResponse, corsOrigin: string | undefined) {
+  const allowedOrigin = allowedCorsOrigin(req, corsOrigin)
+  if (!allowedOrigin) {
+    return
+  }
+  res.setHeader('Access-Control-Allow-Origin', allowedOrigin)
+  if (allowedOrigin !== '*') {
+    res.setHeader('Vary', 'Origin')
+  }
+  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS')
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type')
+}
+
+function writeJson(
+  res: ServerResponse,
+  status: number,
+  body: unknown,
+  options: {
+    headers?: Record<string, string>
+    headOnly?: boolean
+  } = {},
+) {
+  res.writeHead(status, {
+    'Content-Type': 'application/json',
+    ...options.headers,
+  })
+  res.end(options.headOnly ? undefined : JSON.stringify(body))
+}
+
+function writeAIProxyError(res: ServerResponse, error: unknown) {
+  if (error instanceof LikeC4AIRequestBodyTooLargeError) {
+    writeJson(res, error.statusCode, { error: error.message })
+    return
+  }
+  if (error instanceof LikeC4AIRequestBodyValidationError) {
+    writeJson(res, error.statusCode, { error: error.message })
+    return
+  }
+  if (error instanceof SyntaxError) {
+    writeJson(res, 400, { error: 'invalid JSON body' })
+    return
+  }
+  writeJson(res, 500, { error: 'AI proxy request failed' })
+}
+
+export function createAIProxyRequestHandler({
+  ai,
+  listen = 'localhost',
+  port = DEFAULT_PORT,
+  corsOrigin,
+  maxBodySize = DEFAULT_LIKEC4_AI_REQUEST_MAX_BYTES,
+}: AIProxyRequestHandlerParams) {
+  return async (req: IncomingMessage, res: ServerResponse) => {
+    setCorsHeaders(req, res, corsOrigin)
+
+    if (req.method === 'OPTIONS') {
+      res.writeHead(204)
+      res.end()
+      return
+    }
+
+    const url = new URL(req.url ?? '/', `http://${req.headers.host ?? `${listen}:${port}`}`)
+    if (url.pathname === '/health') {
+      if (req.method !== 'GET' && req.method !== 'HEAD') {
+        writeJson(res, 405, { error: 'method not allowed' }, { headers: { Allow: 'GET, HEAD' } })
+        return
+      }
+      writeJson(res, 200, {
+        ok: true,
+        adapter: ai.adapter.name,
+      }, { headOnly: req.method === 'HEAD' })
+      return
+    }
+
+    if (url.pathname !== LIKEC4_AI_ENDPOINT_PATH) {
+      writeJson(res, 404, { error: 'not found' })
+      return
+    }
+
+    if (req.method !== 'POST') {
+      writeJson(res, 405, { error: 'method not allowed' }, { headers: { Allow: 'POST, OPTIONS' } })
+      return
+    }
+
+    try {
+      const body = await readLikeC4AIRequestBody(req, {
+        maxBytes: maxBodySize,
+      })
+      const response = createLikeC4AIResponse({ ai, body })
+      response.headers.forEach((value, key) => {
+        res.setHeader(key, value)
+      })
+      // Apply CORS headers after provider response headers so they cannot be overwritten.
+      setCorsHeaders(req, res, corsOrigin)
+      res.writeHead(response.status, response.statusText)
+
+      if (!response.body) {
+        res.end()
+        return
+      }
+
+      Readable.fromWeb(response.body as import('node:stream/web').ReadableStream<Uint8Array>)
+        .on('error', (error) => {
+          console.error(loggable(error))
+          if (!res.writableEnded) res.end()
+        })
+        .pipe(res, {
+          end: true,
+        })
+    } catch (error) {
+      console.error(loggable(error))
+      if (!res.headersSent) {
+        writeAIProxyError(res, error)
+      } else {
+        res.end()
+      }
+    }
+  }
+}
+
+async function handler({
+  listen = 'localhost',
+  port = DEFAULT_PORT,
+  corsOrigin,
+  maxBodySize = DEFAULT_LIKEC4_AI_REQUEST_MAX_BYTES,
+}: HandlerParams) {
+  validateAIProxyOptions({ listen, corsOrigin, maxBodySize })
+
+  const ai = await detectAI()
+  if (!ai) {
+    throw new Error(
+      [
+        'AI provider is not configured.',
+        'Set OPENAI_API_KEY and optionally OPENAI_CHAT_MODEL or OPENAI_BASE_URL,',
+        'or configure another supported provider.',
+      ].join(' '),
+    )
+  }
+
+  const server = createServer(createAIProxyRequestHandler({
+    ai,
+    listen,
+    port,
+    corsOrigin,
+    maxBodySize,
+  }))
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(port, listen, () => {
+      server.off('error', reject)
+      resolve()
+    })
+  })
+
+  const displayHost = listen === '0.0.0.0' ? 'localhost' : listen
+  console.info(
+    `${k.cyan('LikeC4 AI proxy')} ${k.green(`http://${displayHost}:${port}${LIKEC4_AI_ENDPOINT_PATH}`)}`,
+  )
+  console.info(`${k.dim('adapter')} ${k.green(ai.adapter.name)}`)
+}
+
+const aiProxyCmd = (yargs: yargs.Argv) => {
+  return yargs.command({
+    command: 'ai-proxy',
+    describe: 'Start a LikeC4 AI proxy for static websites',
+    builder: yargs =>
+      yargs
+        .option('listen', {
+          alias: 'l',
+          string: true,
+          desc: 'ip address of the network interface to listen on',
+          default: 'localhost',
+          nargs: 1,
+        })
+        .option('port', {
+          number: true,
+          desc: `port number for the AI proxy (default is ${DEFAULT_PORT})`,
+          default: DEFAULT_PORT,
+          nargs: 1,
+        })
+        .option('cors-origin', {
+          string: true,
+          desc: 'allowed browser origin for static pages, comma-separated; omit for same-origin deployments',
+          nargs: 1,
+        })
+        .option('max-body-size', {
+          number: true,
+          desc: `maximum request body size in bytes (default is ${DEFAULT_LIKEC4_AI_REQUEST_MAX_BYTES})`,
+          default: DEFAULT_LIKEC4_AI_REQUEST_MAX_BYTES,
+          nargs: 1,
+        }),
+    handler: async args => {
+      await handler({
+        listen: args.listen,
+        port: args.port,
+        corsOrigin: args['cors-origin'],
+        maxBodySize: args['max-body-size'],
+      })
+    },
+  })
+}
+
+export default aiProxyCmd

--- a/packages/likec4/src/cli/build/index.ts
+++ b/packages/likec4/src/cli/build/index.ts
@@ -1,4 +1,3 @@
-
 // SPDX-License-Identifier: MIT
 //
 // Copyright (c) 2023-2026 Denis Davydkov
@@ -14,6 +13,7 @@ import { createLikeC4Logger } from '../../logger'
 import { viteBuild } from '../../vite/vite-build'
 import { ensureReact } from '../ensure-libs'
 import {
+  aiEndpoint,
   base,
   outputSingleFile,
   path,
@@ -42,6 +42,7 @@ const buildCmd = (yargs: yargs.Argv) => {
             coerce: resolve,
           })
           .option('base', base)
+          .option('ai-endpoint', aiEndpoint)
           .option('use-hash-history', useHashHistory)
           .option('use-dot', useDotBin)
           .option('webcomponent-prefix', webcomponentPrefix)
@@ -82,6 +83,7 @@ const buildCmd = (yargs: yargs.Argv) => {
           customLogger: logger,
           webcomponentPrefix: params.webcomponentPrefix,
           title: args.title,
+          aiEndpoint: args['ai-endpoint'],
           theme: args.theme,
           languageServices,
           likec4AssetsDir,

--- a/packages/likec4/src/cli/index.ts
+++ b/packages/likec4/src/cli/index.ts
@@ -1,5 +1,12 @@
 #!/usr/bin/env node
 
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import type { ConfigureLanguageServerLoggerOptions } from '@likec4/language-server'
 import {
   configureLogger,
@@ -16,6 +23,7 @@ import k from 'tinyrainbow'
 import yargs from 'yargs'
 import { hideBin } from 'yargs/helpers'
 import pkg from '../../package.json' with { type: 'json' }
+import aiProxyCmd from './ai-proxy'
 import buildCmd from './build'
 import checkUpdateCmd, { notifyAvailableUpdate } from './check-update'
 import codegenCmd from './codegen'
@@ -64,6 +72,7 @@ async function main() {
   const y = pipe(
     yargs(hideBin(argv)),
     serveCmd,
+    aiProxyCmd,
     buildCmd,
     codegenCmd,
     exportCmd,

--- a/packages/likec4/src/cli/options.ts
+++ b/packages/likec4/src/cli/options.ts
@@ -84,6 +84,12 @@ export const outputSingleFile = {
   desc: 'outputs a single self-contained HTML file with all required resources inlined',
 } as const satisfies Options
 
+export const aiEndpoint = {
+  string: true,
+  desc: 'LikeC4 AI proxy endpoint used by the browser chat',
+  nargs: 1,
+} as const satisfies Options
+
 export const listen = {
   alias: 'l',
   string: true,
@@ -106,7 +112,8 @@ export const port = {
 
 export const hmrPort = {
   number: true,
-  desc: 'port number for the HMR WebSocket server (default is auto-discovered from 24678-24690, or HMR_PORT environment variable)',
+  desc:
+    'port number for the HMR WebSocket server (default is auto-discovered from 24678-24690, or HMR_PORT environment variable)',
   nargs: 1,
 } as const satisfies Options
 

--- a/packages/likec4/src/cli/serve/index.ts
+++ b/packages/likec4/src/cli/serve/index.ts
@@ -1,6 +1,24 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import type * as yargs from 'yargs'
 import { ensureReact } from '../ensure-libs'
-import { base, hmrPort, listen, path, port, title, useDotBin, useHashHistory, webcomponentPrefix } from '../options'
+import {
+  aiEndpoint,
+  base,
+  hmrPort,
+  listen,
+  path,
+  port,
+  title,
+  useDotBin,
+  useHashHistory,
+  webcomponentPrefix,
+} from '../options'
 import { handler } from './serve'
 
 const serveCmd = (yargs: yargs.Argv) => {
@@ -15,6 +33,7 @@ const serveCmd = (yargs: yargs.Argv) => {
           .option('base', base)
           .option('webcomponent-prefix', webcomponentPrefix)
           .option('title', title)
+          .option('ai-endpoint', aiEndpoint)
           .option('use-hash-history', useHashHistory)
           .option('use-dot', useDotBin)
           .option('listen', listen)
@@ -40,6 +59,7 @@ const serveCmd = (yargs: yargs.Argv) => {
           base: args.base,
           webcomponentPrefix: args['webcomponent-prefix'],
           title: args['title'],
+          aiEndpoint: args['ai-endpoint'],
           useHashHistory: args['use-hash-history'],
           listen: args['listen'],
           port: args['port'],

--- a/packages/likec4/src/cli/serve/serve.ts
+++ b/packages/likec4/src/cli/serve/serve.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { fromWorkspace } from '@likec4/language-services/node'
 import { mkdtemp } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
@@ -27,6 +34,11 @@ type HandlerParams = {
    * base title of the app pages
    */
   title: string | undefined
+
+  /**
+   * Public LikeC4 AI proxy endpoint used by the browser chat.
+   */
+  aiEndpoint?: string | undefined
 
   /**
    * ip address of the network interface to listen on
@@ -65,6 +77,7 @@ export async function handler({
   useDotBin,
   webcomponentPrefix,
   title,
+  aiEndpoint,
   useHashHistory,
   enableWebcomponent = true,
   enableHMR = true,
@@ -91,6 +104,7 @@ export async function handler({
     base,
     webcomponentPrefix,
     title,
+    aiEndpoint,
     languageServices,
     useHashHistory,
     likec4AssetsDir,

--- a/packages/likec4/src/vite/config-app.ts
+++ b/packages/likec4/src/vite/config-app.ts
@@ -29,6 +29,7 @@ export type LikeC4ViteConfig = {
   useHashHistory?: boolean | undefined
   likec4AssetsDir: string
   outputSingleFile?: boolean | undefined
+  aiEndpoint?: string | undefined
 }
 
 export const viteConfig = async ({ languageServices, likec4AssetsDir, ...cfg }: LikeC4ViteConfig) => {
@@ -111,6 +112,7 @@ export const viteConfig = async ({ languageServices, likec4AssetsDir, ...cfg }: 
       react(),
       LikeC4VitePlugin({
         languageServices: languageServices.languageServices,
+        aiEndpoint: cfg.aiEndpoint,
         appConfig: {
           webcomponentPrefix,
           pageTitle: title,

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -40,6 +40,8 @@
         "default": "./dist/internal/index.mjs"
       }
     },
+    "./ai/detect": "./src/ai/detect-ai.ts",
+    "./ai/server": "./src/ai/server.ts",
     "./ai/tools": "./src/ai/tools.ts",
     "./modules": "./src/modules.d.ts",
     "./package.json": "./package.json"

--- a/packages/vite-plugin/src/ai/enableServer.ts
+++ b/packages/vite-plugin/src/ai/enableServer.ts
@@ -1,32 +1,20 @@
-import { invariant } from '@likec4/core'
-import { chat, convertMessagesToModelMessages, toServerSentEventsResponse } from '@tanstack/ai'
-import type { ModelMessage, UIMessage } from '@tanstack/ai'
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
 import { Readable } from 'node:stream'
-import type { MinimalPluginContextWithoutEnvironment, ViteDevServer } from 'vite'
-import { logger } from '../logger'
-import type { AIOptions } from '../plugin'
+import type { MinimalPluginContextWithoutEnvironment } from 'vite'
 import type { SharedVirtualModuleOptions } from '../virtuals/_shared'
-import { navigateToDef, readUiStateDef, updateUiStateDef } from './tools'
+import {
+  createLikeC4AIResponse,
+  LIKEC4_AI_ENDPOINT_PATH,
+  LikeC4AIRequestBodyTooLargeError,
+  LikeC4AIRequestBodyValidationError,
+  readLikeC4AIRequestBody,
+} from './server'
 
 export type AIServerParams = SharedVirtualModuleOptions & {
-  ai?: AIOptions | undefined
-  server: ViteDevServer
-}
-
-type ChatRequestBody = {
-  messages: Array<UIMessage | ModelMessage>
-  data: Record<string, any>
-}
-
-async function readJsonBody(req: ReadableStream): Promise<ChatRequestBody> {
-  const chunks = [] as string[]
-  logger.info('Reading request')
-  for await (const chunk of req) {
-    const str = Buffer.from(chunk).toString()
-    process.stdout.write(str)
-    chunks.push(str)
-  }
-  return JSON.parse(chunks.join(''))
+  server: import('vite').ViteDevServer
 }
 
 export function enableAIServer(
@@ -34,33 +22,15 @@ export function enableAIServer(
   params: AIServerParams,
 ) {
   const { ai, server, logger } = params
-  invariant(ai, 'AI is not configured')
 
-  server.middlewares.use('/__likec4_ai', async (req, res, next) => {
+  server.middlewares.use(LIKEC4_AI_ENDPOINT_PATH, async (req, res, next) => {
     if (req.method !== 'POST') {
       next()
       return
     }
     try {
-      const body = await readJsonBody(Readable.toWeb(req))
-      const messages = convertMessagesToModelMessages(body.messages ?? [])
-
-      const stream = chat({
-        ...ai,
-        messages,
-        debug: true,
-        conversationId: body.data['conversationId'],
-        systemPrompts: [
-          'You are a helpful assistant that can answer questions about LikeC4 model and update UI.',
-        ],
-        tools: [
-          navigateToDef,
-          updateUiStateDef,
-          readUiStateDef,
-        ],
-      })
-
-      const response = toServerSentEventsResponse(stream)
+      const body = await readLikeC4AIRequestBody(req)
+      const response = createLikeC4AIResponse({ ai, body })
       response.headers.forEach((value, key) => {
         res.setHeader(key, value)
       })
@@ -82,8 +52,22 @@ export function enableAIServer(
     } catch (err) {
       logger.error('AI request failed', { error: err })
       if (!res.headersSent) {
-        res.writeHead(500, { 'Content-Type': 'application/json' })
-        res.end(JSON.stringify({ error: err instanceof Error ? err.message : String(err) }))
+        const status = err instanceof LikeC4AIRequestBodyTooLargeError
+          ? err.statusCode
+          : err instanceof LikeC4AIRequestBodyValidationError
+          ? err.statusCode
+          : err instanceof SyntaxError
+          ? 400
+          : 500
+        const message = err instanceof LikeC4AIRequestBodyTooLargeError
+          ? err.message
+          : err instanceof LikeC4AIRequestBodyValidationError
+          ? err.message
+          : err instanceof SyntaxError
+          ? 'invalid JSON body'
+          : 'AI request failed'
+        res.writeHead(status, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ error: message }))
       } else {
         res.end()
       }

--- a/packages/vite-plugin/src/ai/server.spec.ts
+++ b/packages/vite-plugin/src/ai/server.spec.ts
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import { describe, expect, it } from 'vitest'
+import { LikeC4AIRequestBodyTooLargeError, readLikeC4AIRequestBody } from './server'
+
+async function* bodyChunks(...chunks: Array<string | Uint8Array>): AsyncIterable<unknown> {
+  for (const chunk of chunks) {
+    yield chunk
+  }
+}
+
+describe('readLikeC4AIRequestBody', () => {
+  it('parses request chunks into a chat request body', async () => {
+    await expect(
+      readLikeC4AIRequestBody(bodyChunks('{"messages"', ':[]}'), {
+        maxBytes: 32,
+      }),
+    ).resolves.toEqual({
+      messages: [],
+    })
+  })
+
+  it('rejects request bodies larger than the configured limit', async () => {
+    await expect(
+      readLikeC4AIRequestBody(bodyChunks('{"messages":[] }'), {
+        maxBytes: 8,
+      }),
+    ).rejects.toThrow(LikeC4AIRequestBodyTooLargeError)
+  })
+
+  it('rejects invalid request body shapes', async () => {
+    await expect(
+      readLikeC4AIRequestBody(bodyChunks('{"data":{}}')),
+    ).rejects.toThrow('AI request body messages must be an array')
+
+    await expect(
+      readLikeC4AIRequestBody(bodyChunks('{"messages":[],"data":[]}')),
+    ).rejects.toThrow('AI request body data must be an object')
+  })
+})

--- a/packages/vite-plugin/src/ai/server.ts
+++ b/packages/vite-plugin/src/ai/server.ts
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import { invariant } from '@likec4/core'
+import { chat, convertMessagesToModelMessages, toServerSentEventsResponse } from '@tanstack/ai'
+import type { ModelMessage, UIMessage } from '@tanstack/ai'
+import type { AIOptions } from '../plugin'
+import { navigateToDef, readUiStateDef, updateUiStateDef } from './tools'
+
+export const LIKEC4_AI_ENDPOINT_PATH = '/__likec4_ai'
+export const DEFAULT_LIKEC4_AI_REQUEST_MAX_BYTES = 4 * 1024 * 1024
+
+export type LikeC4AIRequestBody = {
+  messages: Array<UIMessage | ModelMessage>
+  data?: Record<string, unknown>
+}
+
+export class LikeC4AIRequestBodyValidationError extends Error {
+  readonly statusCode = 400
+
+  constructor(message: string) {
+    super(message)
+    this.name = 'LikeC4AIRequestBodyValidationError'
+  }
+}
+
+export class LikeC4AIRequestBodyTooLargeError extends Error {
+  readonly statusCode = 413
+
+  constructor(readonly maxBytes: number) {
+    super(`LikeC4 AI request body exceeds ${maxBytes} bytes`)
+    this.name = 'LikeC4AIRequestBodyTooLargeError'
+  }
+}
+
+function validateLikeC4AIRequestBody(value: unknown): LikeC4AIRequestBody {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new LikeC4AIRequestBodyValidationError('AI request body must be an object')
+  }
+
+  const body = value as Record<string, unknown>
+  if (!Array.isArray(body['messages'])) {
+    throw new LikeC4AIRequestBodyValidationError('AI request body messages must be an array')
+  }
+
+  const data = body['data']
+  if (data !== undefined && (!data || typeof data !== 'object' || Array.isArray(data))) {
+    throw new LikeC4AIRequestBodyValidationError('AI request body data must be an object')
+  }
+
+  return {
+    messages: body['messages'] as Array<UIMessage | ModelMessage>,
+    ...(data && { data: data as Record<string, unknown> }),
+  }
+}
+
+export type ReadLikeC4AIRequestBodyOptions = {
+  maxBytes?: number | undefined
+}
+
+export async function readLikeC4AIRequestBody(
+  req: AsyncIterable<unknown>,
+  { maxBytes = DEFAULT_LIKEC4_AI_REQUEST_MAX_BYTES }: ReadLikeC4AIRequestBodyOptions = {},
+): Promise<LikeC4AIRequestBody> {
+  const chunks = [] as Buffer[]
+  let receivedBytes = 0
+  for await (const chunk of req) {
+    const buffer = typeof chunk === 'string'
+      ? Buffer.from(chunk)
+      : Buffer.isBuffer(chunk)
+      ? chunk
+      : Buffer.from(chunk as Uint8Array)
+    receivedBytes += buffer.byteLength
+    if (receivedBytes > maxBytes) {
+      throw new LikeC4AIRequestBodyTooLargeError(maxBytes)
+    }
+    chunks.push(buffer)
+  }
+  return validateLikeC4AIRequestBody(JSON.parse(Buffer.concat(chunks).toString('utf8')))
+}
+
+export type CreateLikeC4AIResponseParams = {
+  ai: AIOptions | undefined
+  body: LikeC4AIRequestBody
+}
+
+export function createLikeC4AIResponse({
+  ai,
+  body,
+}: CreateLikeC4AIResponseParams): Response {
+  invariant(ai, 'AI is not configured')
+
+  const messages = convertMessagesToModelMessages(body.messages ?? [])
+  const stream = chat({
+    ...ai,
+    messages,
+    conversationId: typeof body.data?.['conversationId'] === 'string' ? body.data['conversationId'] : undefined,
+    systemPrompts: [
+      'You are a helpful assistant that can answer questions about LikeC4 model and update UI.',
+    ],
+    tools: [
+      navigateToDef,
+      updateUiStateDef,
+      readUiStateDef,
+    ],
+  })
+
+  return toServerSentEventsResponse(stream)
+}

--- a/packages/vite-plugin/src/modules.d.ts
+++ b/packages/vite-plugin/src/modules.d.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 declare module 'likec4:projects' {
   import type { ProjectId } from 'likec4/model'
   type LandingPageConfig =
@@ -180,6 +187,10 @@ declare module 'likec4:rpc' {
   export const isRpcAvailable: boolean
 
   export const isAIAvailable: boolean
+
+  export const isLocalAIAvailable: boolean
+
+  export const aiEndpoint: string | undefined
 
   export const AIAdapter: string | undefined
 }

--- a/packages/vite-plugin/src/plugin.ts
+++ b/packages/vite-plugin/src/plugin.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import type { LikeC4LanguageServices } from '@likec4/language-services'
 import { fromWorkspace } from '@likec4/language-services/node'
 import { loggable } from '@likec4/log'
@@ -9,6 +16,7 @@ import type {
   PluginOption,
 } from 'vite'
 import { detectAI } from './ai/detect-ai'
+import { LIKEC4_AI_ENDPOINT_PATH } from './ai/server'
 import { iconBundlePlugin } from './icon-bundle-plugin'
 import { logger } from './logger'
 import { enablePluginRPC } from './rpc'
@@ -79,6 +87,16 @@ type SharedOptions = {
    * ```
    */
   ai?: 'disabled' | 'auto' | AIOptions | undefined
+
+  /**
+   * Browser-facing endpoint used by the in-browser AI chat.
+   *
+   * By default, `likec4 start` serves an internal endpoint at `/__likec4_ai`
+   * when an AI provider is configured. Static builds do not have a server, so
+   * pass a URL to a LikeC4 AI proxy to enable the chat without embedding
+   * provider credentials in the generated assets.
+   */
+  aiEndpoint?: string | undefined
 
   /**
    * Define vite environments where this plugin should be active
@@ -188,6 +206,7 @@ export function LikeC4VitePlugin({
   environments,
   appConfig,
   ai: _ai = 'auto',
+  aiEndpoint: configuredAIEndpoint,
   ...pluginOpts
 }: LikeC4VitePluginOptions): PluginOption {
   let likec4: LikeC4LanguageServices
@@ -195,6 +214,7 @@ export function LikeC4VitePlugin({
   let rpcEnabled = false
   let ai: AIOptions | undefined = undefined
   let shouldDisposeOnStop = pluginOpts.watch ?? false
+  const externalAIEndpoint = configuredAIEndpoint?.trim() || undefined
 
   const virtuals = [
     ..._virtuals,
@@ -222,10 +242,13 @@ export function LikeC4VitePlugin({
   function moduleopts<T>(
     value: Omit<T, keyof SharedVirtualModuleOptions> & Partial<Record<keyof SharedVirtualModuleOptions, never>>,
   ): SharedVirtualModuleOptions & T {
-    const isAIAvailable = !!ai
+    const aiEndpoint = externalAIEndpoint ?? (rpcEnabled && ai ? LIKEC4_AI_ENDPOINT_PATH : undefined)
+    const isAIAvailable = !!aiEndpoint
     return {
       rpcEnabled,
       isAIAvailable,
+      aiEndpoint,
+      aiAdapterName: ai?.adapter.name ?? (aiEndpoint ? 'external' : undefined),
       ai,
       assetsDir,
       likec4,
@@ -289,8 +312,8 @@ export function LikeC4VitePlugin({
       }
       assetsDir = likec4.workspaceUri.fsPath
 
-      // Initialize AI only if RPC is enabled
-      if (rpcEnabled) {
+      // Initialize AI only for the dev-server endpoint. Static builds use a configured external proxy.
+      if (rpcEnabled && !externalAIEndpoint) {
         ai = await initAI()
       }
     },

--- a/packages/vite-plugin/src/virtuals/_shared.ts
+++ b/packages/vite-plugin/src/virtuals/_shared.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import type { LikeC4ProjectConfig } from '@likec4/config'
 import type { LikeC4Project, NonEmptyArray, ProjectId } from '@likec4/core'
 import type { LikeC4LanguageServices } from '@likec4/language-services'
@@ -19,22 +26,16 @@ export type ProjectsData = NonEmptyArray<ProjectData>
 
 export type VirtualModuleLoadResult = Rolldown.SourceDescription | string
 
-export type SharedVirtualModuleOptions =
-  & {
-    rpcEnabled: boolean
-    logger: ViteLogger
-    likec4: LikeC4LanguageServices
-    assetsDir: string
-  }
-  & (
-    {
-      isAIAvailable: false
-      ai: undefined
-    } | {
-      isAIAvailable: false
-      ai: AIOptions
-    }
-  )
+export type SharedVirtualModuleOptions = {
+  rpcEnabled: boolean
+  logger: ViteLogger
+  likec4: LikeC4LanguageServices
+  assetsDir: string
+  isAIAvailable: boolean
+  ai: AIOptions | undefined
+  aiEndpoint: string | undefined
+  aiAdapterName: string | undefined
+}
 
 export interface VirtualModule {
   id: string

--- a/packages/vite-plugin/src/virtuals/rpc.spec.ts
+++ b/packages/vite-plugin/src/virtuals/rpc.spec.ts
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import { describe, expect, it } from 'vitest'
+import type { SharedVirtualModuleOptions } from './_shared'
+import { generateRpcModuleCode } from './rpc'
+
+function moduleOptions(
+  overrides: Partial<SharedVirtualModuleOptions>,
+): SharedVirtualModuleOptions {
+  return {
+    rpcEnabled: false,
+    logger: {} as SharedVirtualModuleOptions['logger'],
+    likec4: {} as SharedVirtualModuleOptions['likec4'],
+    assetsDir: '',
+    isAIAvailable: false,
+    ai: undefined,
+    aiEndpoint: undefined,
+    aiAdapterName: undefined,
+    ...overrides,
+  }
+}
+
+describe('rpc virtual module', () => {
+  it('enables AI chat for static builds when an external AI endpoint is configured', () => {
+    const code = generateRpcModuleCode(moduleOptions({
+      isAIAvailable: true,
+      aiEndpoint: 'https://proxy.example.com/__likec4_ai',
+      aiAdapterName: 'external',
+    }))
+
+    expect(code).toContain('export const isRpcAvailable = !!import.meta.hot && false')
+    expect(code).toContain('export const aiEndpoint = "https://proxy.example.com/__likec4_ai"')
+    expect(code).toContain('export const isAIAvailable = true && !!aiEndpoint')
+    expect(code).toContain('export const isLocalAIAvailable = isRpcAvailable && false')
+  })
+
+  it('uses the local dev-server AI endpoint when local AI is configured', () => {
+    const code = generateRpcModuleCode(moduleOptions({
+      rpcEnabled: true,
+      isAIAvailable: true,
+      ai: { adapter: { name: 'openai' } } as SharedVirtualModuleOptions['ai'],
+      aiEndpoint: '/__likec4_ai',
+      aiAdapterName: 'openai',
+    }))
+
+    expect(code).toContain('export const isRpcAvailable = !!import.meta.hot && true')
+    expect(code).toContain('export const aiEndpoint = "/__likec4_ai"')
+    expect(code).toContain('export const isAIAvailable = true && !!aiEndpoint')
+    expect(code).toContain('export const isLocalAIAvailable = isRpcAvailable && true')
+  })
+})

--- a/packages/vite-plugin/src/virtuals/rpc.ts
+++ b/packages/vite-plugin/src/virtuals/rpc.ts
@@ -1,13 +1,24 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { logGenerating } from '../logger'
 import type { SharedVirtualModuleOptions, VirtualModule } from './_shared'
 
-const code = ({ isAIAvailable, ai, rpcEnabled }: SharedVirtualModuleOptions) =>
+export const generateRpcModuleCode = (
+  { isAIAvailable, ai, aiAdapterName, aiEndpoint, rpcEnabled }: SharedVirtualModuleOptions,
+) =>
   ` 
 import { createRpc } from 'likec4/vite-plugin/internal'
 
 export const isRpcAvailable = !!import.meta.hot && ${rpcEnabled}
-export const isAIAvailable = isRpcAvailable && ${isAIAvailable}
-export const AIAdapter = ${JSON.stringify(ai?.adapter.name)}
+export const aiEndpoint = ${JSON.stringify(aiEndpoint)}
+export const isAIAvailable = ${isAIAvailable} && !!aiEndpoint
+export const isLocalAIAvailable = isRpcAvailable && ${!!ai}
+export const AIAdapter = ${JSON.stringify(aiAdapterName)}
 
 let rpc 
 if (isRpcAvailable) {
@@ -42,7 +53,7 @@ export const rpcModule: VirtualModule = {
   async load(opts) {
     logGenerating('rpc')
     return {
-      code: code(opts),
+      code: generateRpcModuleCode(opts),
       moduleType: 'js',
       moduleSideEffects: false,
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1809,6 +1809,9 @@ importers:
       '@likec4/icons':
         specifier: workspace:*
         version: link:../icons
+      '@tanstack/ai':
+        specifier: catalog:ai
+        version: 0.14.0
       '@tanstack/ai-anthropic':
         specifier: catalog:ai
         version: 0.8.3(@tanstack/ai@0.14.0)(zod@4.3.6)
@@ -1936,9 +1939,6 @@ importers:
       '@tabler/icons-react':
         specifier: catalog:react
         version: 3.40.0(react@19.2.4)
-      '@tanstack/ai':
-        specifier: catalog:ai
-        version: 0.14.0
       '@tanstack/react-router':
         specifier: catalog:tanstack
         version: 1.114.27(react-dom@19.2.4(react@19.2.4))(react@19.2.4)


### PR DESCRIPTION
## Summary
- adds `likec4 ai-proxy` so static AI chat can run without provider keys in generated web assets
- adds `--ai-endpoint` for `likec4 build` and `likec4 serve`, with static/read-only chat routed to that endpoint
- documents deployment expectations: server-side key storage, CORS scope, auth, rate limits, TLS, and audit controls

## Architecture
```mermaid
flowchart LR
  User[Browser user] --> Static[Static LikeC4 webapp\nS3 / CDN hosted files]
  Static -->|POST chat request\nconfigured --ai-endpoint| Proxy[likec4 ai-proxy\ntrusted server runtime]
  Proxy -->|OpenAI-compatible request\nAuthorization header added server-side| Provider[AI provider]
  Provider -->|streamed response| Proxy
  Proxy -->|streamed response| Static

  Build[likec4 build --ai-endpoint] --> Static
  Secret[API key / provider config] -. only on server .-> Proxy

  classDef trusted fill:#e8f5e9,stroke:#2e7d32,color:#111;
  classDef public fill:#fff3e0,stroke:#ef6c00,color:#111;
  classDef external fill:#e3f2fd,stroke:#1565c0,color:#111;
  class Proxy,Secret trusted;
  class User,Static,Build public;
  class Provider external;
```

Static assets only contain the AI endpoint URL. Provider credentials stay outside the generated webapp and are attached by `likec4 ai-proxy` at runtime. In dev mode, chat can still use the Vite/LSP-backed RPC path; in static builds this PR makes the browser call the configured proxy endpoint instead.

## Safety considerations
- **Credential boundary:** API keys are deployed only with the proxy process, not in S3/CDN assets or project config.
- **CORS scope:** allowed origins restrict browser use of the proxy, but CORS is not authentication.
- **Required deployment controls:** production deployments should add authentication/authorization, TLS, rate limits, quotas, and operational monitoring in front of or around the proxy.
- **Data disclosure:** chat prompts and diagram context are sent to the configured proxy/provider; docs call out review of provider retention, logging, and compliance requirements.
- **Failure handling:** proxy responses avoid leaking raw provider errors to browser clients; request size and method handling are covered by tests.

## Validation
- `npx -y pnpm@10.33.3 --filter likec4 test -- ai-proxy`
- `npx -y pnpm@10.33.3 --filter @likec4/vite-plugin test -- ai server rpc`
- `npx -y pnpm@10.33.3 --filter likec4 typecheck`
- `npx -y pnpm@10.33.3 --filter @likec4/vite-plugin typecheck`
- packed CLI bootstrap check in a temporary e2e install passed