### PR TITLE
feat(cli): add --public option for Vite publicDir

### DIFF
--- a/.changeset/cli-public-dir-option.md
+++ b/.changeset/cli-public-dir-option.md
@@ -1,0 +1,5 @@
+---
+'likec4': minor
+---
+
+Add `--public` option (alias `--public-dir`) to `likec4 build` and `likec4 start` for specifying a directory that Vite serves and copies as-is into the output (Vite's `publicDir`). Files in this directory are preserved in the build output, including when `--output-single-file` is used. Resolves #1941.

--- a/apps/docs/src/content/docs/tooling/cli.mdx
+++ b/apps/docs/src/content/docs/tooling/cli.mdx
@@ -101,13 +101,14 @@ likec4 dev
 This recursively searches for `*.c4` and `*.likec4` files in the current folder, parses them, and serves diagrams via a local web server.  
 Any change in the source files triggers a hot update in the browser immediately.
 
-| Option              | Description                                                                                               |
-| ------------------- | --------------------------------------------------------------------------------------------------------- |
-| `--port`            | Port for the dev server (default: 5173, or `PORT` env var)                                                |
-| `--hmr-port`        | Port for the HMR WebSocket (default: auto-discovered from 24678–24690, or `HMR_PORT` env var)             |
-| `--listen, -l`      | IP address to listen on (default: `127.0.0.1`, or `0.0.0.0` inside a container)                          |
-| `--no-react-hmr`    | Disable React HMR (useful for CI or static previews)                                                      |
-| `--use-dot`         | Use local Graphviz (`dot`) binaries instead of bundled WASM                                               |
+| Option                    | Description                                                                                               |
+| ------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `--port`                  | Port for the dev server (default: 5173, or `PORT` env var)                                                |
+| `--hmr-port`              | Port for the HMR WebSocket (default: auto-discovered from 24678–24690, or `HMR_PORT` env var)             |
+| `--listen, -l`            | IP address to listen on (default: `127.0.0.1`, or `0.0.0.0` inside a container)                          |
+| `--no-react-hmr`          | Disable React HMR (useful for CI or static previews)                                                      |
+| `--use-dot`               | Use local Graphviz (`dot`) binaries instead of bundled WASM                                               |
+| `--public, --public-dir`  | Directory whose files are served as-is (Vite [`publicDir`](https://vite.dev/guide/assets#the-public-directory)) |
 
 :::tip
 You can start the process in a separate terminal window and keep it running while you're editing the model in your editor, or even serve multiple projects at once.
@@ -129,15 +130,16 @@ A relocatable app can be built with `--base "./"`.
 likec4 build -o ./dist
 ```
 
-| Option                  | Description                                                                                           |
-| ----------------------- | ----------------------------------------------------------------------------------------------------- |
-| `--output`              | Output directory                                                                                      |
-| `--base, --base-url`    | Base URL from which the app is being served, e.g., "/", "/pages/", or "./" for a relocatable app      |
-| `--use-hash-history`    | Hash-based navigation, e.g. "/#/view" instead of "/view"                                              |
-| `--use-dot`             | Use local binaries of Graphviz ("dot") instead of bundled WASM                                        |
-| `--webcomponent-prefix` | Prefix for web components, e.g. "c4" generates `<c4-view ../>`                                        |
-| `--title`               | Base title of the app pages (default is "LikeC4")                                                     |
-| `--output-single-file`  | Generates a single self-contained HTML file                                                           |
+| Option                   | Description                                                                                           |
+| ------------------------ | ----------------------------------------------------------------------------------------------------- |
+| `--output`               | Output directory                                                                                      |
+| `--base, --base-url`     | Base URL from which the app is being served, e.g., "/", "/pages/", or "./" for a relocatable app      |
+| `--use-hash-history`     | Hash-based navigation, e.g. "/#/view" instead of "/view"                                              |
+| `--use-dot`              | Use local binaries of Graphviz ("dot") instead of bundled WASM                                        |
+| `--webcomponent-prefix`  | Prefix for web components, e.g. "c4" generates `<c4-view ../>`                                        |
+| `--title`                | Base title of the app pages (default is "LikeC4")                                                     |
+| `--output-single-file`   | Generates a single self-contained HTML file                                                           |
+| `--public, --public-dir` | Directory whose files are copied into the output as-is (Vite [`publicDir`](https://vite.dev/guide/assets#the-public-directory)); preserved with `--output-single-file` |
 
 :::note
 Internally, CLI uses Vite to build the website, and `likec4 build` calls `vite build`.  

--- a/packages/likec4/src/cli/build/index.ts
+++ b/packages/likec4/src/cli/build/index.ts
@@ -1,4 +1,3 @@
-
 // SPDX-License-Identifier: MIT
 //
 // Copyright (c) 2023-2026 Denis Davydkov
@@ -17,6 +16,7 @@ import {
   base,
   outputSingleFile,
   path,
+  publicDir,
   theme,
   title,
   useDotBin,
@@ -47,6 +47,7 @@ const buildCmd = (yargs: yargs.Argv) => {
           .option('webcomponent-prefix', webcomponentPrefix)
           .option('title', title)
           .option('output-single-file', outputSingleFile)
+          .option('public', publicDir)
           .option('theme', theme)
           .example(
             `${k.green('$0 build -o ./build ./src')}`,
@@ -55,6 +56,10 @@ const buildCmd = (yargs: yargs.Argv) => {
           .example(
             `${k.green('$0 build --theme dark -o ./build ./src')}`,
             k.gray('Build with dark color scheme as default'),
+          )
+          .example(
+            `${k.green('$0 build --public ./assets -o ./build ./src')}`,
+            k.gray('Copy files from \'assets\' to the output directory as-is'),
           ),
       handler: async (args) => {
         const params = {
@@ -87,6 +92,7 @@ const buildCmd = (yargs: yargs.Argv) => {
           likec4AssetsDir,
           outputDir,
           outputSingleFile: params.outputSingleFile,
+          userPublicDir: args.public,
         })
 
         showSupportUsMessage()

--- a/packages/likec4/src/cli/options.ts
+++ b/packages/likec4/src/cli/options.ts
@@ -84,6 +84,15 @@ export const outputSingleFile = {
   desc: 'outputs a single self-contained HTML file with all required resources inlined',
 } as const satisfies Options
 
+export const publicDir = {
+  alias: 'public-dir',
+  string: true,
+  desc: 'directory whose files are copied to the output as-is (Vite publicDir, e.g. images linked from views)',
+  normalize: true,
+  nargs: 1,
+  coerce: resolve,
+} as const satisfies Options
+
 export const listen = {
   alias: 'l',
   string: true,
@@ -106,7 +115,8 @@ export const port = {
 
 export const hmrPort = {
   number: true,
-  desc: 'port number for the HMR WebSocket server (default is auto-discovered from 24678-24690, or HMR_PORT environment variable)',
+  desc:
+    'port number for the HMR WebSocket server (default is auto-discovered from 24678-24690, or HMR_PORT environment variable)',
   nargs: 1,
 } as const satisfies Options
 

--- a/packages/likec4/src/cli/serve/index.ts
+++ b/packages/likec4/src/cli/serve/index.ts
@@ -1,6 +1,17 @@
 import type * as yargs from 'yargs'
 import { ensureReact } from '../ensure-libs'
-import { base, hmrPort, listen, path, port, title, useDotBin, useHashHistory, webcomponentPrefix } from '../options'
+import {
+  base,
+  hmrPort,
+  listen,
+  path,
+  port,
+  publicDir,
+  title,
+  useDotBin,
+  useHashHistory,
+  webcomponentPrefix,
+} from '../options'
 import { handler } from './serve'
 
 const serveCmd = (yargs: yargs.Argv) => {
@@ -20,6 +31,7 @@ const serveCmd = (yargs: yargs.Argv) => {
           .option('listen', listen)
           .option('port', port)
           .option('hmr-port', hmrPort)
+          .option('public', publicDir)
           .options({
             'react-hmr': {
               type: 'boolean',
@@ -46,6 +58,7 @@ const serveCmd = (yargs: yargs.Argv) => {
           hmrPort: args['hmr-port'],
           enableHMR: args['react-hmr'],
           enableWebcomponent: args['build-webcomponent'],
+          userPublicDir: args.public,
         })
       },
     })

--- a/packages/likec4/src/cli/serve/serve.spec.ts
+++ b/packages/likec4/src/cli/serve/serve.spec.ts
@@ -103,4 +103,25 @@ describe('serve handler', () => {
     expect(callArg.port).toBe(8080)
     expect(callArg.hmrPort).toBe(24705)
   })
+
+  it('propagates userPublicDir to viteDev', async () => {
+    const { handler } = await import('./serve')
+    const { viteDev } = await import('../../vite/vite-dev')
+    const viteDevMock = viteDev as ReturnType<typeof vi.fn>
+
+    await handler({
+      path: '/tmp/test',
+      useDotBin: false,
+      webcomponentPrefix: 'likec4',
+      title: undefined,
+      useHashHistory: undefined,
+      enableHMR: false,
+      enableWebcomponent: false,
+      userPublicDir: '/tmp/test/public',
+    })
+
+    expect(viteDevMock).toHaveBeenCalledOnce()
+    const callArg = viteDevMock.mock.calls[0]![0]
+    expect(callArg.userPublicDir).toBe('/tmp/test/public')
+  })
 })

--- a/packages/likec4/src/cli/serve/serve.ts
+++ b/packages/likec4/src/cli/serve/serve.ts
@@ -57,6 +57,12 @@ type HandlerParams = {
    * @default auto-discovered from 24678-24690
    */
   hmrPort?: number | undefined
+
+  /**
+   * Optional user-provided directory whose files are copied to the dev server
+   * (Vite publicDir).
+   */
+  userPublicDir?: string | undefined
 }
 
 /** Starts the LikeC4 dev server (Vite) for the given workspace path. */
@@ -72,6 +78,7 @@ export async function handler({
   listen,
   port,
   hmrPort,
+  userPublicDir,
 }: HandlerParams) {
   // Explicitly set NODE_ENV to development
   if (enableHMR) {
@@ -97,6 +104,7 @@ export async function handler({
     listen,
     port,
     hmrPort,
+    userPublicDir,
   })
 
   server.config.logger.clearScreen('info')

--- a/packages/likec4/src/vite/config-app.ts
+++ b/packages/likec4/src/vite/config-app.ts
@@ -29,6 +29,12 @@ export type LikeC4ViteConfig = {
   useHashHistory?: boolean | undefined
   likec4AssetsDir: string
   outputSingleFile?: boolean | undefined
+  /**
+   * Optional user-provided directory whose files are copied as-is into the
+   * output (Vite publicDir). Useful for static assets like images referenced
+   * from likec4 views via absolute URLs.
+   */
+  userPublicDir?: string | undefined
 }
 
 export const viteConfig = async ({ languageServices, likec4AssetsDir, ...cfg }: LikeC4ViteConfig) => {

--- a/packages/likec4/src/vite/utils.spec.ts
+++ b/packages/likec4/src/vite/utils.spec.ts
@@ -1,0 +1,51 @@
+import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { copyUserPublicDir } from './utils'
+
+describe('copyUserPublicDir', () => {
+  let src: string
+  let dest: string
+
+  beforeEach(async () => {
+    src = await mkdtemp(join(tmpdir(), 'likec4-public-src-'))
+    dest = await mkdtemp(join(tmpdir(), 'likec4-public-dest-'))
+  })
+
+  afterEach(async () => {
+    await rm(src, { recursive: true, force: true })
+    await rm(dest, { recursive: true, force: true })
+  })
+
+  it('copies all top-level entries into dest and returns their names', async () => {
+    await writeFile(join(src, 'logo.png'), 'fake-png')
+    await writeFile(join(src, 'robots.custom.txt'), 'User-agent: *')
+    await mkdir(join(src, 'media'))
+    await writeFile(join(src, 'media', 'video.mp4'), 'fake-mp4')
+
+    const entries = await copyUserPublicDir(src, dest)
+
+    expect(entries.sort()).toEqual(['logo.png', 'media', 'robots.custom.txt'])
+    expect(await readFile(join(dest, 'logo.png'), 'utf8')).toBe('fake-png')
+    expect(await readFile(join(dest, 'robots.custom.txt'), 'utf8')).toBe('User-agent: *')
+    expect(await readFile(join(dest, 'media', 'video.mp4'), 'utf8')).toBe('fake-mp4')
+  })
+
+  it('returns an empty array when source dir is empty', async () => {
+    const entries = await copyUserPublicDir(src, dest)
+    expect(entries).toEqual([])
+    expect(await readdir(dest)).toEqual([])
+  })
+
+  it('throws a descriptive error when the source path does not exist', async () => {
+    const missing = join(tmpdir(), 'likec4-public-does-not-exist-' + Date.now())
+    await expect(copyUserPublicDir(missing, dest)).rejects.toThrow(/does not exist/)
+  })
+
+  it('throws a descriptive error when the source path is a file', async () => {
+    const file = join(src, 'a-file.txt')
+    await writeFile(file, 'hi')
+    await expect(copyUserPublicDir(file, dest)).rejects.toThrow(/not a directory/)
+  })
+})

--- a/packages/likec4/src/vite/utils.ts
+++ b/packages/likec4/src/vite/utils.ts
@@ -1,6 +1,6 @@
 import { rootLogger } from '@likec4/log'
-import { existsSync } from 'node:fs'
-import { mkdtemp, writeFile } from 'node:fs/promises'
+import { existsSync, statSync } from 'node:fs'
+import { cp, mkdtemp, readdir, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join, relative, resolve } from 'node:path'
 import { cwd } from 'node:process'
@@ -51,4 +51,28 @@ export async function mkTempPublicDir() {
 /** Returns the path relative to the current working directory. */
 export function relativeToCwd(path: string) {
   return relative(cwd(), path)
+}
+
+/**
+ * Copies the contents of a user-provided directory into the temporary publicDir
+ * (the directory Vite uses to serve / copy static assets). The directory must
+ * exist and be a directory — otherwise an error is thrown so the user notices
+ * a typo on the CLI instead of silently getting no assets.
+ *
+ * Returns the top-level entry names that were copied so callers can preserve
+ * them across post-build cleanup (see single-file build).
+ */
+export async function copyUserPublicDir(
+  userPublicDir: string,
+  destPublicDir: string,
+): Promise<string[]> {
+  if (!existsSync(userPublicDir)) {
+    throw new Error(`--public directory does not exist: ${userPublicDir}`)
+  }
+  if (!statSync(userPublicDir).isDirectory()) {
+    throw new Error(`--public path is not a directory: ${userPublicDir}`)
+  }
+  const entries = await readdir(userPublicDir)
+  await cp(userPublicDir, destPublicDir, { recursive: true, errorOnExist: false })
+  return entries
 }

--- a/packages/likec4/src/vite/vite-build.spec.ts
+++ b/packages/likec4/src/vite/vite-build.spec.ts
@@ -1,0 +1,47 @@
+import { mkdir, mkdtemp, readdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { removeAllButPreserved } from './vite-build'
+
+describe('removeAllButPreserved', () => {
+  let outDir: string
+
+  beforeEach(async () => {
+    outDir = await mkdtemp(join(tmpdir(), 'likec4-outdir-'))
+  })
+
+  afterEach(async () => {
+    await rm(outDir, { recursive: true, force: true })
+  })
+
+  it('keeps only the preserved files and removes everything else', async () => {
+    await writeFile(join(outDir, 'index.html'), '<html></html>')
+    await writeFile(join(outDir, 'main.js'), 'console.log(1)')
+    await mkdir(join(outDir, 'assets'))
+    await writeFile(join(outDir, 'assets', 'logo.png'), 'x')
+
+    removeAllButPreserved(outDir, ['index.html'])
+
+    expect((await readdir(outDir)).sort()).toEqual(['index.html'])
+  })
+
+  it('preserves user-provided files alongside index.html (single-file build with --public)', async () => {
+    await writeFile(join(outDir, 'index.html'), '<html></html>')
+    await writeFile(join(outDir, 'main.js'), 'console.log(1)')
+    await writeFile(join(outDir, 'logo.png'), 'x')
+    await mkdir(join(outDir, 'media'))
+    await writeFile(join(outDir, 'media', 'video.mp4'), 'x')
+
+    removeAllButPreserved(outDir, ['index.html', 'logo.png', 'media'])
+
+    expect((await readdir(outDir)).sort()).toEqual(['index.html', 'logo.png', 'media'])
+    expect((await readdir(join(outDir, 'media'))).sort()).toEqual(['video.mp4'])
+  })
+
+  it('is a no-op when outDir only contains preserved files', async () => {
+    await writeFile(join(outDir, 'index.html'), '<html></html>')
+    removeAllButPreserved(outDir, ['index.html'])
+    expect(await readdir(outDir)).toEqual(['index.html'])
+  })
+})

--- a/packages/likec4/src/vite/vite-build.ts
+++ b/packages/likec4/src/vite/vite-build.ts
@@ -9,13 +9,26 @@ import { build } from 'vite'
 import { viteConfig } from './config-app'
 import type { LikeC4ViteConfig } from './config-app'
 import { viteWebcomponentConfig } from './config-webcomponent'
-import { mkTempPublicDir } from './utils'
+import { copyUserPublicDir, mkTempPublicDir } from './utils'
 
 type Config = SetOptional<LikeC4ViteConfig, 'likec4AssetsDir'> & {
   buildWebcomponent?: boolean
 }
 
 export const Assets = ['favicon.ico', 'robots.txt']
+
+/**
+ * Removes every top-level entry in `outDir` except the names in `preserved`.
+ * Used by the `--output-single-file` build to strip the temporary Vite assets
+ * once they have been inlined into `index.html`, while keeping `index.html`
+ * itself and any user-provided files (see `--public`).
+ */
+export function removeAllButPreserved(outDir: string, preserved: readonly string[]): void {
+  const keep = new Set<string>(preserved)
+  for (const extraFile of readdirSync(outDir).filter(f => !keep.has(f))) {
+    rmSync(resolve(outDir, extraFile), { recursive: true })
+  }
+}
 
 export async function viteBuild({
   buildWebcomponent = true,
@@ -24,6 +37,7 @@ export async function viteBuild({
   languageServices,
   likec4AssetsDir,
   outputSingleFile,
+  userPublicDir,
   ...cfg
 }: Config) {
   likec4AssetsDir ??= await mkdtemp(join(tmpdir(), '.likec4-assets-'))
@@ -40,6 +54,10 @@ export async function viteBuild({
   const outDirWasEmpty = !existsSync(config.build.outDir) || readdirSync(config.build.outDir).length === 0
 
   const publicDir = await mkTempPublicDir()
+
+  const userPublicEntries = userPublicDir
+    ? await copyUserPublicDir(userPublicDir, publicDir)
+    : []
 
   for (const asset of Assets) {
     const origin = resolve(config.root, asset)
@@ -139,10 +157,7 @@ export async function viteBuild({
       config.customLogger.warn(k.yellow('outDir was not empty, skipping cleanup'))
       return
     }
-    // Delete all files other than index.html
-    for (let extraFile of readdirSync(resolve(config.build.outDir)).filter(f => f !== 'index.html')) {
-      rmSync(resolve(config.build.outDir, extraFile), { recursive: true })
-    }
+    removeAllButPreserved(config.build.outDir, ['index.html', ...userPublicEntries])
   }
 
   // Copy index.html to 404.html

--- a/packages/likec4/src/vite/vite-dev.ts
+++ b/packages/likec4/src/vite/vite-dev.ts
@@ -12,7 +12,7 @@ import { build, createServer } from 'vite'
 import type { LikeC4ViteConfig } from './config-app'
 import { viteConfig } from './config-app'
 import { viteWebcomponentConfig } from './config-webcomponent'
-import { mkTempPublicDir } from './utils'
+import { copyUserPublicDir, mkTempPublicDir } from './utils'
 
 /**
  * Validates that a port is a valid integer between 1 and 65535.
@@ -73,6 +73,7 @@ export async function viteDev({
   listen,
   port,
   hmrPort,
+  userPublicDir,
   ...cfg
 }: Config): Promise<ViteDevServer> {
   likec4AssetsDir ??= await mkdtemp(join(tmpdir(), '.likec4-assets-'))
@@ -101,6 +102,9 @@ export async function viteDev({
     })
   }
   const publicDir = await mkTempPublicDir()
+  if (userPublicDir) {
+    await copyUserPublicDir(userPublicDir, publicDir)
+  }
 
   const host = listen ?? (isInsideContainer() ? '0.0.0.0' : 'localhost')
 


### PR DESCRIPTION
## Checklist

- [x] I've thoroughly read the latest [contribution guidelines](https://github.com/likec4/likec4/blob/main/CONTRIBUTING.md).
- [x] I've rebased my branch onto `main` **before** creating this PR.
- [x] I've added tests to cover my changes (if applicable).
- [x] I've verified `pnpm typecheck` and `pnpm test`.
- [x] I've added [changesets](https://changesets-docs.vercel.app/) (you can use `/changeset-generator` SKILL).
- [x] My change requires documentation updates.
- [x] I've updated the documentation accordingly (or will do in follow-up PR).

## Summary

Resolves #1941.

Adds `--public` (alias `--public-dir`) to `likec4 build` and `likec4 start` (`dev`/`serve`). Files in this directory are copied into the build output as-is via Vite's `publicDir` — and, importantly, are preserved when `--output-single-file` is used.

Today the single-file build cleans up `outDir` by deleting every file that isn't `index.html`. That step also wipes out user assets sitting in `outDir` (the original report: PNGs linked from views disappearing). The new flag lets users keep a folder of static assets that the build copies through and the single-file cleanup leaves alone.

Implementation approach matches the maintainer's hint in #1941 ("Setting the [public dir](https://vite.dev/guide/assets#the-public-directory) may solve your issue. (to be implemented in CLI)").

## Implementation

- New option in `packages/likec4/src/cli/options.ts`, wired into both `build` and `serve` commands.
- `viteBuild` / `viteDev` copy the user-provided directory's contents into the internal temp `publicDir` before invoking Vite, so all existing assets (favicon, robots.txt, webcomponent bundle) keep working unchanged.
- Extracted the single-file cleanup into `removeAllButPreserved(outDir, preserved)` so the same deletion logic now also preserves the user's top-level entries (in addition to `index.html`).
- Errors early with a clear message if the path doesn't exist or isn't a directory.

## Out of scope

This PR exposes the option as a CLI flag only, per the maintainer's note in #1941 ("to be implemented in CLI"). A `likec4.config` schema entry could be a follow-up if there's interest.

## Test plan

New unit tests (run via `pnpm test`):

- [x] `copyUserPublicDir` copies all top-level entries and returns their names (`packages/likec4/src/vite/utils.spec.ts`)
- [x] `copyUserPublicDir` returns `[]` for an empty dir
- [x] `copyUserPublicDir` throws a clear error when the path is missing / not a dir
- [x] `removeAllButPreserved` keeps `index.html` only when no user dir provided (`packages/likec4/src/vite/vite-build.spec.ts`)
- [x] `removeAllButPreserved` keeps `index.html` + user files (the actual #1941 fix)
- [x] `removeAllButPreserved` is a no-op when nothing to remove
- [x] `serve` handler propagates `userPublicDir` to `viteDev` (extends `serve.spec.ts`)

Local checks:

- [x] `pnpm test` — 11 / 11 new tests passing
- [x] `pnpm --filter likec4 typecheck` — clean
- [x] `pnpm lint:errors-only` — clean (pre-existing warnings unchanged)
- [x] `pnpm fmt` — applied