### PR TITLE
fix(diagram): restore embedded overlay background

### DIFF
--- a/.changeset/fix-embedded-view-overlay-background.md
+++ b/.changeset/fix-embedded-view-overlay-background.md
@@ -1,0 +1,7 @@
+---
+'@likec4/diagram': patch
+---
+
+Fix expanded embedded LikeC4 views rendering with a transparent overlay background.
+
+Fixes [#2965](https://github.com/likec4/likec4/issues/2965).

--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -19,6 +19,7 @@ tests/*.spec.ts
 !tests/static-navigation.spec.ts
 !tests/markdown-image.spec.ts
 !tests/manual-layout-views.spec.ts
+!tests/webcomponent-overlay.spec.ts
 
 pnpm-lock.yaml
 package-lock.json

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,3 +1,9 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { defineConfig, devices } from '@playwright/test'
 import { isCI } from 'std-env'
 
@@ -57,7 +63,7 @@ export default defineConfig({
   ],
 
   webServer: {
-    command: 'pnpm likec4 start --verbose --no-react-hmr --no-build-webcomponent',
+    command: 'pnpm likec4 start --verbose --no-react-hmr',
     port: 5173,
     stdout: 'pipe',
     timeout: 60 * 1000,

--- a/e2e/tests/webcomponent-overlay.spec.ts
+++ b/e2e/tests/webcomponent-overlay.spec.ts
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import type { Page } from '@playwright/test'
+import { expect, test } from '@playwright/test'
+import { CANVAS_SELECTOR } from '../helpers/selectors'
+import { TIMEOUT_CANVAS } from '../helpers/timeouts'
+
+const WEBCOMPONENT_BUNDLE = '/likec4-views.js'
+const WEBCOMPONENT_PREVIEW = '/webcomponent/index'
+const SHADOW_ROOT_SELECTOR = '.likec4-shadow-root'
+const TRANSPARENT_BACKGROUND = 'rgba(0, 0, 0, 0)'
+
+async function waitForWebcomponentBundle(page: Page): Promise<void> {
+  await expect.poll(
+    async () => {
+      const response = await page.request.get(WEBCOMPONENT_BUNDLE, {
+        failOnStatusCode: false,
+      })
+      return response.status()
+    },
+    {
+      timeout: 60_000,
+      message: `${WEBCOMPONENT_BUNDLE} should be available after the background webcomponent build`,
+    },
+  ).toBe(200)
+}
+
+test('webcomponent expanded overlay uses the shadow-root theme background (#2965)', async ({ page }) => {
+  test.setTimeout(75_000)
+
+  await waitForWebcomponentBundle(page)
+  await page.goto(WEBCOMPONENT_PREVIEW)
+
+  const frame = page.frameLocator('iframe')
+  await expect(frame.locator(CANVAS_SELECTOR).first()).toBeVisible({ timeout: TIMEOUT_CANVAS })
+
+  const shadowRoot = frame.locator(SHADOW_ROOT_SELECTOR).first()
+  await expect(shadowRoot).toBeVisible({ timeout: TIMEOUT_CANVAS })
+
+  const styleProbe = await shadowRoot.evaluate(element => {
+    const root = element.getRootNode()
+    if (!(root instanceof ShadowRoot)) {
+      return {
+        hasScopedRootSelector: false,
+        hasUnscopedRootHostSelector: false,
+      }
+    }
+    const bundledStyles = root.adoptedStyleSheets
+      .flatMap(sheet => [...sheet.cssRules].map(rule => rule.cssText))
+      .join('\n')
+    return {
+      hasScopedRootSelector: bundledStyles.includes(':where(.likec4-shadow-root)'),
+      hasUnscopedRootHostSelector: /:where\(:root,\s*:host\)/.test(bundledStyles),
+    }
+  })
+  expect(styleProbe).toEqual({
+    hasScopedRootSelector: true,
+    hasUnscopedRootHostSelector: false,
+  })
+
+  await frame.locator(CANVAS_SELECTOR).first().click()
+
+  const overlayBody = frame.locator('dialog[open] .likec4-overlay-body').first()
+  await expect(overlayBody).toBeVisible({ timeout: TIMEOUT_CANVAS })
+
+  await expect.poll(
+    async () => {
+      return overlayBody.evaluate(element => getComputedStyle(element).backgroundColor)
+    },
+    {
+      timeout: 5_000,
+      message: 'expanded embedded overlay body should resolve a non-transparent background color',
+    },
+  ).not.toBe(TRANSPARENT_BACKGROUND)
+
+  await expect.poll(
+    async () => {
+      return overlayBody.evaluate(element =>
+        getComputedStyle(element).getPropertyValue('--colors-likec4-overlay-body').trim()
+      )
+    },
+    {
+      timeout: 5_000,
+      message: 'overlay background theme variable should be scoped into the embedded shadow root',
+    },
+  ).not.toBe('')
+})

--- a/packages/diagram/src/shadowroot/styles.css.spec.ts
+++ b/packages/diagram/src/shadowroot/styles.css.spec.ts
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import { describe, expect, it } from 'vitest'
+import { scopeStylesToShadowRoot } from './styles.css'
+
+describe('scopeStylesToShadowRoot', () => {
+  it('moves root-level variables into the shadow root without rewriting overlay body selectors', () => {
+    const scoped = scopeStylesToShadowRoot(`
+:where(:root,:host){--colors-likec4-overlay-body:var(--mantine-color-body)}
+:where(:root, :host){--colors-likec4-app-background:var(--mantine-color-body)}
+:root{--colors-likec4-overlay-border:transparent}
+body { margin: 0 }
+.likec4-overlay .likec4-overlay-body{background:var(--colors-likec4-overlay-body)}
+:host{display:block}
+`)
+
+    expect(scoped).toContain(
+      ':where(.likec4-shadow-root){--colors-likec4-overlay-body:var(--mantine-color-body)}',
+    )
+    expect(scoped).toContain(
+      ':where(.likec4-shadow-root){--colors-likec4-app-background:var(--mantine-color-body)}',
+    )
+    expect(scoped).toContain('.likec4-shadow-root{--colors-likec4-overlay-border:transparent}')
+    expect(scoped).toContain('.likec4-shadow-root { margin: 0 }')
+    expect(scoped).toContain(
+      '.likec4-overlay .likec4-overlay-body{background:var(--colors-likec4-overlay-body)}',
+    )
+    expect(scoped).toContain(':host{display:block}')
+    expect(scoped).not.toContain('.likec4-overlay .likec4-overlay-.likec4-shadow-root')
+  })
+
+  it('does not rewrite descendant body selectors', () => {
+    const scoped = scopeStylesToShadowRoot(`
+html body { color: red }
+html, body { min-height: 100% }
+body, html { background: white }
+@media (prefers-color-scheme: dark) { body { color: white } }
+@charset "UTF-8"; body { color: black }
+/* reset */ body{line-height:1}
+.foo{}body{padding:0}
+html,body{width:100%}
+`)
+
+    expect(scoped).toContain('html body { color: red }')
+    expect(scoped).toContain('html, .likec4-shadow-root { min-height: 100% }')
+    expect(scoped).toContain('.likec4-shadow-root, html { background: white }')
+    expect(scoped).toContain('@media (prefers-color-scheme: dark) { .likec4-shadow-root { color: white } }')
+    expect(scoped).toContain('@charset "UTF-8"; .likec4-shadow-root { color: black }')
+    expect(scoped).toContain('/* reset */ .likec4-shadow-root{line-height:1}')
+    expect(scoped).toContain('.foo{}.likec4-shadow-root{padding:0}')
+    expect(scoped).toContain('html,.likec4-shadow-root{width:100%}')
+  })
+})

--- a/packages/diagram/src/shadowroot/styles.css.ts
+++ b/packages/diagram/src/shadowroot/styles.css.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { css } from '@likec4/styles/css'
 import {
   useColorScheme as usePreferredColorScheme,
@@ -18,20 +25,23 @@ export const cssInteractive = css({
   },
 })
 
+export function scopeStylesToShadowRoot(styles: string): string {
+  return styles
+    // Order matters: rewrite the longest root selector before the plain `:root` token.
+    .replaceAll(/:where\(\s*:root\s*,\s*:host\s*\)/g, `:where(.likec4-shadow-root)`)
+    .replaceAll(':root', `.likec4-shadow-root`)
+    /**
+     * Replace only top-level body selectors, for example
+     * `body { }` should be replaced with `.likec4-shadow-root { }`
+     * but `.likec4-overlay-body { }` must stay unchanged.
+     */
+    .replaceAll(/(^|[{},;]|\*\/)(\s*)body(?=\s*[{,])/g, '$1$2.likec4-shadow-root')
+}
+
 export function useBundledStyleSheet(injectFontCss: boolean, styleNonce?: string | (() => string) | undefined) {
   const [styleSheets] = useState(() => {
     const css = new CSSStyleSheet()
-    css.replaceSync(
-      inlinedStyles,
-      // .replaceAll(':where(:root,:host)', `:where(.likec4-shadow-root)`)
-      // .replaceAll(':root', `.likec4-shadow-root`)
-      /**
-       * replace only top-level body selectors, for example
-       * `body { }` should be replaced with `.likec4-shadow-root { }`
-       * but `.likec4-overlay-body { }` - not
-       */
-      // .replaceAll(/(?<![-_])\bbody\s*\{/g, `.likec4-shadow-root{`),
-    )
+    css.replaceSync(scopeStylesToShadowRoot(inlinedStyles))
     return [css]
   })
 


### PR DESCRIPTION
## Summary

Fixes #2965 by scoping bundled diagram CSS variables into the `LikeC4View` shadow root again. Expanded embedded views now render with the themed overlay background instead of inheriting transparency from the page behind them.

Root cause: commit `cfe6cd11c` from #2906 stopped rewriting `:root` / `:host` token selectors for the shadow root, so embedded shadow styles were no longer rooted on `.likec4-shadow-root`.

## Visual check

| Before | After |
| --- | --- |
| <img width="720" alt="Before: transparent expanded overlay background" src="https://github.com/user-attachments/assets/bcccd036-9168-4864-8565-2591b84f6fc8" /> | <img width="720" alt="After: opaque expanded overlay background" src="https://github.com/user-attachments/assets/85193dbf-0e38-4cd1-85b4-635342e3703b" /> |

- Before: transparent overlay body, `--colors-likec4-overlay-body` empty
- After: opaque overlay body, `--colors-likec4-overlay-body: #fff`

## Validation

- Added the unit regression first and confirmed it failed before the fix.
- Added the Playwright regression and confirmed it failed against a pre-fix packed e2e package, then passed after repacking the fixed source.
- `npx -y pnpm@10.33.3 --filter @likec4/diagram test -- src/shadowroot/styles.css.spec.ts`
- `npx -y pnpm@10.33.3 --filter @likec4/diagram typecheck`
- `npx -y pnpm@10.33.3 --filter @likec4/diagram build`
- `NODE_ENV=production npx -y pnpm@10.33.3 turbo run pack --filter="@likec4/core" --filter="@likec4/icons" --filter="likec4" --force`
- `npx -y pnpm@10.33.3 --dir e2e install --no-lockfile`
- `npx -y pnpm@10.33.3 --dir e2e exec playwright test webcomponent-overlay.spec.ts --reporter=list`
- `npx -y pnpm@10.33.3 --dir e2e exec playwright test static-navigation.spec.ts manual-layout-views.spec.ts --reporter=list`
- `npx -y pnpm@10.33.3 exec dprint check packages/diagram/src/shadowroot/styles.css.ts packages/diagram/src/shadowroot/styles.css.spec.ts e2e/tests/webcomponent-overlay.spec.ts e2e/playwright.config.ts e2e/.gitignore`
- `git diff --check`