### PR TITLE
feat: improve AI chat window usability

### DIFF
--- a/.changeset/ai-chat-window.md
+++ b/.changeset/ai-chat-window.md
@@ -1,0 +1,5 @@
+---
+"@likec4/spa": patch
+---
+
+Improve AI chat window usability with resizing, transcript copy/download, per-message copy, and readable tool activity labels.

--- a/packages/likec4-spa/src/aichat/AIChat.tsx
+++ b/packages/likec4-spa/src/aichat/AIChat.tsx
@@ -1,19 +1,39 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { css } from '@likec4/styles/css'
 import { HStack, Txt, VStack } from '@likec4/styles/jsx'
 import {
   ActionIcon,
   Badge,
   CloseButton,
+  CopyButton as MantineCopyButton,
   FloatingWindow,
+  rem,
   ScrollAreaAutosize,
   Tooltip,
 } from '@mantine/core'
+import type { SetFloatingWindowPosition } from '@mantine/hooks'
 import { useLocalStorage } from '@mantine/hooks'
 import { useTimeoutEffect } from '@react-hookz/web'
-import { IconSparkles } from '@tabler/icons-react'
+import { IconCheck, IconCopy, IconDownload, IconSparkles } from '@tabler/icons-react'
 import { AIAdapter } from 'likec4:rpc'
 import { AnimatePresence, m } from 'motion/react'
+import type { PanInfo } from 'motion/react'
 import { useRef } from 'react'
+import { formatChatTranscript } from './chat-transcript'
+import {
+  type ChatWindowResizeDelta,
+  type ChatWindowSize,
+  CHAT_WINDOW_CONSTRAIN_OFFSET,
+  DEFAULT_CHAT_WINDOW_SIZE,
+  maxChatWindowSizeForResize,
+  resizeChatWindowSize,
+} from './chat-window-size'
 import { ChatContext } from './ChatContext'
 import { ChatInput } from './ChatInput'
 import { ChatMessages } from './ChatMessage'
@@ -45,8 +65,38 @@ const storage = {
     return position
   },
 }
+
+const chatWindowClassName = css({
+  rounded: 'md',
+  padding: 'xs',
+  shadow: 'md',
+  layerStyle: 'likec4.panel',
+  overflow: 'hidden',
+})
+
+const resizeHandleClassName = css({
+  position: 'absolute',
+  width: '14px',
+  height: '14px',
+  border: '3px solid',
+  borderColor: 'text.dimmed',
+  borderTop: 'none',
+  borderLeft: 'none',
+  borderRadius: 'xs',
+  bottom: '1',
+  right: '1',
+  cursor: 'se-resize',
+  opacity: 0.7,
+  transition: 'fast',
+  _hover: {
+    opacity: 1,
+    borderColor: 'text.bright',
+  },
+})
+
 export default function AIChatComponent() {
   const initialPosition = useRef<{ left?: number; top?: number; right?: number; bottom?: number }>(null)
+  const setPositionRef = useRef<SetFloatingWindowPosition | null>(null)
   if (!initialPosition.current) {
     initialPosition.current = storage.read() ?? { right: 16, bottom: 100 }
   }
@@ -59,25 +109,46 @@ export default function AIChatComponent() {
     defaultValue: true,
   })
 
+  const [windowSize, setWindowSize] = useLocalStorage<ChatWindowSize>({
+    key: 'likec4.ai.chat.size',
+    defaultValue: DEFAULT_CHAT_WINDOW_SIZE,
+  })
+
+  const resizeWindow = (delta: ChatWindowResizeDelta) => {
+    const windowElement = document.querySelector<HTMLElement>('[data-likec4-ai-window]')
+    const rect = windowElement?.getBoundingClientRect()
+    const position = rect
+      ? {
+        left: Math.max(CHAT_WINDOW_CONSTRAIN_OFFSET, rect.left),
+        top: Math.max(CHAT_WINDOW_CONSTRAIN_OFFSET, rect.top),
+      }
+      : undefined
+    const maxSize = rect ? maxChatWindowSizeForResize(rect) : undefined
+    setWindowSize(size => resizeChatWindowSize(size, delta, maxSize))
+    if (position) {
+      requestAnimationFrame(() => setPositionRef.current?.(position))
+    }
+  }
+
   return (
     <AnimatePresence>
       {!isCollapsed && (
         <FloatingWindow
-          w={300}
+          w={`min(${windowSize.width}px, calc(100vw - 16px))`}
+          h={`min(${windowSize.height}px, calc(100vh - 16px))`}
           pos="fixed"
-          className={css({
-            rounded: 'md',
-            padding: 'xs',
-            shadow: 'md',
-            layerStyle: 'likec4.panel',
-          })}
+          className={chatWindowClassName}
+          data-likec4-ai-window
           constrainToViewport
-          constrainOffset={8}
-          excludeDragHandleSelector=".chat-input"
+          constrainOffset={CHAT_WINDOW_CONSTRAIN_OFFSET}
+          excludeDragHandleSelector=".chat-input, .chat-action, .chat-resize-handle"
           initialPosition={initialPosition.current}
           onPositionChange={onPositionChange}
+          setPositionRef={setPositionRef}
         >
-          <AIChatWindowContent onClose={() => setCollapsed(true)} />
+          <AIChatWindowContent
+            onClose={() => setCollapsed(true)}
+            onResize={resizeWindow} />
         </FloatingWindow>
       )}
       {isCollapsed && (
@@ -111,7 +182,13 @@ export default function AIChatComponent() {
   )
 }
 
-function AIChatWindowContent({ onClose }: { onClose: () => void }) {
+function AIChatWindowContent({
+  onClose,
+  onResize,
+}: {
+  onClose: () => void
+  onResize: (delta: ChatWindowResizeDelta) => void
+}) {
   const scrollAnchorRef = useRef<HTMLDivElement>(null)
   const scrollIntoView = () => {
     scrollAnchorRef.current?.scrollIntoView()
@@ -124,27 +201,74 @@ function AIChatWindowContent({ onClose }: { onClose: () => void }) {
   const chat = useChat({
     onChunk: scrollIntoView,
   })
+  const transcript = formatChatTranscript(chat.messages)
+  const hasTranscript = transcript.length > 0
+  const resizeByDrag = (_event: MouseEvent | TouchEvent | PointerEvent, info: PanInfo) => {
+    onResize({
+      width: info.delta.x,
+      height: info.delta.y,
+    })
+  }
   return (
     <ChatContext value={chat}>
-      <VStack w="100%">
+      <VStack w="100%" h="100%">
         <HStack cursor={'move'} justify="space-between">
           <HStack>
-            <Txt textStyle="likec4.panel" noUserSelect>AI Assistant</Txt>
+            <Txt textStyle="likec4.panel" userSelect="none">AI Assistant</Txt>
             <Badge size="xs" radius={'sm'} variant="light">{AIAdapter}</Badge>
           </HStack>
-          <CloseButton
-            size={'sm'}
-            onClick={e => {
-              e.stopPropagation()
-              onClose()
-            }} />
+          <HStack gap="xs">
+            <MantineCopyButton value={transcript} timeout={2000}>
+              {({ copied, copy }) => (
+                <Tooltip label={copied ? 'Copied' : 'Copy chat'} color="dark" fz={'xs'}>
+                  <ActionIcon
+                    aria-label="Copy chat transcript"
+                    className="chat-action"
+                    size={'sm'}
+                    color={copied ? 'teal' : 'gray'}
+                    variant="subtle"
+                    disabled={!hasTranscript}
+                    onClick={e => {
+                      e.stopPropagation()
+                      copy()
+                    }}>
+                    {copied
+                      ? <IconCheck style={{ width: rem(14), height: rem(14) }} />
+                      : <IconCopy style={{ width: rem(14), height: rem(14) }} />}
+                  </ActionIcon>
+                </Tooltip>
+              )}
+            </MantineCopyButton>
+            <Tooltip label="Download chat" color="dark" fz={'xs'}>
+              <ActionIcon
+                aria-label="Download chat transcript"
+                className="chat-action"
+                size={'sm'}
+                color="gray"
+                variant="subtle"
+                disabled={!hasTranscript}
+                onClick={e => {
+                  e.stopPropagation()
+                  downloadTranscript(transcript)
+                }}>
+                <IconDownload style={{ width: rem(14), height: rem(14) }} />
+              </ActionIcon>
+            </Tooltip>
+            <CloseButton
+              className="chat-action"
+              size={'sm'}
+              onClick={e => {
+                e.stopPropagation()
+                onClose()
+              }} />
+          </HStack>
         </HStack>
         <ScrollAreaAutosize
           scrollbars="y"
           w="100%"
           flex={1}
-          mih={250}
-          mah={350}
+          mih={0}
+          mah="100%"
           classNames={{
             content: css({
               display: 'contents',
@@ -156,7 +280,25 @@ function AIChatWindowContent({ onClose }: { onClose: () => void }) {
           </VStack>
         </ScrollAreaAutosize>
         <ChatInput />
+        <m.div
+          aria-label="Resize AI Assistant"
+          className={`${resizeHandleClassName} chat-resize-handle`}
+          drag
+          dragElastic={0}
+          dragMomentum={false}
+          dragConstraints={{ top: 0, left: 0, right: 0, bottom: 0 }}
+          onDrag={resizeByDrag} />
       </VStack>
     </ChatContext>
   )
+}
+
+function downloadTranscript(transcript: string) {
+  const blob = new Blob([transcript], { type: 'text/markdown;charset=utf-8' })
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = url
+  link.download = `likec4-ai-chat-${new Date().toISOString().replace(/[:.]/g, '-')}.md`
+  link.click()
+  setTimeout(() => URL.revokeObjectURL(url), 0)
 }

--- a/packages/likec4-spa/src/aichat/ChatMessage.tsx
+++ b/packages/likec4-spa/src/aichat/ChatMessage.tsx
@@ -1,12 +1,24 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { RichText } from '@likec4/core'
 import { Markdown } from '@likec4/diagram/custom'
 import { css } from '@likec4/styles/css'
-import { Txt } from '@likec4/styles/jsx'
-import { Notification } from '@mantine/core'
+import { HStack, Txt } from '@likec4/styles/jsx'
+import { ActionIcon, CopyButton as MantineCopyButton, Notification, rem, Tooltip } from '@mantine/core'
+import { IconCheck, IconCopy } from '@tabler/icons-react'
+import type { ToolCallRenderProps } from '@tanstack/ai-react-ui'
 import {
   ChatMessage as TanstackChatMessage,
 } from '@tanstack/ai-react-ui'
-import { type TypedUIMessage, useChatContext } from './ChatContext'
+import { formatToolActivityLabel } from './chat-tool-status'
+import { formatChatMessageText } from './chat-transcript'
+import type { TypedUIMessage } from './ChatContext'
+import { useChatContext } from './ChatContext'
 
 export function ChatMessages() {
   const { messages, error } = useChatContext()
@@ -39,20 +51,96 @@ export function ChatMessages() {
 
 export const ChatMessage = ({ message }: { message: TypedUIMessage }) => {
   const role = message.role
+  const text = formatChatMessageText(message)
   return (
-    <TanstackChatMessage
-      message={message}
-      userClassName={css({
-        color: 'text.bright',
-        alignSelf: 'flex-end',
-        paddingInline: '2',
-        paddingBlock: '1',
-        marginInlineEnd: '2',
-        rounded: 'sm',
-        backgroundColor: 'default.hover',
-        whiteSpace: 'pre-wrap',
-      })}
-      textPartRenderer={role === 'user' ? UserMessageTextPart : MarkdownTextPart} />
+    <HStack
+      className={messageGroupClassName}
+      data-likec4-ai-message-role={role}
+      alignItems="flex-start">
+      {role === 'user' && <CopyMessageButton text={text} />}
+      <TanstackChatMessage
+        message={message}
+        userClassName={userMessageClassName}
+        defaultToolRenderer={ToolActivityPart}
+        toolResultRenderer={() => null}
+        textPartRenderer={role === 'user' ? UserMessageTextPart : MarkdownTextPart} />
+      {role !== 'user' && <CopyMessageButton text={text} />}
+    </HStack>
+  )
+}
+
+const messageGroupClassName = css({
+  maxWidth: '100%',
+  '&[data-likec4-ai-message-role="user"]': {
+    alignSelf: 'flex-end',
+  },
+  '&[data-likec4-ai-message-role="assistant"]': {
+    alignSelf: 'flex-start',
+  },
+  '& [data-likec4-ai-message-copy]': {
+    opacity: 0,
+  },
+  _hover: {
+    '& [data-likec4-ai-message-copy]': {
+      opacity: 1,
+    },
+  },
+  _focusWithin: {
+    '& [data-likec4-ai-message-copy]': {
+      opacity: 1,
+    },
+  },
+})
+
+const userMessageClassName = css({
+  color: 'text.bright',
+  paddingInline: '2',
+  paddingBlock: '1',
+  marginInlineEnd: '2',
+  rounded: 'sm',
+  backgroundColor: 'default.hover',
+  whiteSpace: 'pre-wrap',
+})
+
+const toolActivityClassName = css({
+  alignSelf: 'flex-start',
+  color: 'text.dimmed',
+  fontSize: 'xs',
+  paddingInline: '2',
+  paddingBlock: '1',
+})
+
+const ToolActivityPart = ({ name }: ToolCallRenderProps) => {
+  return (
+    <div
+      className={toolActivityClassName}
+      data-likec4-ai-tool-status>
+      {formatToolActivityLabel(name)}
+    </div>
+  )
+}
+
+const CopyMessageButton = ({ text }: { text: string }) => {
+  return (
+    <MantineCopyButton value={text} timeout={2000}>
+      {({ copied, copy }) => (
+        <Tooltip label={copied ? 'Copied' : 'Copy message'} color="dark" fz={'xs'}>
+          <ActionIcon
+            aria-label="Copy message"
+            data-likec4-ai-message-copy
+            className="chat-action"
+            size={'sm'}
+            color={copied ? 'teal' : 'gray'}
+            variant="subtle"
+            disabled={!text}
+            onClick={copy}>
+            {copied
+              ? <IconCheck style={{ width: rem(14), height: rem(14) }} />
+              : <IconCopy style={{ width: rem(14), height: rem(14) }} />}
+          </ActionIcon>
+        </Tooltip>
+      )}
+    </MantineCopyButton>
   )
 }
 

--- a/packages/likec4-spa/src/aichat/chat-tool-status.spec.ts
+++ b/packages/likec4-spa/src/aichat/chat-tool-status.spec.ts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import { describe, expect, it } from 'vitest'
+import { formatToolActivityLabel } from './chat-tool-status'
+
+describe('formatToolActivityLabel', () => {
+  it('uses readable labels for LikeC4 UI tools', () => {
+    expect(formatToolActivityLabel('read_ui')).toBe('Reading diagram state...')
+    expect(formatToolActivityLabel('update_ui')).toBe('Updating diagram...')
+    expect(formatToolActivityLabel('navigate_to')).toBe('Opening view...')
+  })
+
+  it('falls back to the tool name for unknown tools', () => {
+    expect(formatToolActivityLabel('custom_tool')).toBe('Running custom_tool...')
+  })
+})

--- a/packages/likec4-spa/src/aichat/chat-tool-status.ts
+++ b/packages/likec4-spa/src/aichat/chat-tool-status.ts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+const toolLabels: Record<string, string> = {
+  navigate_to: 'Opening view',
+  read_ui: 'Reading diagram state',
+  update_ui: 'Updating diagram',
+}
+
+export function formatToolActivityLabel(toolName: string): string {
+  return `${toolLabels[toolName] ?? `Running ${toolName}`}...`
+}

--- a/packages/likec4-spa/src/aichat/chat-transcript.spec.ts
+++ b/packages/likec4-spa/src/aichat/chat-transcript.spec.ts
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import { describe, expect, it } from 'vitest'
+import { formatChatMessageText, formatChatTranscript } from './chat-transcript'
+import type { TypedUIMessages } from './useChat'
+
+describe('formatChatTranscript', () => {
+  it('formats user and assistant text messages', () => {
+    const messages: TypedUIMessages = [
+      {
+        id: 'user-1',
+        role: 'user',
+        parts: [{ type: 'text', content: 'What view is open?' }],
+      },
+      {
+        id: 'assistant-1',
+        role: 'assistant',
+        parts: [{ type: 'text', content: 'top<Graphlet>' }],
+      },
+    ]
+
+    expect(formatChatTranscript(messages)).toBe(
+      '## User\n\nWhat view is open?\n\n## Assistant\n\ntop<Graphlet>',
+    )
+  })
+
+  it('omits tool calls and tool results from exported transcript', () => {
+    const messages: TypedUIMessages = [
+      {
+        id: 'assistant-1',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'tool-call',
+            id: 'call-1',
+            name: 'read_ui',
+            arguments: '{}',
+            state: 'input-complete',
+            output: {
+              projectId: 'demo_project',
+              editMode: false,
+              view: {
+                id: 'top',
+                title: 'top<Graphlet>',
+                type: 'element',
+              },
+            },
+          },
+          {
+            type: 'tool-result',
+            toolCallId: 'call-1',
+            content: '{"projectId":"demo_project"}',
+            state: 'complete',
+          },
+          { type: 'text', content: 'top<Graphlet>' },
+        ],
+      },
+    ]
+
+    expect(formatChatTranscript(messages)).toBe('## Assistant\n\ntop<Graphlet>')
+    expect(formatChatMessageText(messages[0]!)).toBe('top<Graphlet>')
+  })
+})

--- a/packages/likec4-spa/src/aichat/chat-transcript.ts
+++ b/packages/likec4-spa/src/aichat/chat-transcript.ts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import type { TypedUIMessages } from './useChat'
+
+const roleLabel = {
+  system: 'System',
+  user: 'User',
+  assistant: 'Assistant',
+} as const
+
+export function formatChatTranscript(messages: TypedUIMessages): string {
+  return messages
+    .map(message => {
+      const text = formatChatMessageText(message)
+
+      if (!text) {
+        return ''
+      }
+
+      return `## ${roleLabel[message.role]}\n\n${text}`
+    })
+    .filter(Boolean)
+    .join('\n\n')
+}
+
+export function formatChatMessageText(message: TypedUIMessages[number]): string {
+  return message.parts
+    .flatMap(part => part.type === 'text' ? [part.content.trim()] : [])
+    .filter(Boolean)
+    .join('\n\n')
+}

--- a/packages/likec4-spa/src/aichat/chat-window-size.spec.ts
+++ b/packages/likec4-spa/src/aichat/chat-window-size.spec.ts
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import { describe, expect, it } from 'vitest'
+import { maxChatWindowSizeForResize, resizeChatWindowSize } from './chat-window-size'
+
+describe('resizeChatWindowSize', () => {
+  it('applies resize deltas', () => {
+    expect(
+      resizeChatWindowSize(
+        { width: 440, height: 420 },
+        { width: 60, height: 40 },
+        { width: 1000, height: 1000 },
+      ),
+    ).toEqual({ width: 500, height: 460 })
+  })
+
+  it('keeps the window inside min and max bounds', () => {
+    expect(
+      resizeChatWindowSize(
+        { width: 440, height: 420 },
+        { width: -500, height: -500 },
+        { width: 1000, height: 1000 },
+      ),
+    ).toEqual({ width: 320, height: 360 })
+
+    expect(
+      resizeChatWindowSize(
+        { width: 440, height: 420 },
+        { width: 2000, height: 2000 },
+        { width: 900, height: 700 },
+      ),
+    ).toEqual({ width: 900, height: 700 })
+  })
+
+  it('computes max size from the current window position', () => {
+    expect(
+      maxChatWindowSizeForResize(
+        { left: 984, top: 380 },
+        { width: 1440, height: 900 },
+      ),
+    ).toEqual({ width: 448, height: 512 })
+  })
+
+  it('uses a safe fallback viewport outside the browser', () => {
+    expect(maxChatWindowSizeForResize({ left: 0, top: 0 })).toEqual({ width: 432, height: 412 })
+  })
+})

--- a/packages/likec4-spa/src/aichat/chat-window-size.ts
+++ b/packages/likec4-spa/src/aichat/chat-window-size.ts
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+export type ChatWindowSize = {
+  width: number
+  height: number
+}
+
+export type ChatWindowResizeDelta = {
+  width: number
+  height: number
+}
+
+export const CHAT_WINDOW_VIEWPORT_PADDING = 16
+export const CHAT_WINDOW_CONSTRAIN_OFFSET = 8
+
+export const DEFAULT_CHAT_WINDOW_SIZE: ChatWindowSize = {
+  width: 440,
+  height: 420,
+}
+
+export const MIN_CHAT_WINDOW_SIZE: ChatWindowSize = {
+  width: 320,
+  height: 360,
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max)
+}
+
+function defaultMaxWindowSize(): ChatWindowSize {
+  if (typeof window === 'undefined') {
+    return DEFAULT_CHAT_WINDOW_SIZE
+  }
+  return {
+    width: Math.max(MIN_CHAT_WINDOW_SIZE.width, window.innerWidth - CHAT_WINDOW_VIEWPORT_PADDING),
+    height: Math.max(MIN_CHAT_WINDOW_SIZE.height, window.innerHeight - CHAT_WINDOW_VIEWPORT_PADDING),
+  }
+}
+
+function defaultViewportSize(): ChatWindowSize {
+  if (typeof window === 'undefined') {
+    return DEFAULT_CHAT_WINDOW_SIZE
+  }
+  return {
+    width: window.innerWidth,
+    height: window.innerHeight,
+  }
+}
+
+export function maxChatWindowSizeForResize(
+  rect: Pick<DOMRect, 'left' | 'top'>,
+  viewport: ChatWindowSize = defaultViewportSize(),
+): ChatWindowSize {
+  return {
+    width: Math.max(
+      MIN_CHAT_WINDOW_SIZE.width,
+      viewport.width - rect.left - CHAT_WINDOW_CONSTRAIN_OFFSET,
+    ),
+    height: Math.max(
+      MIN_CHAT_WINDOW_SIZE.height,
+      viewport.height - rect.top - CHAT_WINDOW_CONSTRAIN_OFFSET,
+    ),
+  }
+}
+
+export function resizeChatWindowSize(
+  size: ChatWindowSize,
+  delta: ChatWindowResizeDelta,
+  maxSize = defaultMaxWindowSize(),
+): ChatWindowSize {
+  return {
+    width: clamp(size.width + delta.width, MIN_CHAT_WINDOW_SIZE.width, maxSize.width),
+    height: clamp(size.height + delta.height, MIN_CHAT_WINDOW_SIZE.height, maxSize.height),
+  }
+}

--- a/packages/likec4-spa/src/aichat/useChat.tsx
+++ b/packages/likec4-spa/src/aichat/useChat.tsx
@@ -169,7 +169,13 @@ export function useChat(options: Omit<UseChatOptions, 'connection' | 'tools' | '
     tools: useChatTools(),
   })
   useEffect(() => {
-    storage.write(chat.messages)
+    const timeout = window.setTimeout(() => {
+      storage.write(chat.messages)
+    }, 250)
+    return () => {
+      window.clearTimeout(timeout)
+      storage.write(chat.messages)
+    }
   }, [chat.messages])
   return chat
 }


### PR DESCRIPTION
Stacked on #2958.

## Summary
- makes the AI chat window resizable and persists its size locally
- adds copy/download actions for the transcript and per-message copy actions
- shows readable chat tool activity labels instead of raw tool payloads

## Screenshots
Captured from the `examples/cloud-system` view with a seeded chat transcript.

| Before | After |
| --- | --- |
| ![Before PR 2959 AI chat window](https://gist.githubusercontent.com/ckeller42/9cdbe9bd14a0a5d204c85f02afde4b8f/raw/b3a3fc1b483117166bbba40611aad5a3b68d0c2b/likec4-pr2959-before.svg) | ![After PR 2959 AI chat window](https://gist.githubusercontent.com/ckeller42/9cdbe9bd14a0a5d204c85f02afde4b8f/raw/0e133c215c4c720c63318dde7ef3ff04ba9bca24/likec4-pr2959-after.svg) |

## Validation
- `npx -y pnpm@10.33.3 --filter @likec4/spa test -- aichat`
- `npx -y pnpm@10.33.3 --filter @likec4/spa typecheck`
