### PR TITLE
feat: add configurable AI chat context

### DIFF
--- a/.changeset/ai-chat-context.md
+++ b/.changeset/ai-chat-context.md
@@ -1,0 +1,7 @@
+---
+"@likec4/config": patch
+"@likec4/spa": patch
+"@likec4/vite-plugin": patch
+---
+
+Add safe project-level AI chat defaults for prompts, suggested questions, and context exposed through chat tools.

--- a/apps/docs/src/content/docs/dsl/Config/index.mdx
+++ b/apps/docs/src/content/docs/dsl/Config/index.mdx
@@ -62,6 +62,50 @@ You can also use these names:
 See [Programmatic config](/dsl/config/programmatic) for more information.
 :::
 
+## AI chat
+
+Use `aiChat` to tune the browser AI assistant for this project.
+This config controls safe prompt and context defaults only.
+Provider credentials are configured on the dev server or AI proxy, not in project config.
+
+```jsonc
+{
+  "$schema": "https://likec4.dev/schemas/config.json",
+  "name": "project-name",
+  "aiChat": {
+    "enabled": true,
+    "systemPrompt": "Answer from LikeC4 model facts. Say when the model does not contain enough context.",
+    "suggestedQuestions": {
+      "element": [
+        "What does {title} do?",
+        "What depends on {title}?"
+      ]
+    },
+    "context": {
+      "element": {
+        "description": true,
+        "metadata": true,
+        "incoming": true,
+        "outgoing": true
+      },
+      "relationships": {
+        "metadata": true,
+        "links": false
+      },
+      "limits": {
+        "children": 50,
+        "relationships": 100,
+        "views": 20
+      }
+    }
+  }
+}
+```
+
+Set `"enabled": false` to hide AI chat for a project even when an AI endpoint is available.
+Suggested questions and `systemPrompt` support element variables such as `{title}`, `{kind}`, `{technology}`, `{view}`, `{dependencies}`, and `{dependents}`.
+Use `context` to limit which metadata, links, relationships, and related views may be sent to the configured AI provider or proxy.
+
 ## Extend styles
 
 If you want to share styles across multiple projects, you can use `extends` in **JSON configs**.

--- a/apps/docs/src/content/docs/tooling/ai-tools.mdx
+++ b/apps/docs/src/content/docs/tooling/ai-tools.mdx
@@ -52,6 +52,53 @@ Model metadata, links, relationships, and tool results may expose sensitive arch
 Review provider retention and compliance terms before using external or custom `OPENAI_BASE_URL` endpoints.
 :::
 
+### Configure project context
+
+Project config can tune the chat prompt, suggested questions, and which model details are exposed to AI context tools.
+It does not configure provider credentials; keep API keys in the dev server or proxy environment.
+
+```jsonc
+{
+  "$schema": "https://likec4.dev/schemas/config.json",
+  "name": "my-project",
+  "aiChat": {
+    "systemPrompt": "Answer from the LikeC4 model. Call out unknowns instead of guessing.",
+    "suggestedQuestions": {
+      "element": [
+        "What does {title} do?",
+        "What depends on {title}?",
+        "What does {title} connect to?"
+      ]
+    },
+    "context": {
+      "element": {
+        "description": true,
+        "metadata": true,
+        "incoming": true,
+        "outgoing": true
+      },
+      "relationships": {
+        "metadata": true,
+        "links": false
+      },
+      "limits": {
+        "children": 50,
+        "relationships": 100,
+        "views": 20
+      }
+    }
+  }
+}
+```
+
+The chat reads context through tools:
+- `read_ui` for current view and layout state.
+- `read_connections` for current-view edges, ports, datatypes, and relationship metadata.
+- `read_element` for selected or focused element details, dependencies, dependents, children, metadata, and related views.
+
+Suggested questions and `systemPrompt` support element variables like `{title}`, `{kind}`, `{technology}`, `{view}`, `{dependencies}`, and `{dependents}`.
+Use `aiChat.context` to turn off metadata, links, relationship details, or related views before tool results are sent to the configured AI provider or proxy.
+
 ## Agent Skills
 
 Agent skills are DSL references that AI coding assistants load automatically when editing `.c4`/`.likec4` files.

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,4 +1,12 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 export type {
+  AIChatConfig,
   GeneratorFn,
   GeneratorFnContext,
   GeneratorFnParams,

--- a/packages/config/src/schema.spec.ts
+++ b/packages/config/src/schema.spec.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { describe, it } from 'vitest'
 import { validateProjectConfig as validateConfig } from './schema'
 import { ImageAliasesSchema } from './schema.image-alias'
@@ -273,6 +280,95 @@ describe('ProjectConfig schema', () => {
       const result = validateConfig(config)
       expect(result.name).toBe('test')
       expect(result.landingPage).toEqual({ redirect: true })
+    })
+
+    describe('aiChat field', () => {
+      it('should accept safe AI Chat defaults', ({ expect }) => {
+        const result = validateConfig({
+          name: 'test',
+          aiChat: {
+            enabled: true,
+            systemPrompt: 'Answer from LikeC4 facts.',
+            suggestedQuestions: {
+              element: [
+                'What does {title} do?',
+                'What depends on {title}?',
+              ],
+            },
+            context: {
+              element: {
+                description: true,
+                metadata: false,
+                incoming: true,
+                outgoing: true,
+              },
+              relationships: {
+                title: true,
+                technology: true,
+                metadata: true,
+                links: false,
+              },
+              limits: {
+                children: 25,
+                relationships: 50,
+                views: 10,
+              },
+            },
+          },
+        })
+
+        expect(result.aiChat?.enabled).toBe(true)
+        expect(result.aiChat?.context?.limits?.relationships).toBe(50)
+      })
+
+      it('should reject empty AI Chat prompt and questions', ({ expect }) => {
+        expect(() =>
+          validateConfig({
+            name: 'test',
+            aiChat: {
+              systemPrompt: '',
+            },
+          })
+        ).toThrow('AI Chat system prompt cannot be empty')
+
+        expect(() =>
+          validateConfig({
+            name: 'test',
+            aiChat: {
+              suggestedQuestions: {
+                element: [''],
+              },
+            },
+          })
+        ).toThrow('Suggested question cannot be empty')
+      })
+
+      it('should reject non-positive AI Chat limits', ({ expect }) => {
+        expect(() =>
+          validateConfig({
+            name: 'test',
+            aiChat: {
+              context: {
+                limits: {
+                  relationships: 0,
+                },
+              },
+            },
+          })
+        ).toThrow()
+      })
+
+      it('should reject provider credentials in AI Chat config', ({ expect }) => {
+        expect(() =>
+          validateConfig({
+            name: 'test',
+            aiChat: {
+              apiKey: 'secret',
+              allowUnsafeApiKey: true,
+            },
+          })
+        ).toThrow()
+      })
     })
 
     // Skipped in Vitest: config object can arrive without landingPage key in this env. Behavior verified via:

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -75,6 +75,62 @@ export const LandingPageSchema = z
       'Configure the landing page. Use redirect to go to the index view, or include/exclude to filter the view grid.',
   })
 
+const AIChatContextElementSchema = z.strictObject({
+  summary: z.boolean().optional(),
+  description: z.boolean().optional(),
+  technology: z.boolean().optional(),
+  tags: z.boolean().optional(),
+  links: z.boolean().optional(),
+  metadata: z.boolean().optional(),
+  parent: z.boolean().optional(),
+  children: z.boolean().optional(),
+  incoming: z.boolean().optional(),
+  outgoing: z.boolean().optional(),
+  alsoAppearsInViews: z.boolean().optional(),
+})
+
+const AIChatContextRelationshipsSchema = z.strictObject({
+  title: z.boolean().optional(),
+  technology: z.boolean().optional(),
+  metadata: z.boolean().optional(),
+  links: z.boolean().optional(),
+})
+
+const AIChatContextLimitsSchema = z.strictObject({
+  children: z.number().int().positive().optional(),
+  relationships: z.number().int().positive().optional(),
+  views: z.number().int().positive().optional(),
+})
+
+export const AIChatConfigSchema = z.strictObject({
+  enabled: z.boolean()
+    .optional()
+    .meta({ description: 'Enable or disable AI Chat for this project.' }),
+  systemPrompt: z.string()
+    .nonempty('AI Chat system prompt cannot be empty')
+    .optional()
+    .meta({
+      description: 'Additional project-specific instructions for the AI Chat assistant.',
+    }),
+  suggestedQuestions: z.strictObject({
+    element: z.array(z.string().nonempty('Suggested question cannot be empty')).optional(),
+  }).optional().meta({
+    description: 'Suggested starter questions shown by AI Chat. Element questions support template variables.',
+  }),
+  context: z.strictObject({
+    element: AIChatContextElementSchema.optional(),
+    relationships: AIChatContextRelationshipsSchema.optional(),
+    limits: AIChatContextLimitsSchema.optional(),
+  }).optional().meta({
+    description: 'Controls which model details AI Chat context tools expose to the assistant.',
+  }),
+}).meta({
+  id: 'AIChatConfig',
+  description: 'Safe AI Chat project defaults. Provider credentials are not configured here.',
+})
+
+export type AIChatConfig = z.infer<typeof AIChatConfigSchema>
+
 export const LikeC4ProjectJsonConfigSchema = z.object({
   name: z.string()
     .nonempty('Project name cannot be empty')
@@ -128,6 +184,7 @@ export const LikeC4ProjectJsonConfigSchema = z.object({
       description: 'Auto-generate scoped views for elements without explicit views. Defaults to false.',
     }),
   landingPage: LandingPageSchema.optional(),
+  aiChat: AIChatConfigSchema.optional(),
 })
   .meta({
     id: 'LikeC4ProjectConfig',

--- a/packages/likec4-spa/src/aichat/AIChat.tsx
+++ b/packages/likec4-spa/src/aichat/AIChat.tsx
@@ -5,11 +5,13 @@
 //
 // Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
 
+import { useCurrentViewModel, useDiagramContext } from '@likec4/diagram'
 import { css } from '@likec4/styles/css'
 import { HStack, Txt, VStack } from '@likec4/styles/jsx'
 import {
   ActionIcon,
   Badge,
+  Button,
   CloseButton,
   CopyButton as MantineCopyButton,
   FloatingWindow,
@@ -24,7 +26,8 @@ import { IconCheck, IconCopy, IconDownload, IconSparkles } from '@tabler/icons-r
 import { AIAdapter } from 'likec4:rpc'
 import { AnimatePresence, m } from 'motion/react'
 import type { PanInfo } from 'motion/react'
-import { useRef } from 'react'
+import { useMemo, useRef } from 'react'
+import { useCurrentProject } from '../hooks'
 import { formatChatTranscript } from './chat-transcript'
 import {
   type ChatWindowResizeDelta,
@@ -37,6 +40,7 @@ import {
 import { ChatContext } from './ChatContext'
 import { ChatInput } from './ChatInput'
 import { ChatMessages } from './ChatMessage'
+import { buildElementTemplateVariables, getSelectedElementId, interpolateChatTemplate } from './ui-state-data'
 import { useChat } from './useChat'
 
 type Position = { left?: number; top?: number; right?: number; bottom?: number }
@@ -92,6 +96,14 @@ const resizeHandleClassName = css({
     opacity: 1,
     borderColor: 'text.bright',
   },
+})
+
+const suggestedQuestionClassName = css({
+  maxWidth: '100%',
+  height: 'auto',
+  minHeight: '7',
+  whiteSpace: 'normal',
+  textAlign: 'left',
 })
 
 export default function AIChatComponent() {
@@ -201,6 +213,7 @@ function AIChatWindowContent({
   const chat = useChat({
     onChunk: scrollIntoView,
   })
+  const suggestedQuestions = useSuggestedQuestions()
   const transcript = formatChatTranscript(chat.messages)
   const hasTranscript = transcript.length > 0
   const resizeByDrag = (_event: MouseEvent | TouchEvent | PointerEvent, info: PanInfo) => {
@@ -275,6 +288,21 @@ function AIChatWindowContent({
             }),
           }}>
           <VStack>
+            {chat.messages.length === 0 && suggestedQuestions.length > 0 && (
+              <HStack flexWrap="wrap" gap="xs" alignSelf="stretch">
+                {suggestedQuestions.map(question => (
+                  <Button
+                    key={question}
+                    className={`${suggestedQuestionClassName} chat-action`}
+                    size="xs"
+                    variant="light"
+                    color="gray"
+                    onClick={() => chat.sendMessage(question)}>
+                    {question}
+                  </Button>
+                ))}
+              </HStack>
+            )}
             <ChatMessages />
             <div ref={scrollAnchorRef} style={{ height: 2 }}></div>
           </VStack>
@@ -301,4 +329,24 @@ function downloadTranscript(transcript: string) {
   link.download = `likec4-ai-chat-${new Date().toISOString().replace(/[:.]/g, '-')}.md`
   link.click()
   setTimeout(() => URL.revokeObjectURL(url), 0)
+}
+
+function useSuggestedQuestions(): string[] {
+  const project = useCurrentProject()
+  const currentViewModel = useCurrentViewModel()
+  const selectedElementId = useDiagramContext(getSelectedElementId)
+  const templates: readonly string[] = project.aiChat?.suggestedQuestions?.element ?? []
+
+  return useMemo(() => {
+    if (templates.length === 0) {
+      return []
+    }
+
+    const element = selectedElementId ? currentViewModel.$model.findElement(selectedElementId) : null
+    const variables = buildElementTemplateVariables(element, currentViewModel)
+
+    return templates
+      .map(template => interpolateChatTemplate(template, variables, { hideIfEmpty: true }))
+      .filter((question): question is string => !!question)
+  }, [currentViewModel, selectedElementId, templates])
 }

--- a/packages/likec4-spa/src/aichat/chat-tool-status.spec.ts
+++ b/packages/likec4-spa/src/aichat/chat-tool-status.spec.ts
@@ -8,6 +8,8 @@ import { formatToolActivityLabel } from './chat-tool-status'
 describe('formatToolActivityLabel', () => {
   it('uses readable labels for LikeC4 UI tools', () => {
     expect(formatToolActivityLabel('read_ui')).toBe('Reading diagram state...')
+    expect(formatToolActivityLabel('read_connections')).toBe('Reading connections...')
+    expect(formatToolActivityLabel('read_element')).toBe('Reading element details...')
     expect(formatToolActivityLabel('update_ui')).toBe('Updating diagram...')
     expect(formatToolActivityLabel('navigate_to')).toBe('Opening view...')
   })

--- a/packages/likec4-spa/src/aichat/chat-tool-status.ts
+++ b/packages/likec4-spa/src/aichat/chat-tool-status.ts
@@ -4,6 +4,8 @@
 
 const toolLabels: Record<string, string> = {
   navigate_to: 'Opening view',
+  read_connections: 'Reading connections',
+  read_element: 'Reading element details',
   read_ui: 'Reading diagram state',
   update_ui: 'Updating diagram',
 }

--- a/packages/likec4-spa/src/aichat/ui-state-data.spec.ts
+++ b/packages/likec4-spa/src/aichat/ui-state-data.spec.ts
@@ -1,0 +1,332 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import { describe, expect, it } from 'vitest'
+import {
+  buildElementTemplateVariables,
+  getSelectedElementId,
+  interpolateChatTemplate,
+  mapElementContextData,
+  mapViewEdgeData,
+} from './ui-state-data'
+
+describe('AI UI state data', () => {
+  it('maps view edges without relation details by default', () => {
+    const [edge] = mapViewEdgeData(viewModel())
+
+    expect(edge).toEqual({
+      id: 'edge-1',
+      source: 'sensorServices',
+      target: 'ssr_app',
+      label: '[...]',
+      technology: 'nvsci',
+    })
+  })
+
+  it('maps underlying relation metadata when requested', () => {
+    const [edge] = mapViewEdgeData(viewModel(), { includeRelations: true })
+
+    expect(edge?.relations).toEqual([
+      {
+        id: 'rel-1',
+        source: 'sensorServices.cameraSensor0.outputSelectorIsp1',
+        target: 'ssr_app',
+        title: 'IMAGE_NATIVE_PROCESSED -> EXTERNAL:SENSOR_SERVICES_SSR_CAMERA_SENSOR0_CUDA_PROCESSED1 :dwImageHandle_t',
+        technology: 'nvsci',
+        metadata: {
+          datatype: 'dwImageHandle_t',
+          src_port: 'IMAGE_NATIVE_PROCESSED',
+          dst_port: 'EXTERNAL:SENSOR_SERVICES_SSR_CAMERA_SENSOR0_CUDA_PROCESSED1',
+          tags: 'camera, ssr',
+        },
+      },
+    ])
+  })
+
+  it('maps rich element context with configured relationship metadata', () => {
+    const { api, view } = elementFixture()
+
+    expect(mapElementContextData(api, view, {
+      relationships: {
+        links: true,
+      },
+    })).toEqual({
+      id: 'cloud.api',
+      title: 'API',
+      kind: 'component',
+      technology: 'Node.js',
+      summary: 'Handles requests',
+      description: 'GraphQL API',
+      tags: ['public'],
+      links: [{ url: 'https://example.com/api', title: 'API docs' }],
+      metadata: {
+        owner: 'team-a',
+        tags: 'critical, external',
+        details: '{"tier":"gold"}',
+      },
+      parent: {
+        id: 'cloud',
+        title: 'Cloud',
+        kind: 'system',
+        technology: null,
+      },
+      children: [],
+      incoming: [
+        {
+          id: 'rel-web-api',
+          source: {
+            id: 'cloud.web',
+            title: 'Web',
+            kind: 'component',
+            technology: 'React',
+          },
+          target: {
+            id: 'cloud.api',
+            title: 'API',
+            kind: 'component',
+            technology: 'Node.js',
+          },
+          title: 'calls',
+          technology: 'HTTPS',
+          metadata: {
+            datatype: 'JSON',
+          },
+          links: [{ url: 'https://example.com/relation', title: null }],
+        },
+      ],
+      outgoing: [
+        {
+          id: 'rel-api-db',
+          source: {
+            id: 'cloud.api',
+            title: 'API',
+            kind: 'component',
+            technology: 'Node.js',
+          },
+          target: {
+            id: 'cloud.db',
+            title: 'Database',
+            kind: 'component',
+            technology: 'PostgreSQL',
+          },
+          title: 'reads',
+          technology: 'SQL',
+          metadata: {
+            port: '5432',
+          },
+        },
+      ],
+      alsoAppearsInViews: [{
+        id: 'api',
+        title: 'API',
+        type: 'element',
+      }],
+    })
+  })
+
+  it('honors element context switches and limits', () => {
+    const { api, view } = elementFixture()
+
+    expect(mapElementContextData(api, view, {
+      element: {
+        description: false,
+        metadata: false,
+        incoming: false,
+        outgoing: false,
+        alsoAppearsInViews: false,
+      },
+      limits: {
+        children: 1,
+      },
+    })).toMatchObject({
+      id: 'cloud.api',
+      children: [],
+    })
+    expect(mapElementContextData(api, view, {
+      element: {
+        description: false,
+        metadata: false,
+        incoming: false,
+        outgoing: false,
+        alsoAppearsInViews: false,
+      },
+    })).not.toHaveProperty('description')
+  })
+
+  it('builds template variables and hides empty suggested questions', () => {
+    const { api, view } = elementFixture()
+    const variables = buildElementTemplateVariables(api, view)
+
+    expect(interpolateChatTemplate(
+      'What depends on {title} in {view}?',
+      variables,
+      { hideIfEmpty: true },
+    )).toBe('What depends on API in Overview?')
+    expect(interpolateChatTemplate(
+      'Uses {unknown}',
+      variables,
+      { hideIfEmpty: true },
+    )).toBe('Uses {unknown}')
+    expect(interpolateChatTemplate(
+      'What uses {technology}?',
+      buildElementTemplateVariables(null, view),
+      { hideIfEmpty: true },
+    )).toBeNull()
+  })
+
+  it('gets selected or focused element id from diagram context', () => {
+    expect(getSelectedElementId({
+      focusedNode: 'api-node',
+      xynodes: [{
+        id: 'api-node',
+        data: {
+          modelFqn: 'cloud.api',
+        },
+      }],
+    })).toBe('cloud.api')
+  })
+})
+
+function viewModel() {
+  return {
+    edges: () => [
+      {
+        id: 'edge-1',
+        source: { id: 'sensorServices' },
+        target: { id: 'ssr_app' },
+        label: '[...]',
+        technology: 'nvsci',
+        relationships: () => [
+          {
+            id: 'rel-1',
+            source: { id: 'sensorServices.cameraSensor0.outputSelectorIsp1' },
+            target: { id: 'ssr_app' },
+            title:
+              'IMAGE_NATIVE_PROCESSED -> EXTERNAL:SENSOR_SERVICES_SSR_CAMERA_SENSOR0_CUDA_PROCESSED1 :dwImageHandle_t',
+            technology: 'nvsci',
+            metadata: {
+              datatype: 'dwImageHandle_t',
+              src_port: 'IMAGE_NATIVE_PROCESSED',
+              dst_port: 'EXTERNAL:SENSOR_SERVICES_SSR_CAMERA_SENSOR0_CUDA_PROCESSED1',
+              tags: ['camera', 'ssr'],
+            },
+          },
+        ],
+      },
+    ],
+  }
+}
+
+function richText(text: string) {
+  return {
+    isEmpty: text.length === 0,
+    text,
+  }
+}
+
+function elementFixture() {
+  const view = {
+    id: 'overview',
+    title: 'Overview',
+    _type: 'element' as const,
+  }
+  const apiView = {
+    id: 'api',
+    title: 'API',
+    _type: 'element' as const,
+  }
+  const parent = {
+    id: 'cloud',
+    title: 'Cloud',
+    kind: 'system',
+    technology: null,
+    summary: richText(''),
+    description: richText(''),
+    tags: [],
+    links: [],
+    metadata: {},
+    parent: null,
+    children: () => [],
+    incoming: () => [],
+    outgoing: () => [],
+    views: () => [view],
+  }
+  const web = {
+    id: 'cloud.web',
+    title: 'Web',
+    kind: 'component',
+    technology: 'React',
+    summary: richText(''),
+    description: richText(''),
+    tags: [],
+    links: [],
+    metadata: {},
+    parent,
+    children: () => [],
+    incoming: () => [],
+    outgoing: () => [],
+    views: () => [view],
+  }
+  const db = {
+    id: 'cloud.db',
+    title: 'Database',
+    kind: 'component',
+    technology: 'PostgreSQL',
+    summary: richText(''),
+    description: richText(''),
+    tags: [],
+    links: [],
+    metadata: {},
+    parent,
+    children: () => [],
+    incoming: () => [],
+    outgoing: () => [],
+    views: () => [view],
+  }
+  const api = {
+    id: 'cloud.api',
+    title: 'API',
+    kind: 'component',
+    technology: 'Node.js',
+    summary: richText('Handles requests'),
+    description: richText('GraphQL API'),
+    tags: ['public'],
+    links: [{ url: 'https://example.com/api', title: 'API docs' }],
+    metadata: {
+      owner: 'team-a',
+      tags: ['critical', 'external'],
+      details: { tier: 'gold' },
+    },
+    parent,
+    children: () => [],
+    incoming: () => [
+      {
+        id: 'rel-web-api',
+        source: web,
+        target: api,
+        title: 'calls',
+        technology: 'HTTPS',
+        metadata: {
+          datatype: 'JSON',
+        },
+        links: [{ url: 'https://example.com/relation', title: null }],
+      },
+    ],
+    outgoing: () => [
+      {
+        id: 'rel-api-db',
+        source: api,
+        target: db,
+        title: 'reads',
+        technology: 'SQL',
+        metadata: {
+          port: '5432',
+        },
+        links: [],
+      },
+    ],
+    views: () => [view, apiView],
+  }
+  return { api, view }
+}

--- a/packages/likec4-spa/src/aichat/ui-state-data.ts
+++ b/packages/likec4-spa/src/aichat/ui-state-data.ts
@@ -1,0 +1,367 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import type { CurrentViewModel } from '@likec4/diagram'
+import type { Types, XYStoreState } from '@likec4/diagram/custom'
+import type { EdgeData, EdgeRelationData, ElementContextData, NodeData } from '@likec4/vite-plugin/ai/tools'
+
+type Metadata = Record<string, unknown>
+type LinkLike = {
+  url: string
+  title?: string | null
+}
+type RichTextLike = {
+  isEmpty: boolean
+  text: string | null
+}
+type ViewLike = {
+  id: string
+  title: string | null
+  _type: 'element' | 'deployment' | 'dynamic'
+}
+
+type RelationLike = {
+  id: string
+  source: { id: string }
+  target: { id: string }
+  title: string | null
+  technology: string | null
+  metadata: Metadata
+}
+
+type ElementLike = {
+  id: string
+  title: string
+  kind: string
+  technology: string | null
+  summary: RichTextLike
+  description: RichTextLike
+  tags: ReadonlyArray<string>
+  links: ReadonlyArray<LinkLike>
+  metadata: Metadata
+  parent: ElementLike | null
+  children(): Iterable<ElementLike>
+  incoming(): Iterable<ElementRelationshipLike>
+  outgoing(): Iterable<ElementRelationshipLike>
+  views(): Iterable<ViewLike>
+}
+
+type ElementRelationshipLike = {
+  id: string
+  source: ElementLike
+  target: ElementLike
+  title: string | null
+  technology: string | null
+  metadata: Metadata
+  links: ReadonlyArray<LinkLike>
+}
+
+type EdgeLike = {
+  id: string
+  source: { id: string }
+  target: { id: string }
+  label: string | null
+  technology: string | null
+  relationships(): Iterable<RelationLike>
+}
+
+type ViewModelLike = {
+  edges(): Iterable<EdgeLike>
+}
+
+export type AIChatContextConfig = {
+  element?: {
+    summary?: boolean
+    description?: boolean
+    technology?: boolean
+    tags?: boolean
+    links?: boolean
+    metadata?: boolean
+    parent?: boolean
+    children?: boolean
+    incoming?: boolean
+    outgoing?: boolean
+    alsoAppearsInViews?: boolean
+  }
+  relationships?: {
+    title?: boolean
+    technology?: boolean
+    metadata?: boolean
+    links?: boolean
+  }
+  limits?: {
+    children?: number
+    relationships?: number
+    views?: number
+  }
+}
+
+export type ChatTemplateVariables = {
+  title: string
+  kind: string
+  technology: string
+  parent: string
+  tags: string
+  view: string
+  dependencies: string
+  dependents: string
+}
+
+export function mapToNodeData(storeState: XYStoreState) {
+  return <T extends Types.NodeType>({ id, data, ...node }: Types.Node<T>): NodeData => {
+    let icon = data.icon ?? undefined
+    if (icon === 'none') {
+      icon = undefined
+    }
+
+    let children = storeState.parentLookup.get(id)?.values().map(child => child.id).toArray()
+
+    return {
+      id,
+      title: data.title,
+      shape: data.shape,
+      color: data.color,
+      icon,
+      parentId: node.parentId,
+      children,
+      x: data.x,
+      y: data.y,
+      width: node.measured?.width ?? node.width ?? node.initialWidth ?? 0,
+      height: node.measured?.height ?? node.height ?? node.initialHeight ?? 0,
+      ...('modelFqn' in data && data.modelFqn && { modelFqn: data.modelFqn }),
+    }
+  }
+}
+
+export function mapViewEdges(
+  viewModel: CurrentViewModel,
+  options: { includeRelations?: boolean } = {},
+): EdgeData[] {
+  return mapViewEdgeData(viewModel, options)
+}
+
+export function mapViewEdgeData(
+  viewModel: ViewModelLike,
+  options: { includeRelations?: boolean } = {},
+): EdgeData[] {
+  const includeRelations = options.includeRelations === true
+  return [...viewModel.edges()].map(edge => ({
+    id: edge.id,
+    source: edge.source.id,
+    target: edge.target.id,
+    label: edge.label,
+    technology: edge.technology,
+    ...(includeRelations && {
+      relations: [...edge.relationships()].map(mapRelationData),
+    }),
+  }))
+}
+
+export function mapElementContextData(
+  element: ElementLike,
+  currentView: ViewLike,
+  context: AIChatContextConfig | undefined = undefined,
+): ElementContextData {
+  const elementConfig = context?.element
+  const relationConfig = context?.relationships
+  const childrenLimit = context?.limits?.children ?? 50
+  const relationshipLimit = context?.limits?.relationships ?? 100
+  const viewsLimit = context?.limits?.views ?? 20
+  const metadata = normalizeMetadata(element.metadata)
+  const summary = textFromRichText(element.summary)
+  const description = textFromRichText(element.description)
+
+  return {
+    id: element.id,
+    title: element.title,
+    kind: element.kind,
+    ...(elementConfig?.technology !== false && { technology: element.technology }),
+    ...(elementConfig?.summary !== false && summary && { summary }),
+    ...(elementConfig?.description !== false && description && { description }),
+    ...(elementConfig?.tags !== false && element.tags.length > 0 && { tags: [...element.tags] }),
+    ...(elementConfig?.links !== false && element.links.length > 0 && { links: [...element.links] }),
+    ...(elementConfig?.metadata !== false && metadata && { metadata }),
+    ...(elementConfig?.parent !== false && element.parent && { parent: mapElementRef(element.parent) }),
+    ...(elementConfig?.children !== false && {
+      children: limitItems(element.children(), childrenLimit).map(mapElementRef),
+    }),
+    ...(elementConfig?.incoming !== false && {
+      incoming: limitItems(element.incoming(), relationshipLimit).map(relation =>
+        mapElementRelationshipData(relation, relationConfig)
+      ),
+    }),
+    ...(elementConfig?.outgoing !== false && {
+      outgoing: limitItems(element.outgoing(), relationshipLimit).map(relation =>
+        mapElementRelationshipData(relation, relationConfig)
+      ),
+    }),
+    ...(elementConfig?.alsoAppearsInViews !== false && {
+      alsoAppearsInViews: limitItems(element.views(), viewsLimit)
+        .filter(view => view.id !== currentView.id)
+        .map(mapViewRef),
+    }),
+  }
+}
+
+export function buildElementTemplateVariables(
+  element: ElementLike | null,
+  currentView: ViewLike,
+): ChatTemplateVariables {
+  if (!element) {
+    return {
+      title: '',
+      kind: '',
+      technology: '',
+      parent: '',
+      tags: '',
+      view: currentView.title ?? currentView.id,
+      dependencies: '',
+      dependents: '',
+    }
+  }
+
+  return {
+    title: element.title,
+    kind: element.kind,
+    technology: element.technology ?? '',
+    parent: element.parent?.title ?? '',
+    tags: element.tags.join(', '),
+    view: currentView.title ?? currentView.id,
+    dependencies: uniqueTitles(element.outgoing(), relation => relation.target.title).join(', '),
+    dependents: uniqueTitles(element.incoming(), relation => relation.source.title).join(', '),
+  }
+}
+
+const TEMPLATE_VARIABLE_RE = /\{(\w+)\}/g
+
+export function interpolateChatTemplate(
+  template: string,
+  variables: ChatTemplateVariables,
+  { hideIfEmpty }: { hideIfEmpty: boolean },
+): string | null {
+  let hasEmptyVariable = false
+  const result = template.replace(TEMPLATE_VARIABLE_RE, (match, key: string) => {
+    if (!isTemplateVariable(key)) {
+      return match
+    }
+    const value = variables[key]
+    if (!value) {
+      hasEmptyVariable = true
+    }
+    return value
+  })
+  return hideIfEmpty && hasEmptyVariable ? null : result
+}
+
+type DiagramContextLike = {
+  focusedNode?: string | null
+  xynodes: ReadonlyArray<{
+    id: string
+    selected?: boolean | undefined
+    data: Record<string, unknown>
+  }>
+}
+
+export function getSelectedElementId(context: DiagramContextLike): string | undefined {
+  const node = context.xynodes.find(n => !!n.selected || n.id === context.focusedNode)
+  return typeof node?.data['modelFqn'] === 'string' ? node.data['modelFqn'] : undefined
+}
+
+function mapRelationData(relation: RelationLike): EdgeRelationData {
+  const metadata = normalizeMetadata(relation.metadata)
+  return {
+    id: relation.id,
+    source: relation.source.id,
+    target: relation.target.id,
+    title: relation.title,
+    technology: relation.technology,
+    ...(metadata && { metadata }),
+  }
+}
+
+function mapElementRelationshipData(
+  relation: ElementRelationshipLike,
+  context: AIChatContextConfig['relationships'] | undefined,
+) {
+  const metadata = normalizeMetadata(relation.metadata)
+  return {
+    id: relation.id,
+    source: mapElementRef(relation.source),
+    target: mapElementRef(relation.target),
+    ...(context?.title !== false && { title: relation.title }),
+    ...(context?.technology !== false && { technology: relation.technology }),
+    ...(context?.metadata !== false && metadata && { metadata }),
+    ...(context?.links === true && relation.links.length > 0 && { links: [...relation.links] }),
+  }
+}
+
+function mapElementRef(element: ElementLike) {
+  return {
+    id: element.id,
+    title: element.title,
+    kind: element.kind,
+    technology: element.technology,
+  }
+}
+
+function mapViewRef(view: ViewLike) {
+  return {
+    id: view.id,
+    title: view.title ?? '',
+    type: view._type,
+  }
+}
+
+function textFromRichText(value: RichTextLike): string | undefined {
+  if (value.isEmpty || !value.text) {
+    return undefined
+  }
+  const text = value.text.trim()
+  return text ? text : undefined
+}
+
+function normalizeMetadata(metadata: Metadata): Record<string, string> | undefined {
+  const stringifyValue = (value: unknown): string => {
+    if (Array.isArray(value)) {
+      return value.map(item => stringifyValue(item)).join(', ')
+    }
+    if (value !== null && typeof value === 'object') {
+      try {
+        return JSON.stringify(value)
+      } catch {
+        return '[unserializable]'
+      }
+    }
+    return String(value)
+  }
+
+  const normalized = Object.fromEntries(
+    Object.entries(metadata).map(([key, value]) => [
+      key,
+      stringifyValue(value),
+    ]),
+  )
+  return Object.keys(normalized).length > 0 ? normalized : undefined
+}
+
+function limitItems<T>(items: Iterable<T>, limit: number): T[] {
+  return [...items].slice(0, limit)
+}
+
+function uniqueTitles<T>(items: Iterable<T>, selectTitle: (item: T) => string): string[] {
+  return [...new Set([...items].map(selectTitle))]
+}
+
+function isTemplateVariable(key: string): key is keyof ChatTemplateVariables {
+  return [
+    'title',
+    'kind',
+    'technology',
+    'parent',
+    'tags',
+    'view',
+    'dependencies',
+    'dependents',
+  ].includes(key)
+}

--- a/packages/likec4-spa/src/aichat/useChat.tsx
+++ b/packages/likec4-spa/src/aichat/useChat.tsx
@@ -6,9 +6,14 @@
 // Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
 
 import { type Fqn, nonexhaustive } from '@likec4/core'
-import { useDiagram } from '@likec4/diagram'
-import type { Types, XYStoreState } from '@likec4/diagram/custom'
-import { type NodeData, navigateToDef, readUiStateDef, updateUiStateDef } from '@likec4/vite-plugin/ai/tools'
+import { useCurrentViewModel, useDiagram } from '@likec4/diagram'
+import {
+  navigateToDef,
+  readConnectionsDef,
+  readElementDef,
+  readUiStateDef,
+  updateUiStateDef,
+} from '@likec4/vite-plugin/ai/tools'
 import {
   type UIMessage,
   clientTools,
@@ -16,42 +21,39 @@ import {
 import { type UseChatOptions, fetchServerSentEvents, useChat as useTanstackChat } from '@tanstack/ai-react'
 import { useNavigate } from '@tanstack/react-router'
 import { aiEndpoint } from 'likec4:rpc'
-import { useEffect, useMemo } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 import { find, map, pipe } from 'remeda'
 import { parse, stringify } from 'superjson'
 import { useCurrentProject } from '../hooks'
+import {
+  buildElementTemplateVariables,
+  getSelectedElementId,
+  interpolateChatTemplate,
+  mapElementContextData,
+  mapToNodeData,
+  mapViewEdges,
+} from './ui-state-data'
 
-function mapToNodeData(storeState: XYStoreState) {
-  return <T extends Types.NodeType>({ id, data, ...node }: Types.Node<T>): NodeData => {
-    let icon = data.icon ?? undefined
-    if (icon === 'none') {
-      icon = undefined
-    }
-
-    let children = storeState.parentLookup.get(id)?.values().map(child => child.id).toArray()
-
-    return {
-      id,
-      title: data.title,
-      shape: data.shape,
-      color: data.color,
-      icon,
-      parentId: node.parentId,
-      children,
-      x: data.x,
-      y: data.y,
-      width: node.measured?.width ?? node.width ?? node.initialWidth ?? 0,
-      height: node.measured?.height ?? node.height ?? node.initialHeight ?? 0,
-      ...('modelFqn' in data && data.modelFqn && { modelFqn: data.modelFqn }),
-    }
-  }
+function useLatestRef<T>(value: T) {
+  const ref = useRef(value)
+  ref.current = value
+  return ref
 }
 
 function useChatTools() {
-  const { id: projectId } = useCurrentProject()
+  const projectRef = useLatestRef(useCurrentProject())
+  const diagramRef = useLatestRef(useDiagram())
+  const currentViewModelRef = useLatestRef(useCurrentViewModel())
   const navigate = useNavigate()
 
-  const diagram = useDiagram()
+  const getCurrentView = () => {
+    const { view } = diagramRef.current.getContext()
+    return {
+      id: view.id,
+      title: view.title ?? '',
+      type: view._type,
+    }
+  }
 
   return useMemo(() =>
     clientTools(
@@ -69,22 +71,22 @@ function useChatTools() {
       // -------------
       readUiStateDef.client((params) => {
         const {
-          view,
           focusedNode,
           xynodes,
           xystore,
           toggledFeatures,
           features,
-        } = diagram.getContext()
+        } = diagramRef.current.getContext()
 
+        const currentViewModel = currentViewModelRef.current
         const isReadOnly = toggledFeatures.enableReadOnly ?? features.enableReadOnly
-
         const toNodeData = mapToNodeData(xystore.getState())
 
-        // if include nodes
         const nodes = params.nodes === true && map(xynodes, toNodeData) || undefined
+        const edges = (params.edges === true || params.edgeRelations === true) &&
+            mapViewEdges(currentViewModel, { includeRelations: params.edgeRelations === true }) ||
+          undefined
 
-        // if include nodes
         const selectedNode = params.selectedNode === true && pipe(
           xynodes,
           find(n => !!n.selected || n.id === focusedNode),
@@ -92,20 +94,60 @@ function useChatTools() {
         )
 
         return {
-          projectId,
+          projectId: projectRef.current.id,
           editMode: !isReadOnly,
-          view: {
-            id: view.id,
-            title: view.title ?? '',
-            type: view._type,
-          },
+          view: getCurrentView(),
           ...(nodes && { nodes }),
+          ...(edges && { edges }),
           ...(selectedNode && { selectedNode }),
         }
       }),
       // -------------
+      readConnectionsDef.client(() => {
+        const currentViewModel = currentViewModelRef.current
+        return {
+          projectId: projectRef.current.id,
+          view: getCurrentView(),
+          edges: mapViewEdges(currentViewModel, { includeRelations: true }),
+        }
+      }),
+      // -------------
+      readElementDef.client(({ elementId }) => {
+        const diagram = diagramRef.current
+        const currentViewModel = currentViewModelRef.current
+        const project = projectRef.current
+        const target = elementId ?? getSelectedElementId(diagram.getContext())
+        const element = target ? currentViewModel.$model.findElement(target) : null
+
+        if (!target) {
+          return {
+            projectId: project.id,
+            view: getCurrentView(),
+            element: null,
+            reason: 'No selected or focused element',
+          }
+        }
+
+        if (!element) {
+          return {
+            projectId: project.id,
+            view: getCurrentView(),
+            element: null,
+            reason: `Element not found: ${target}`,
+          }
+        }
+
+        return {
+          projectId: project.id,
+          view: getCurrentView(),
+          element: mapElementContextData(element, currentViewModel, project.aiChat?.context),
+        }
+      }),
+      // -------------
       updateUiStateDef.client(({ command }) => {
-        switch (command.type) {
+        const diagram = diagramRef.current
+        const commandType = command.type
+        switch (commandType) {
           case 'focus':
             diagram.focusOnElement(command.elementId as Fqn)
             break
@@ -113,15 +155,16 @@ function useChatTools() {
             diagram.fitDiagram()
             break
           default:
-            nonexhaustive(command)
+            nonexhaustive(commandType)
         }
         return {}
       }),
     ), [
     // Dependencies
     navigate,
-    diagram,
-    projectId,
+    diagramRef,
+    currentViewModelRef,
+    projectRef,
   ])
 }
 
@@ -154,15 +197,25 @@ const storage = {
 }
 
 export function useChat(options: Omit<UseChatOptions, 'connection' | 'tools' | 'initialMessages'>) {
+  const projectRef = useLatestRef(useCurrentProject())
+  const diagramRef = useLatestRef(useDiagram())
+  const currentViewModelRef = useLatestRef(useCurrentViewModel())
+
   const memoProps = useMemo(() => {
     if (!aiEndpoint) {
       throw new Error('AI chat endpoint is not configured')
     }
     return {
-      connection: fetchServerSentEvents(aiEndpoint),
+      connection: fetchServerSentEvents(aiEndpoint, () => ({
+        body: buildAIRequestBody(
+          projectRef.current.aiChat?.systemPrompt,
+          diagramRef.current,
+          currentViewModelRef.current,
+        ),
+      })),
       initialMessages: storage.read(),
     }
-  }, [])
+  }, [currentViewModelRef, diagramRef, projectRef])
   const chat = useTanstackChat({
     ...memoProps,
     ...options,
@@ -181,3 +234,20 @@ export function useChat(options: Omit<UseChatOptions, 'connection' | 'tools' | '
 }
 
 export type UseChatReturn = ReturnType<typeof useChat>
+
+function buildAIRequestBody(
+  systemPrompt: string | undefined,
+  diagram: ReturnType<typeof useDiagram>,
+  currentViewModel: ReturnType<typeof useCurrentViewModel>,
+) {
+  if (!systemPrompt?.trim()) {
+    return {}
+  }
+
+  const selectedElementId = getSelectedElementId(diagram.getContext())
+  const element = selectedElementId ? currentViewModel.$model.findElement(selectedElementId) : null
+  const variables = buildElementTemplateVariables(element, currentViewModel)
+  const renderedSystemPrompt = interpolateChatTemplate(systemPrompt, variables, { hideIfEmpty: false })?.trim()
+
+  return renderedSystemPrompt ? { systemPrompt: renderedSystemPrompt } : {}
+}

--- a/packages/likec4-spa/src/pages/ViewEditor.tsx
+++ b/packages/likec4-spa/src/pages/ViewEditor.tsx
@@ -99,7 +99,7 @@ export function ViewEditor() {
         <ListenForDynamicVariantChange />
         <OpenRelationshipBrowserFromUrl />
         <FocusElementFromUrl />
-        {isAIAvailable && <AIChat />}
+        {isAIAvailable && project.aiChat?.enabled !== false && <AIChat />}
         {isLocalAIAvailable && <SemanticLayoutLog />}
       </LikeC4Diagram>
     </LikeC4EditorProvider>

--- a/packages/likec4-spa/src/pages/ViewReact.tsx
+++ b/packages/likec4-spa/src/pages/ViewReact.tsx
@@ -22,10 +22,11 @@ import { isAIAvailable } from 'likec4:rpc'
 import { useRef } from 'react'
 import { AIChat } from '../aichat'
 import { NotFound } from '../components/NotFound'
-import { useCurrentView } from '../hooks'
+import { useCurrentProject, useCurrentView } from '../hooks'
 
 export function ViewReact() {
   const navigate = useNavigate()
+  const project = useCurrentProject()
   const [view, setLayoutType] = useCurrentView()
   const model = useLikeC4Model()
   const { dynamic } = useSearch({
@@ -90,7 +91,7 @@ export function ViewReact() {
       <ListenForDynamicVariantChange />
       <OpenRelationshipBrowserFromUrl />
       <FocusElementFromUrl />
-      {isAIAvailable && <AIChat />}
+      {isAIAvailable && project.aiChat?.enabled !== false && <AIChat />}
     </LikeC4Diagram>
   )
 }

--- a/packages/likec4/src/config/index.ts
+++ b/packages/likec4/src/config/index.ts
@@ -1,4 +1,12 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 export {
+  type AIChatConfig,
   defineConfig,
   defineGenerators,
   defineStyle,

--- a/packages/vite-plugin/src/ai/server.ts
+++ b/packages/vite-plugin/src/ai/server.ts
@@ -6,7 +6,7 @@ import { invariant } from '@likec4/core'
 import { chat, convertMessagesToModelMessages, toServerSentEventsResponse } from '@tanstack/ai'
 import type { ModelMessage, UIMessage } from '@tanstack/ai'
 import type { AIOptions } from '../plugin'
-import { navigateToDef, readUiStateDef, updateUiStateDef } from './tools'
+import { navigateToDef, readConnectionsDef, readElementDef, readUiStateDef, updateUiStateDef } from './tools'
 
 export const LIKEC4_AI_ENDPOINT_PATH = '/__likec4_ai'
 export const DEFAULT_LIKEC4_AI_REQUEST_MAX_BYTES = 4 * 1024 * 1024
@@ -92,17 +92,25 @@ export function createLikeC4AIResponse({
   invariant(ai, 'AI is not configured')
 
   const messages = convertMessagesToModelMessages(body.messages ?? [])
+  const projectSystemPrompt = typeof body.data?.['systemPrompt'] === 'string'
+    ? body.data['systemPrompt'].trim()
+    : ''
   const stream = chat({
     ...ai,
     messages,
     conversationId: typeof body.data?.['conversationId'] === 'string' ? body.data['conversationId'] : undefined,
     systemPrompts: [
       'You are a helpful assistant that can answer questions about LikeC4 model and update UI.',
+      'For questions about a specific element, component, system, parent, children, dependencies, or dependents, call read_element.',
+      'For questions about connections, inputs, outputs, edges, connection datatypes, ports, or metadata, call read_connections and answer from that tool result without repeating the same tool call.',
+      ...(projectSystemPrompt ? [projectSystemPrompt] : []),
     ],
     tools: [
       navigateToDef,
       updateUiStateDef,
       readUiStateDef,
+      readConnectionsDef,
+      readElementDef,
     ],
   })
 

--- a/packages/vite-plugin/src/ai/tools.spec.ts
+++ b/packages/vite-plugin/src/ai/tools.spec.ts
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+import { readConnectionsDef, readElementDef, readUiStateDef, updateUiStateDef } from './tools'
+
+describe('AI UI tools', () => {
+  it('allows opting into edges and relationship metadata', () => {
+    expect(
+      readUiStateDef.inputSchema?.safeParse({
+        edges: true,
+        edgeRelations: true,
+      }).success,
+    ).toBe(true)
+  })
+
+  it('has a dedicated connections tool without required parameters', () => {
+    expect(readConnectionsDef.inputSchema?.safeParse({}).success).toBe(true)
+  })
+
+  it('can read the selected element or an explicit element id', () => {
+    expect(readElementDef.inputSchema?.safeParse({}).success).toBe(true)
+    expect(readElementDef.inputSchema?.safeParse({ elementId: 'cloud.backend' }).success).toBe(true)
+    expect(readElementDef.inputSchema?.safeParse({ elementId: '' }).success).toBe(false)
+  })
+
+  it('requires elementId for focus commands', () => {
+    expect(
+      updateUiStateDef.inputSchema?.safeParse({
+        command: {
+          type: 'focus',
+        },
+      }).success,
+    ).toBe(false)
+
+    expect(
+      updateUiStateDef.inputSchema?.safeParse({
+        command: {
+          type: 'fitview',
+        },
+      }).success,
+    ).toBe(true)
+
+    expect(
+      updateUiStateDef.inputSchema?.safeParse({
+        command: {
+          type: 'focus',
+          elementId: 'cloud.backend',
+        },
+      }).success,
+    ).toBe(true)
+  })
+
+  it('uses an OpenAI-compatible flat schema for commands', () => {
+    const jsonSchema = z.toJSONSchema(updateUiStateDef.inputSchema!)
+
+    expect(JSON.stringify(jsonSchema)).not.toContain('"oneOf"')
+  })
+})

--- a/packages/vite-plugin/src/ai/tools.ts
+++ b/packages/vite-plugin/src/ai/tools.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { ElementShapes } from '@likec4/core/styles'
 import { toolDefinition } from '@tanstack/ai'
 import { z } from 'zod'
@@ -19,55 +26,161 @@ const nodeSchema = z.object({
 
 export type NodeData = z.infer<typeof nodeSchema>
 
+const edgeRelationSchema = z.object({
+  id: z.string().meta({ description: 'Relationship ID' }),
+  source: z.string().meta({ description: 'Source model element or deployment reference' }),
+  target: z.string().meta({ description: 'Target model element or deployment reference' }),
+  title: z.string().nullish().meta({ description: 'Relationship label/title' }),
+  technology: z.string().nullish().meta({ description: 'Relationship technology/kind label' }),
+  metadata: z.record(z.string(), z.string()).nullish().meta({
+    description: 'Relationship metadata as string values, for example datatype, src_port, and dst_port',
+  }),
+})
+
+export type EdgeRelationData = z.infer<typeof edgeRelationSchema>
+
+const edgeSchema = z.object({
+  id: z.string().meta({ description: 'Edge ID in the current view' }),
+  source: z.string().meta({ description: 'Source node ID in the current view' }),
+  target: z.string().meta({ description: 'Target node ID in the current view' }),
+  label: z.string().nullish().meta({ description: 'Visible edge label' }),
+  technology: z.string().nullish().meta({ description: 'Visible edge technology label' }),
+  relations: z.array(edgeRelationSchema).nullish().meta({
+    description: 'Underlying relationships represented by this view edge',
+  }),
+})
+
+export type EdgeData = z.infer<typeof edgeSchema>
+
+const viewSchema = z
+  .object({
+    id: z.string(),
+    title: z.string(),
+    type: z.enum(['element', 'deployment', 'dynamic']).meta({ description: 'Type of the current view' }),
+  })
+  .meta({ description: 'Current view' })
+
+const linkSchema = z.object({
+  url: z.string(),
+  title: z.string().nullish(),
+})
+
+const elementRefSchema = z.object({
+  id: z.string().meta({ description: 'Model element FQN' }),
+  title: z.string(),
+  kind: z.string(),
+  technology: z.string().nullish(),
+})
+
+const elementRelationshipSchema = z.object({
+  id: z.string().meta({ description: 'Relationship ID' }),
+  source: elementRefSchema,
+  target: elementRefSchema,
+  title: z.string().nullish(),
+  technology: z.string().nullish(),
+  metadata: z.record(z.string(), z.string()).nullish(),
+  links: z.array(linkSchema).nullish(),
+})
+
+const elementContextSchema = z.object({
+  id: z.string().meta({ description: 'Model element FQN' }),
+  title: z.string(),
+  kind: z.string(),
+  technology: z.string().nullish(),
+  summary: z.string().nullish(),
+  description: z.string().nullish(),
+  tags: z.array(z.string()).nullish(),
+  links: z.array(linkSchema).nullish(),
+  metadata: z.record(z.string(), z.string()).nullish(),
+  parent: elementRefSchema.nullish(),
+  children: z.array(elementRefSchema).nullish(),
+  incoming: z.array(elementRelationshipSchema).nullish(),
+  outgoing: z.array(elementRelationshipSchema).nullish(),
+  alsoAppearsInViews: z.array(viewSchema).nullish(),
+})
+
+export type ElementContextData = z.infer<typeof elementContextSchema>
+
 export const readUiStateDef = toolDefinition({
   name: 'read_ui',
-  description: 'Read current UI state. Use arguments to include additional data.',
+  description:
+    'Read current UI state. Use nodes for element questions. Use edges for connection/input/output questions. Use edgeRelations for relationship metadata such as datatypes and ports.',
   needsApproval: false,
   inputSchema: z.object({
     selectedNode: z.boolean().default(false).meta({ description: 'Include selected node (if any)' }),
     nodes: z.boolean().default(false).meta({ description: 'Include all nodes from the view' }),
+    edges: z.boolean().default(false).meta({
+      description: 'Include all edges from the current view',
+    }),
+    edgeRelations: z.boolean().default(false).meta({
+      description: 'Include underlying relationship details and metadata for returned edges. Implies edges.',
+    }),
   }),
   outputSchema: z.object({
     projectId: z.string(),
     editMode: z.boolean().meta({ description: 'Whether the UI is in edit mode' }),
-    view: z
-      .object({
-        id: z.string(),
-        title: z.string(),
-        type: z.enum(['element', 'deployment', 'dynamic']).meta({ description: 'Type of the current view' }),
-      })
-      .meta({ description: 'Current view' }),
+    view: viewSchema,
     nodes: z.array(nodeSchema).nullish(),
+    edges: z.array(edgeSchema).nullish(),
     selectedNode: nodeSchema.nullish(),
   }),
 })
 
-const focusCommand = z
-  .object({
-    type: z.literal('focus'),
-    elementId: z.string().meta({ description: 'Element ID (FQN)' }),
-  })
-  .meta({
-    description: 'Focus UI on an element by its FQN',
-  })
+export const readConnectionsDef = toolDefinition({
+  name: 'read_connections',
+  description:
+    'Read current view connections/edges including underlying relationship metadata. Use for questions about inputs, outputs, datatypes, ports, and connection metadata.',
+  needsApproval: false,
+  inputSchema: z.object({}),
+  outputSchema: z.object({
+    projectId: z.string(),
+    view: viewSchema,
+    edges: z.array(edgeSchema),
+  }),
+})
 
-const fitViewCommand = z
-  .object({
-    type: z.literal('fitview'),
-  })
-  .meta({
-    description: 'Zoom out to fit all elements in the viewport, and clear any selection/focus',
-  })
+export const readElementDef = toolDefinition({
+  name: 'read_element',
+  description:
+    'Read rich model context for an element. If elementId is omitted, reads the selected or focused element.',
+  needsApproval: false,
+  inputSchema: z.object({
+    elementId: z.string().min(1).nullish().meta({
+      description: 'Model element FQN. If omitted, selected or focused element is used.',
+    }),
+  }),
+  outputSchema: z.object({
+    projectId: z.string(),
+    view: viewSchema,
+    element: elementContextSchema.nullish(),
+    reason: z.string().nullish(),
+  }),
+})
 
 export const updateUiStateDef = toolDefinition({
   name: 'update_ui',
   description: 'Update UI state by executing a command.',
   needsApproval: false,
   inputSchema: z.object({
-    command: z.discriminatedUnion('type', [
-      focusCommand,
-      fitViewCommand,
-    ]),
+    command: z
+      .object({
+        type: z.enum(['focus', 'fitview']).meta({
+          description:
+            'Command to execute. "focus" requires elementId. "fitview" zooms out and clears selection/focus.',
+        }),
+        elementId: z.string().min(1).nullish().meta({
+          description: 'Element ID (FQN), required for focus commands.',
+        }),
+      })
+      .superRefine((command, ctx) => {
+        if (command.type === 'focus' && !command.elementId) {
+          ctx.addIssue({
+            code: 'custom',
+            message: 'elementId is required for focus commands',
+            path: ['elementId'],
+          })
+        }
+      }),
   }),
   outputSchema: z.object({}),
 })

--- a/packages/vite-plugin/src/modules.d.ts
+++ b/packages/vite-plugin/src/modules.d.ts
@@ -6,6 +6,7 @@
 // Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
 
 declare module 'likec4:projects' {
+  import type { AIChatConfig } from 'likec4/config'
   import type { ProjectId } from 'likec4/model'
   type LandingPageConfig =
     | { redirect: true }
@@ -15,6 +16,7 @@ declare module 'likec4:projects' {
     id: ProjectId
     title?: string
     landingPage?: LandingPageConfig
+    aiChat?: AIChatConfig
   }
   export const isSingleProject: boolean
   export const projects: readonly [Project, ...Project[]]

--- a/packages/vite-plugin/src/plugin.ts
+++ b/packages/vite-plugin/src/plugin.ts
@@ -267,6 +267,7 @@ export function LikeC4VitePlugin({
       title: p.title,
       folder: p.folder.toString(),
       landingPage: p.config.landingPage,
+      aiChat: p.config.aiChat,
     })) satisfies (data: ProjectsData) => any
     let _last: any
     return <T extends ProjectsData>(update: T): boolean => {

--- a/packages/vite-plugin/src/virtuals/projects.spec.ts
+++ b/packages/vite-plugin/src/virtuals/projects.spec.ts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import { describe, expect, it } from 'vitest'
+import { generateProjectsModuleCode } from './projects'
+
+describe('projects virtual module', () => {
+  it('exposes safe AI Chat project defaults', () => {
+    const code = generateProjectsModuleCode([{
+      id: 'demo',
+      title: 'Demo',
+      landingPage: undefined,
+      aiChat: {
+        enabled: true,
+        systemPrompt: 'Answer from model facts.',
+        suggestedQuestions: {
+          element: ['What does {title} do?'],
+        },
+        context: {
+          relationships: {
+            metadata: true,
+          },
+        },
+      },
+    }])
+
+    expect(code).toContain('aiChat')
+    expect(code).toContain('Answer from model facts.')
+    expect(code).toContain('What does {title} do?')
+    expect(code).not.toContain('apiKey')
+    expect(code).not.toContain('allowUnsafeApiKey')
+  })
+})

--- a/packages/vite-plugin/src/virtuals/projects.ts
+++ b/packages/vite-plugin/src/virtuals/projects.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import type { LikeC4ProjectConfig } from '@likec4/config'
 import type { NonEmptyArray } from '@likec4/core'
 import JSON5 from 'json5'
@@ -9,9 +16,10 @@ type ProjectData = {
   id: string
   title: string | undefined
   landingPage: LikeC4ProjectConfig['landingPage']
+  aiChat: LikeC4ProjectConfig['aiChat']
 }
 
-const code = (projects: NonEmptyArray<ProjectData>) => `
+export const generateProjectsModuleCode = (projects: NonEmptyArray<ProjectData>) => `
 import { atom, useStore } from 'likec4/vite-plugin/internal'
 
 export const isSingleProject = ${projects.length === 1};
@@ -49,10 +57,11 @@ export const projectsModule = {
   async load({ projects }) {
     logGenerating('projects')
     return {
-      code: code(map(projects, p => ({
+      code: generateProjectsModuleCode(map(projects, p => ({
         id: p.id,
         title: p.title,
         landingPage: p.config.landingPage,
+        aiChat: p.config.aiChat,
       }))),
       moduleType: 'js',
     }


### PR DESCRIPTION
Stacked on #2959.

## Summary
- adds project-level `aiChat` defaults for enabling chat, system prompts, suggested element questions, and context selection
- sends configured project prompt/context with chat requests without adding provider credentials to project config
- adds richer current-view connection and selected/focused element context tools, with documentation for what may be sent to the provider/proxy

## Validation
- `npx -y pnpm@10.33.3 generate`
- `npx -y pnpm@10.33.3 --filter @likec4/spa test -- aichat`
- `npx -y pnpm@10.33.3 --filter @likec4/vite-plugin test -- ai tools projects`
- `npx -y pnpm@10.33.3 --dir packages/config exec vitest run --no-isolate -- schema`
- `npx -y pnpm@10.33.3 --filter @likec4/config typecheck`
- `npx -y pnpm@10.33.3 --filter @likec4/spa typecheck`
- `npx -y pnpm@10.33.3 --filter @likec4/vite-plugin typecheck`
- `npx -y pnpm@10.33.3 --filter likec4 typecheck`