### PR TITLE
WIP: Add export background option

### DIFF
--- a/.changeset/export-background-option.md
+++ b/.changeset/export-background-option.md
@@ -1,0 +1,5 @@
+---
+"likec4": minor
+---
+
+Add a `--background` option to PNG and JPEG exports so generated images can use a custom CSS background color.

--- a/apps/docs/src/content/docs/tooling/cli.mdx
+++ b/apps/docs/src/content/docs/tooling/cli.mdx
@@ -159,6 +159,7 @@ For example, this command can be used in CI to compare diagrams with ones from t
 
 ```sh
 likec4 export png -o ./assets
+likec4 export png -o ./assets --background "#fff"
 likec4 export jpg -o ./assets --quality 90
 ```
 
@@ -167,6 +168,7 @@ If you plan to use it in CI, refer to the [Playwright documentation](https://pla
 or consider [LikeC4 GitHub Actions](/tooling/github)
 
 Use `likec4 export jpg` to export JPEG files. It supports the same screenshot options, plus `--quality`.
+JPEG files default to the selected theme body color when `--background` is omitted.
 
 :::note
 Exporting to PNG or JPEG requires Playwright.
@@ -184,6 +186,7 @@ You will be prompted with a command to install if it's not found.
 | `--seq, --sequence`     | use sequence layout for dynamic views                                                                         |
 | `--flat, --flatten`     | Flatten all images in outdir, ignoring source structure                                                       |
 | `-f, --filter`          | include views with ids matching given patterns<br/>(multiple patterns are combined with OR)                   |
+| `--background`          | CSS background color for exported images. PNG defaults to transparent; JPEG defaults to the selected theme body color |
 | `--quality, -q`         | JPEG quality from 1 to 100 (default is 80); only used by `likec4 export jpg`                                  |
 | `-i, --ignore`          | continue if export fails for some views                                                                       |
 | `-t, --timeout`         | timeout for playwright in seconds, default is 15                                                              |

--- a/packages/likec4-spa/src/pages/ExportPage.tsx
+++ b/packages/likec4-spa/src/pages/ExportPage.tsx
@@ -23,7 +23,7 @@ import {
   EXPORT_DESCRIPTION_TOP_PADDING,
   EXPORT_NOTATION_ITEM_HEIGHT,
 } from './export-layout'
-import { isExportSearchFlagEnabled } from './export-page-params'
+import { hasSolidExportBackground, isExportSearchFlagEnabled, normalizeExportBackground } from './export-page-params'
 
 type PaletteCssVars =
   & CSSProperties
@@ -54,16 +54,18 @@ function triggerDownload(url: string, filename: string) {
  * Converts the export viewport into a PNG file and starts a browser download.
  */
 async function downloadAsPng({
+  background,
   pngFilename,
   viewport,
 }: {
+  background?: string | undefined
   pngFilename: string
   viewport: HTMLElement
 }) {
   try {
     const { toBlob } = await import('html-to-image')
     const blob = await toBlob(viewport, {
-      backgroundColor: 'transparent',
+      backgroundColor: background ?? 'transparent',
       cacheBust: true,
       imagePlaceholder: 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==',
     })
@@ -84,17 +86,20 @@ async function downloadAsPng({
  * Converts the export viewport into a JPEG file and starts a browser download.
  */
 async function downloadAsJpeg({
+  background,
   filename,
   viewport,
   quality = 0.8,
 }: {
+  background?: string | undefined
   filename: string
   viewport: HTMLElement
   quality?: number
 }) {
   try {
     const { toJpeg } = await import('html-to-image')
-    const backgroundColor = getComputedStyle(document.documentElement).getPropertyValue('--mantine-color-body')
+    const backgroundColor = background ??
+      getComputedStyle(document.documentElement).getPropertyValue('--mantine-color-body')
     const dataUrl = await toJpeg(viewport, {
       backgroundColor,
       quality,
@@ -115,7 +120,8 @@ async function downloadAsJpeg({
  */
 export function ExportPage() {
   const [diagram] = useCurrentView()
-  const { format } = useSearch({ strict: false })
+  const { background, format } = useSearch({ strict: false })
+  const exportBackground = normalizeExportBackground(background)
   const isJpeg = format === 'jpeg'
 
   useTransparentBackground(!isJpeg)
@@ -124,13 +130,21 @@ export function ExportPage() {
     return <div>Loading...</div>
   }
 
-  return <GuardedExportPage diagram={diagram} isJpeg={isJpeg} />
+  return <GuardedExportPage diagram={diagram} exportBackground={exportBackground} isJpeg={isJpeg} />
 }
 
 /**
  * Renders the measured export viewport for a loaded diagram.
  */
-function GuardedExportPage({ diagram, isJpeg }: { diagram: LayoutedView; isJpeg: boolean }) {
+function GuardedExportPage({
+  diagram,
+  exportBackground,
+  isJpeg,
+}: {
+  diagram: LayoutedView
+  exportBackground: string | undefined
+  isJpeg: boolean
+}) {
   const {
     padding = 20,
     download = false,
@@ -159,6 +173,7 @@ function GuardedExportPage({ diagram, isJpeg }: { diagram: LayoutedView; isJpeg:
     description: showDescription ? { title: viewTitle, text: viewDescription.text } : null,
     notationEntries: showNotation ? notationEntries.length : 0,
   })
+  const hasSolidBackground = isJpeg || hasSolidExportBackground(exportBackground)
 
   const downloadDiagram = () => {
     const viewport = viewportRef.current
@@ -172,12 +187,14 @@ function GuardedExportPage({ diagram, isJpeg }: { diagram: LayoutedView; isJpeg:
     downloadedRef.current = true
     if (isJpeg) {
       void downloadAsJpeg({
+        background: exportBackground,
         filename: diagram.id,
         viewport,
         quality: quality ?? 0.8,
       })
     } else {
       void downloadAsPng({
+        background: exportBackground,
         pngFilename: diagram.id,
         viewport,
       })
@@ -204,7 +221,7 @@ function GuardedExportPage({ diagram, isJpeg }: { diagram: LayoutedView; isJpeg:
         width: layout.width,
         minHeight: layout.height,
         height: layout.height,
-        background: isJpeg ? 'var(--mantine-color-body)' : 'transparent',
+        backgroundColor: exportBackground ?? (isJpeg ? 'var(--mantine-color-body)' : 'transparent'),
       }}>
       {download && <LoadingOverlay ref={loadingOverlayRef} visible />}
       <Box
@@ -228,7 +245,7 @@ function GuardedExportPage({ diagram, isJpeg }: { diagram: LayoutedView; isJpeg:
             left: '0px',
             right: '0px',
           }}
-          background={isJpeg ? 'solid' : 'transparent'}
+          background={hasSolidBackground ? 'solid' : 'transparent'}
           reduceGraphics={false}
           dynamicViewVariant={dynamic}
           className={'likec4-static-view'}

--- a/packages/likec4-spa/src/pages/export-page-params.spec.ts
+++ b/packages/likec4-spa/src/pages/export-page-params.spec.ts
@@ -3,7 +3,7 @@
 // Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import { describe, expect, it } from 'vitest'
-import { isExportSearchFlagEnabled } from './export-page-params'
+import { hasSolidExportBackground, isExportSearchFlagEnabled, normalizeExportBackground } from './export-page-params'
 
 describe('isExportSearchFlagEnabled', () => {
   it('accepts boolean and URL string true values', () => {
@@ -16,5 +16,43 @@ describe('isExportSearchFlagEnabled', () => {
     expect(isExportSearchFlagEnabled('false')).toBe(false)
     expect(isExportSearchFlagEnabled(undefined)).toBe(false)
     expect(isExportSearchFlagEnabled('')).toBe(false)
+  })
+})
+
+describe('normalizeExportBackground', () => {
+  it('trims non-empty background values', () => {
+    expect(normalizeExportBackground('  #111827  ')).toBe('#111827')
+    expect(normalizeExportBackground('white')).toBe('white')
+  })
+
+  it('ignores missing and blank background values', () => {
+    expect(normalizeExportBackground(undefined)).toBeUndefined()
+    expect(normalizeExportBackground('')).toBeUndefined()
+    expect(normalizeExportBackground('   ')).toBeUndefined()
+  })
+})
+
+describe('hasSolidExportBackground', () => {
+  it('rejects missing and transparent background values', () => {
+    expect(hasSolidExportBackground(undefined)).toBe(false)
+    expect(hasSolidExportBackground('transparent')).toBe(false)
+    expect(hasSolidExportBackground('  TRANSPARENT  ')).toBe(false)
+    expect(hasSolidExportBackground('rgba(0, 0, 0, 0)')).toBe(false)
+    expect(hasSolidExportBackground('rgb(0 0 0 / 0%)')).toBe(false)
+    expect(hasSolidExportBackground('hsl(0 0% 0% / 0)')).toBe(false)
+    expect(hasSolidExportBackground('hsla(0, 0%, 0%, 0)')).toBe(false)
+    expect(hasSolidExportBackground('hwb(0 0% 0% / 0%)')).toBe(false)
+    expect(hasSolidExportBackground('oklch(0 0 0 / 0)')).toBe(false)
+    expect(hasSolidExportBackground('#0000')).toBe(false)
+    expect(hasSolidExportBackground('#00000000')).toBe(false)
+  })
+
+  it('accepts opaque background values', () => {
+    expect(hasSolidExportBackground('#fff')).toBe(true)
+    expect(hasSolidExportBackground('#111827')).toBe(true)
+    expect(hasSolidExportBackground('white')).toBe(true)
+    expect(hasSolidExportBackground('rgba(0, 0, 0, 0.5)')).toBe(true)
+    expect(hasSolidExportBackground('rgb(0 0 0 / 50%)')).toBe(true)
+    expect(hasSolidExportBackground('oklch(0.8 0.1 200 / 50%)')).toBe(true)
   })
 })

--- a/packages/likec4-spa/src/pages/export-page-params.ts
+++ b/packages/likec4-spa/src/pages/export-page-params.ts
@@ -8,3 +8,47 @@
 export function isExportSearchFlagEnabled(value: unknown): boolean {
   return value === true || value === 'true'
 }
+
+/**
+ * Normalizes an optional export background color from router search params.
+ */
+export function normalizeExportBackground(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined
+}
+
+/**
+ * Checks whether an export background value should be treated as an opaque diagram background.
+ */
+export function hasSolidExportBackground(value: string | undefined): boolean {
+  if (!value) {
+    return false
+  }
+  const normalized = value.trim().toLowerCase()
+  if (!normalized || normalized === 'transparent') {
+    return false
+  }
+  if (/^#[\da-f]{4}$/i.test(normalized)) {
+    return normalized[4] !== '0'
+  }
+  if (/^#[\da-f]{8}$/i.test(normalized)) {
+    return normalized.slice(7) !== '00'
+  }
+
+  const colorFunctionMatch = normalized.match(/^[a-z][a-z0-9-]*\((.*)\)$/i)
+  if (!colorFunctionMatch) {
+    return true
+  }
+
+  const body = colorFunctionMatch[1] ?? ''
+  const slashAlpha = body.match(/\/\s*([^)]+)$/)?.[1]
+  const parts = body.split(',')
+  const commaAlpha = parts.length === 4 ? parts.at(-1) : undefined
+  const alpha = slashAlpha ?? commaAlpha
+  return !alpha || !isZeroAlpha(alpha)
+}
+
+function isZeroAlpha(value: string): boolean {
+  const normalized = value.trim()
+  const numeric = normalized.endsWith('%') ? Number.parseFloat(normalized) / 100 : Number.parseFloat(normalized)
+  return Number.isFinite(numeric) && numeric === 0
+}

--- a/packages/likec4-spa/src/routes/_single/export.$viewId.tsx
+++ b/packages/likec4-spa/src/routes/_single/export.$viewId.tsx
@@ -11,6 +11,7 @@ import { ExportPage } from '../../pages/ExportPage'
 
 export const Route = createFileRoute('/_single/export/$viewId')({
   validateSearch: z.object({
+    background: z.string().optional().catch(undefined),
     description: z.boolean().optional().catch(false),
     download: z.boolean().optional().catch(false),
     format: z.enum(['png', 'jpeg']).optional().catch('png'),
@@ -20,6 +21,7 @@ export const Route = createFileRoute('/_single/export/$viewId')({
   search: {
     middlewares: [
       stripSearchParams({
+        background: undefined,
         description: false,
         download: false,
         format: 'png',

--- a/packages/likec4-spa/src/routes/project.$projectId/export.$viewId.tsx
+++ b/packages/likec4-spa/src/routes/project.$projectId/export.$viewId.tsx
@@ -11,6 +11,7 @@ import { ExportPage } from '../../pages/ExportPage'
 
 export const Route = createFileRoute('/project/$projectId/export/$viewId')({
   validateSearch: z.object({
+    background: z.string().optional().catch(undefined),
     description: z.boolean().optional().catch(false),
     download: z.boolean().optional().catch(false),
     format: z.enum(['png', 'jpeg']).optional().catch('png'),
@@ -20,6 +21,7 @@ export const Route = createFileRoute('/project/$projectId/export/$viewId')({
   search: {
     middlewares: [
       stripSearchParams({
+        background: undefined,
         description: false,
         download: false,
         format: 'png',

--- a/packages/likec4/src/cli/export/jpg/handler.ts
+++ b/packages/likec4/src/cli/export/jpg/handler.ts
@@ -119,6 +119,12 @@ export function jpgCmd(yargs: Argv) {
             desc: 'include view description in exported JPEG files',
             default: false,
           },
+          'background': {
+            type: 'string',
+            desc:
+              'CSS background color for exported JPEG files, e.g. "#fff" or "white"; defaults to the selected theme body color',
+            nargs: 1,
+          },
         })
         .epilog(`${k.bold('Examples:')}
   ${k.green('$0 export jpg')}
@@ -129,6 +135,9 @@ export function jpgCmd(yargs: Argv) {
 
   ${k.green('$0 export jpg --quality 90 -o ./jpg src/likec4')}
     ${k.gray('Export JPEG with 90% quality')}
+
+  ${k.green('$0 export jpg --background "#111827" -o ./jpg src/likec4')}
+    ${k.gray('Export JPEG files with a custom background color')}
 
   ${k.green('$0 export jpg -f "team1*" -f "team2*" --flat -o ./jpg src/likec4')}
     ${k.gray('Export views matching team1* or team2* only')}
@@ -159,6 +168,7 @@ export function jpgCmd(yargs: Argv) {
           quality: args.quality,
           notation: args.notation,
           description: args.description,
+          background: args.background,
         } satisfies PngExportArgs,
       )
       showSupportUsMessage()

--- a/packages/likec4/src/cli/export/png/handler.ts
+++ b/packages/likec4/src/cli/export/png/handler.ts
@@ -53,6 +53,8 @@ export type PngExportArgs = {
   notation?: boolean
   /** Include view description in exported images. */
   description?: boolean
+  /** CSS background color for exported images. */
+  background?: string | undefined
 }
 
 /** Launch headless Chromium, capture each view as PNG to output dir; returns list of succeeded view ids. */
@@ -72,6 +74,7 @@ export async function exportViewsToPNG(
     quality,
     notation = false,
     description = false,
+    background,
   }: {
     logger: ViteLogger
     serverUrl: string
@@ -87,6 +90,7 @@ export async function exportViewsToPNG(
     quality?: number | undefined
     notation?: boolean
     description?: boolean
+    background?: string | undefined
   },
 ) {
   logger.info(`${k.dim('output')} ${output}`)
@@ -124,6 +128,7 @@ export async function exportViewsToPNG(
       quality,
       notation,
       description,
+      background,
     })
   } finally {
     logger.info(k.cyan(`close chromium`))
@@ -152,6 +157,7 @@ export async function runExportPng(args: PngExportArgs, logger: ViteLogger): Pro
     quality,
     notation = false,
     description = false,
+    background,
   } = args
 
   await using likec4 = await fromWorkspace(workspacePath, {
@@ -237,6 +243,7 @@ export async function runExportPng(args: PngExportArgs, logger: ViteLogger): Pro
         quality,
         notation,
         description,
+        background,
       })
       const { pretty } = inMillis(startTakeScreenshot)
 
@@ -362,6 +369,11 @@ export function pngCmd(yargs: Argv) {
             desc: 'include view description in exported PNG files',
             default: false,
           },
+          'background': {
+            type: 'string',
+            desc: 'CSS background color for exported PNG files, e.g. "#fff" or "white"; defaults to transparent',
+            nargs: 1,
+          },
         })
         .epilog(`${k.bold('Examples:')}
   ${k.green('$0 export png')}
@@ -369,6 +381,9 @@ export function pngCmd(yargs: Argv) {
 
   ${k.green('$0 export png --theme dark -o ./png src/likec4')}
     ${k.gray('Search for likec4 files in src/likec4 and output PNG with dark theme to png folder')}
+
+  ${k.green('$0 export png --background "#fff" -o ./png src/likec4')}
+    ${k.gray('Export PNG files with a solid background color')}
 
   ${k.green('$0 export png -f "team1*" -f "team2*" --flat -o ./png src/likec4')}
     ${k.gray('Export views matching team1* or team2* only')}
@@ -399,6 +414,7 @@ export function pngCmd(yargs: Argv) {
           chromiumSandbox: args['chromium-sandbox'],
           notation: args.notation,
           description: args.description,
+          background: args.background,
         } satisfies PngExportArgs,
       )
       showSupportUsMessage()

--- a/packages/likec4/src/cli/export/png/takeScreenshot.spec.ts
+++ b/packages/likec4/src/cli/export/png/takeScreenshot.spec.ts
@@ -22,6 +22,7 @@ describe('createExportViewUrl', () => {
     expect(url.searchParams.get('theme')).toBe('light')
     expect(url.searchParams.has('notation')).toBe(false)
     expect(url.searchParams.has('description')).toBe(false)
+    expect(url.searchParams.has('background')).toBe(false)
   })
 
   it('adds notation query parameter when requested', () => {
@@ -48,6 +49,18 @@ describe('createExportViewUrl', () => {
     expect(url.searchParams.get('description')).toBe('true')
   })
 
+  it('adds background query parameter when requested', () => {
+    const url = parseExportUrl(createExportViewUrl({
+      viewId: 'orders',
+      padding: 20,
+      theme: 'dark',
+      background: '#111827',
+    }))
+
+    expect(url.pathname).toBe('/export/orders/')
+    expect(url.searchParams.get('background')).toBe('#111827')
+  })
+
   it('keeps JPEG and dynamic export query parameters with decorations', () => {
     const url = parseExportUrl(createExportViewUrl({
       viewId: 'checkout',
@@ -57,6 +70,7 @@ describe('createExportViewUrl', () => {
       format: 'jpeg',
       notation: true,
       description: true,
+      background: 'white',
     }))
 
     expect(url.searchParams.get('padding')).toBe('24')
@@ -65,5 +79,6 @@ describe('createExportViewUrl', () => {
     expect(url.searchParams.get('format')).toBe('jpeg')
     expect(url.searchParams.get('notation')).toBe('true')
     expect(url.searchParams.get('description')).toBe('true')
+    expect(url.searchParams.get('background')).toBe('white')
   })
 })

--- a/packages/likec4/src/cli/export/png/takeScreenshot.ts
+++ b/packages/likec4/src/cli/export/png/takeScreenshot.ts
@@ -29,13 +29,14 @@ type TakeScreenshotParams = {
   quality?: number | undefined
   notation?: boolean
   description?: boolean
+  background?: string | undefined
 }
 
 /**
  * Builds the SPA export URL for a view screenshot, encoding the view id and export query parameters.
  *
- * @param params - View id, padding, theme, and optional dynamic layout, image format, notation, and description settings.
- * @returns Relative URL containing `padding`, `theme`, optional `dynamic`, `format`, `notation`, and `description`.
+ * @param params - View id, padding, theme, and optional dynamic layout, image format, decoration, and background settings.
+ * @returns Relative URL containing `padding`, `theme`, optional `dynamic`, `format`, decoration, and background query params.
  */
 export function createExportViewUrl({
   viewId,
@@ -45,6 +46,7 @@ export function createExportViewUrl({
   format = 'png',
   notation = false,
   description = false,
+  background,
 }: {
   viewId: string
   padding: number
@@ -53,6 +55,7 @@ export function createExportViewUrl({
   format?: 'png' | 'jpeg'
   notation?: boolean
   description?: boolean
+  background?: string | undefined
 }): string {
   return withQuery(`export/${encodeURIComponent(viewId)}/`, {
     padding,
@@ -60,6 +63,7 @@ export function createExportViewUrl({
     dynamic: dynamicVariant,
     ...(notation ? { notation: true } : {}),
     ...(description ? { description: true } : {}),
+    ...(background ? { background } : {}),
     ...(format === 'jpeg' ? { format: 'jpeg' } : {}),
   })
 }
@@ -83,6 +87,7 @@ export async function takeScreenshot({
   quality,
   notation = false,
   description = false,
+  background,
 }: TakeScreenshotParams) {
   const padding = 20
 
@@ -147,6 +152,7 @@ export async function takeScreenshot({
         format,
         notation,
         description,
+        background,
       }))
 
       logger.info(k.cyan(url) + k.dim(` -> ${relative(output, path)}`))


### PR DESCRIPTION
## Summary

- Add `--background <css-color>` to `likec4 export png` and `likec4 export jpg`.
- Keep the existing defaults: PNG stays transparent, JPEG falls back to the selected theme body color.
- Thread the value through the CLI export URL, SPA export routes, and browser download export path.
- Add focused tests, CLI docs, and a changeset.

Refs #1639

## Before / After

![comparison.png](https://github.com/user-attachments/assets/f073ecd6-7795-4dad-b77b-0fef10c64784)

## Validation

- CodeRabbit review: 0 findings on final diff
- Cursor Agent review: no issues on final diff
- Claude review: no blocking issues on final diff
- `pnpm generate`
- `pnpm --filter likec4 test -- takeScreenshot`
- `pnpm --filter @likec4/spa test -- export-page-params`
- `pnpm --filter likec4 typecheck`
- `pnpm --filter @likec4/spa typecheck`
- Real CLI export smoke tests for default PNG transparency, PNG `--background "#fff"`, and JPEG `--background "#111827"`
