### PR TITLE
fix: restore static embed relationship popup

### DIFF
--- a/.changeset/fix-static-embed-relationship-popover.md
+++ b/.changeset/fix-static-embed-relationship-popover.md
@@ -1,0 +1,6 @@
+---
+'@likec4/spa': patch
+'likec4': patch
+---
+
+Fixes [#2962](https://github.com/likec4/likec4/issues/2962) by showing relationship popovers in static embedded views generated with `likec4 build`.

--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -17,6 +17,7 @@ tests/*.spec.ts
 !tests/overview-page.spec.ts
 !tests/search-params.spec.ts
 !tests/static-navigation.spec.ts
+!tests/static-build-relationship-popover.spec.ts
 !tests/markdown-image.spec.ts
 !tests/manual-layout-views.spec.ts
 

--- a/e2e/playwright.static-build.config.ts
+++ b/e2e/playwright.static-build.config.ts
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import { defineConfig, devices } from '@playwright/test'
+import { isCI } from 'std-env'
+
+export default defineConfig({
+  testDir: 'tests',
+  testMatch: ['**/static-build-relationship-popover.spec.ts'],
+  forbidOnly: isCI,
+  timeout: 20 * 1000,
+  retries: isCI ? 1 : 0,
+  reporter: isCI ? [['github'], ['list'], ['html']] : 'html',
+
+  use: {
+    baseURL: 'http://127.0.0.1:5175',
+    browserName: 'chromium',
+    colorScheme: 'light',
+    trace: 'on',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome HiDPI'] },
+    },
+  ],
+
+  webServer: {
+    command:
+      'OUT=$(mktemp -d /tmp/likec4-static-build-XXXXXX) && pnpm likec4 build -o "$OUT" ./src && node ./serve-static-build.mjs "$OUT" 5175',
+    url: 'http://127.0.0.1:5175',
+    stdout: 'pipe',
+    timeout: 120 * 1000,
+    env: {
+      NODE_ENV: 'production',
+    },
+  },
+})

--- a/e2e/serve-static-build.mjs
+++ b/e2e/serve-static-build.mjs
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import { createReadStream, statSync } from 'node:fs'
+import { createServer } from 'node:http'
+import { resolve, sep } from 'node:path'
+
+const [rootArg, portArg = '5175'] = process.argv.slice(2)
+if (!rootArg) {
+  throw new Error('Usage: node serve-static-build.mjs <root> [port]')
+}
+
+const root = resolve(rootArg)
+const port = Number(portArg)
+
+const mimeTypes = new Map([
+  ['.css', 'text/css; charset=utf-8'],
+  ['.html', 'text/html; charset=utf-8'],
+  ['.ico', 'image/x-icon'],
+  ['.js', 'text/javascript; charset=utf-8'],
+  ['.json', 'application/json; charset=utf-8'],
+  ['.map', 'application/json; charset=utf-8'],
+  ['.png', 'image/png'],
+  ['.svg', 'image/svg+xml'],
+  ['.webp', 'image/webp'],
+  ['.woff', 'font/woff'],
+  ['.woff2', 'font/woff2'],
+])
+
+function resolveRequest(pathname) {
+  const relative = decodeURIComponent(pathname).replace(/^\/+/, '')
+  const candidate = resolve(root, relative)
+  if (candidate !== root && !candidate.startsWith(root + sep)) {
+    return resolve(root, 'index.html')
+  }
+  try {
+    if (statSync(candidate).isFile()) {
+      return candidate
+    }
+  } catch {
+    // Fall through to SPA fallback.
+  }
+  return resolve(root, 'index.html')
+}
+
+function contentType(file) {
+  const ext = file.slice(file.lastIndexOf('.'))
+  return mimeTypes.get(ext) ?? 'application/octet-stream'
+}
+
+const server = createServer((request, response) => {
+  if (request.method !== 'GET' && request.method !== 'HEAD') {
+    response.writeHead(405)
+    response.end()
+    return
+  }
+
+  const url = new URL(request.url ?? '/', `http://${request.headers.host ?? '127.0.0.1'}`)
+  const file = resolveRequest(url.pathname)
+  response.setHeader('content-type', contentType(file))
+
+  if (request.method === 'HEAD') {
+    response.end()
+    return
+  }
+
+  createReadStream(file)
+    .on('error', () => {
+      response.writeHead(404)
+      response.end()
+    })
+    .pipe(response)
+})
+
+server.listen(port, '127.0.0.1', () => {
+  console.log(`Serving ${root} at http://127.0.0.1:${port}`)
+})

--- a/e2e/serve-static-build.mjs
+++ b/e2e/serve-static-build.mjs
@@ -29,7 +29,13 @@ const mimeTypes = new Map([
 ])
 
 function resolveRequest(pathname) {
-  const relative = decodeURIComponent(pathname).replace(/^\/+/, '')
+  let relative
+  try {
+    relative = decodeURIComponent(pathname).replace(/^\/+/, '')
+  } catch {
+    return null
+  }
+
   const candidate = resolve(root, relative)
   if (candidate !== root && !candidate.startsWith(root + sep)) {
     return resolve(root, 'index.html')
@@ -56,8 +62,22 @@ const server = createServer((request, response) => {
     return
   }
 
-  const url = new URL(request.url ?? '/', `http://${request.headers.host ?? '127.0.0.1'}`)
+  let url
+  try {
+    url = new URL(request.url ?? '/', 'http://127.0.0.1')
+  } catch {
+    response.writeHead(400)
+    response.end()
+    return
+  }
+
   const file = resolveRequest(url.pathname)
+  if (!file) {
+    response.writeHead(400)
+    response.end()
+    return
+  }
+
   response.setHeader('content-type', contentType(file))
 
   if (request.method === 'HEAD') {

--- a/e2e/tests/static-build-relationship-popover.spec.ts
+++ b/e2e/tests/static-build-relationship-popover.spec.ts
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import { expect, test } from '@playwright/test'
+import { canvas } from '../helpers/selectors'
+import { TIMEOUT_CANVAS } from '../helpers/timeouts'
+
+const PROJECT = 'e2e'
+const VIEW = 'index'
+const RELATIONSHIP_LABEL = '.likec4-edge-label[data-edge-id]'
+const RELATIONSHIP_POPOVER_TEXT = 'DIRECT RELATIONSHIPS'
+
+function embedUrl(viewId: string): string {
+  return `/project/${encodeURIComponent(PROJECT)}/embed/${encodeURIComponent(viewId)}/`
+}
+
+test('static build embed pages show relationship popup on edge hover (#2962)', async ({ page }) => {
+  await page.goto(embedUrl(VIEW))
+  await expect(canvas(page)).toBeVisible({ timeout: TIMEOUT_CANVAS })
+
+  const relationship = page.locator(RELATIONSHIP_LABEL).filter({ hasText: /uses/i }).first()
+  await expect(relationship).toBeVisible()
+  await relationship.hover()
+
+  await expect(page.getByText(RELATIONSHIP_POPOVER_TEXT)).toBeVisible()
+  await expect(page.getByRole('button', { name: /browse relationships/i })).toBeVisible()
+})

--- a/packages/likec4-spa/src/pages/EmbedPage.tsx
+++ b/packages/likec4-spa/src/pages/EmbedPage.tsx
@@ -1,3 +1,9 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { pickViewBounds, StaticLikeC4Diagram } from '@likec4/diagram'
 import { useSearch } from '@tanstack/react-router'
 import { useCurrentView, useTransparentBackground } from '../hooks'
@@ -41,6 +47,8 @@ export function EmbedPage() {
         background={'transparent'}
         fitViewPadding={0}
         dynamicViewVariant={dynamic}
+        enableRelationshipDetails
+        enableRelationshipBrowser
         initialWidth={bounds.width}
         initialHeight={bounds.height} />
     </div>


### PR DESCRIPTION
Fixes #2962.

## Summary
- Enable relationship details and the relationship browser for static embedded views generated by `likec4 build`.
- Keep export/image rendering unchanged; `ExportPage` still explicitly disables relationship details and relationship browser.
- Add focused Playwright coverage that builds the static site, serves the generated output, and verifies the embed relationship popover on hover.

## Root Cause
Relationship popover support was introduced in [#2145](https://github.com/likec4/likec4/pull/2145) / `48ad2c741` (`feat: Relationship popover`). Normal view pages enabled `enableRelationshipDetails`, but static embed pages still rendered through `StaticLikeC4Diagram`, whose default remained `enableRelationshipDetails = false`.

So this was not an export regression from a previously working popup. The new relationship popover feature was added without being wired into the static embed route.

## Screenshots
| Before | After |
| --- | --- |
| ![Static embed before relationship popup fix](https://github.com/user-attachments/assets/c71e51d3-599d-407d-b6fd-3403f7dfe904) | ![Static embed after relationship popup fix](https://github.com/user-attachments/assets/ce89cc62-fb07-4906-b930-850d282904d2) |

## Verification
- Red: the new static-build embed test failed before the fix because `DIRECT RELATIONSHIPS` was not visible.
- `npx -y pnpm@10.33.3 --filter @likec4/spa typecheck`
- `npx -y pnpm@10.33.3 --dir e2e exec playwright test -c playwright.static-build.config.ts`
- Targeted compile of the new e2e files passed.
- Cursor review: ready, no blockers.
- CodeRabbit review: `findings: 0`.

Note: broad `e2e tsc --noEmit` still fails on existing unrelated generated model/view type assertions for `multiple-*` IDs.