### PR TITLE
feat(cli): add --allowed-host option for dev server

### DIFF
--- a/.changeset/cli-allowed-host-option.md
+++ b/.changeset/cli-allowed-host-option.md
@@ -1,0 +1,5 @@
+---
+'likec4': patch
+---
+
+Add `--allowed-host` option to `likec4 start` (`serve` / `dev`) for scoping which hostnames are allowed to access the dev server (Vite's `server.allowedHosts`). Can be repeated. When omitted, all hosts are allowed (current behaviour). Resolves #1650.

--- a/apps/docs/src/content/docs/tooling/cli.mdx
+++ b/apps/docs/src/content/docs/tooling/cli.mdx
@@ -109,6 +109,7 @@ Any change in the source files triggers a hot update in the browser immediately.
 | `--no-react-hmr`          | Disable React HMR (useful for CI or static previews)                                                      |
 | `--use-dot`               | Use local Graphviz (`dot`) binaries instead of bundled WASM                                               |
 | `--public, --public-dir`  | Directory whose files are served as-is (Vite [`publicDir`](https://vite.dev/guide/assets#the-public-directory)) |
+| `--allowed-host`          | Hostname allowed to access the dev server (Vite [`server.allowedHosts`](https://vite.dev/config/server-options#server-allowedhosts)); repeatable. Defaults to allowing all hosts. |
 
 :::tip
 You can start the process in a separate terminal window and keep it running while you're editing the model in your editor, or even serve multiple projects at once.

--- a/packages/likec4/src/cli/index.ts
+++ b/packages/likec4/src/cli/index.ts
@@ -88,6 +88,7 @@ async function main() {
   await y
     .scriptName('likec4')
     .usage(`Usage: $0 <command>`)
+    .parserConfiguration({ 'greedy-arrays': false })
     .version(pkg.version)
     .alias('v', 'version')
     .alias('h', 'help')

--- a/packages/likec4/src/cli/options.ts
+++ b/packages/likec4/src/cli/options.ts
@@ -93,6 +93,13 @@ export const publicDir = {
   coerce: resolve,
 } as const satisfies Options
 
+export const allowedHost = {
+  array: true,
+  string: true,
+  desc: 'hostname allowed to respond to (Vite server.allowedHosts); can be repeated. Defaults to allowing all hosts.',
+  requiresArg: true,
+} as const satisfies Options
+
 export const listen = {
   alias: 'l',
   string: true,

--- a/packages/likec4/src/cli/serve/index.ts
+++ b/packages/likec4/src/cli/serve/index.ts
@@ -1,6 +1,7 @@
 import type * as yargs from 'yargs'
 import { ensureReact } from '../ensure-libs'
 import {
+  allowedHost,
   base,
   hmrPort,
   listen,
@@ -32,6 +33,7 @@ const serveCmd = (yargs: yargs.Argv) => {
           .option('port', port)
           .option('hmr-port', hmrPort)
           .option('public', publicDir)
+          .option('allowed-host', allowedHost)
           .options({
             'react-hmr': {
               type: 'boolean',
@@ -59,6 +61,7 @@ const serveCmd = (yargs: yargs.Argv) => {
           enableHMR: args['react-hmr'],
           enableWebcomponent: args['build-webcomponent'],
           userPublicDir: args.public,
+          allowedHosts: args['allowed-host'],
         })
       },
     })

--- a/packages/likec4/src/cli/serve/serve.spec.ts
+++ b/packages/likec4/src/cli/serve/serve.spec.ts
@@ -124,4 +124,45 @@ describe('serve handler', () => {
     const callArg = viteDevMock.mock.calls[0]![0]
     expect(callArg.userPublicDir).toBe('/tmp/test/public')
   })
+
+  it('propagates allowedHosts to viteDev', async () => {
+    const { handler } = await import('./serve')
+    const { viteDev } = await import('../../vite/vite-dev')
+    const viteDevMock = viteDev as ReturnType<typeof vi.fn>
+
+    await handler({
+      path: '/tmp/test',
+      useDotBin: false,
+      webcomponentPrefix: 'likec4',
+      title: undefined,
+      useHashHistory: undefined,
+      enableHMR: false,
+      enableWebcomponent: false,
+      allowedHosts: ['example.local', 'review.example.com'],
+    })
+
+    expect(viteDevMock).toHaveBeenCalledOnce()
+    const callArg = viteDevMock.mock.calls[0]![0]
+    expect(callArg.allowedHosts).toEqual(['example.local', 'review.example.com'])
+  })
+
+  it('propagates undefined allowedHosts when not provided (preserves "allow all" default)', async () => {
+    const { handler } = await import('./serve')
+    const { viteDev } = await import('../../vite/vite-dev')
+    const viteDevMock = viteDev as ReturnType<typeof vi.fn>
+
+    await handler({
+      path: '/tmp/test',
+      useDotBin: false,
+      webcomponentPrefix: 'likec4',
+      title: undefined,
+      useHashHistory: undefined,
+      enableHMR: false,
+      enableWebcomponent: false,
+    })
+
+    expect(viteDevMock).toHaveBeenCalledOnce()
+    const callArg = viteDevMock.mock.calls[0]![0]
+    expect(callArg.allowedHosts).toBeUndefined()
+  })
 })

--- a/packages/likec4/src/cli/serve/serve.ts
+++ b/packages/likec4/src/cli/serve/serve.ts
@@ -63,6 +63,13 @@ type HandlerParams = {
    * (Vite publicDir).
    */
   userPublicDir?: string | undefined
+
+  /**
+   * Hostnames allowed to access the dev server (maps to Vite's
+   * `server.allowedHosts`). When omitted, all hosts are allowed.
+   * @see https://vite.dev/config/server-options#server-allowedhosts
+   */
+  allowedHosts?: string[] | undefined
 }
 
 /** Starts the LikeC4 dev server (Vite) for the given workspace path. */
@@ -79,6 +86,7 @@ export async function handler({
   port,
   hmrPort,
   userPublicDir,
+  allowedHosts,
 }: HandlerParams) {
   // Explicitly set NODE_ENV to development
   if (enableHMR) {
@@ -105,6 +113,7 @@ export async function handler({
     port,
     hmrPort,
     userPublicDir,
+    allowedHosts,
   })
 
   server.config.logger.clearScreen('info')

--- a/packages/likec4/src/vite/vite-dev.ts
+++ b/packages/likec4/src/vite/vite-dev.ts
@@ -60,6 +60,11 @@ type Config = SetOptional<LikeC4ViteConfig, 'likec4AssetsDir'> & {
   listen?: string | undefined
   port?: number | undefined
   hmrPort?: number | undefined
+  /**
+   * Hostnames allowed to respond to (Vite `server.allowedHosts`).
+   * When omitted, all hosts are allowed.
+   */
+  allowedHosts?: string[] | undefined
 }
 
 export async function viteDev({
@@ -74,6 +79,7 @@ export async function viteDev({
   port,
   hmrPort,
   userPublicDir,
+  allowedHosts,
   ...cfg
 }: Config): Promise<ViteDevServer> {
   likec4AssetsDir ??= await mkdtemp(join(tmpdir(), '.likec4-assets-'))
@@ -134,10 +140,7 @@ export async function viteDev({
     },
     server: {
       host,
-      // TODO: temprorary enable access to any host
-      // This is not recommended as it can be a security risk - https://vite.dev/config/server-options#server-allowedhosts
-      // Enabled after request in discord support just to check if it solves the problem
-      allowedHosts: true,
+      allowedHosts: allowedHosts && allowedHosts.length > 0 ? allowedHosts : true,
       port,
       hmr: hmr && {
         overlay: true,


### PR DESCRIPTION
## Checklist

- [x] I've thoroughly read the latest [contribution guidelines](https://github.com/likec4/likec4/blob/main/CONTRIBUTING.md).
- [x] I've rebased my branch onto `main` **before** creating this PR.
- [x] I've added tests to cover my changes (if applicable).
- [x] I've verified `pnpm typecheck` and `pnpm test`.
- [x] I've added [changesets](https://changesets-docs.vercel.app/).
- [x] My change requires documentation updates.
- [x] I've updated the documentation accordingly.

## Summary

Resolves #1650.

Adds a repeatable `--allowed-host` option to `likec4 start` (aliases `serve` / `dev`) which threads through to Vite's [`server.allowedHosts`](https://vite.dev/config/server-options#server-allowedhosts).

Today, `vite-dev.ts` hardcodes `allowedHosts: true` with a `// TODO: temprorary enable access to any host` comment from #1649. This PR keeps `true` as the default (so existing behaviour is preserved and the change is strictly additive), and gives users a CLI surface to scope access down when they want it.

```sh
likec4 start --allowed-host foo.local --allowed-host bar.example.com
```

## Implementation

- New `allowedHost` option in `packages/likec4/src/cli/options.ts` (`array: true`, `string: true`, `requiresArg: true`).
- Wired through `serve/index.ts` → `serve.ts` handler → `viteDev`.
- In `vite-dev.ts`, replaces the hardcoded `allowedHosts: true` with `allowedHosts && allowedHosts.length > 0 ? allowedHosts : true`. The obsolete `// TODO: temprorary…` comment is removed since users now have a way to address this themselves.
- Added two propagation tests to `serve.spec.ts` (with the hostnames + without — default branch).
- Added `--allowed-host` row to the `serve` options table in `apps/docs/src/content/docs/tooling/cli.mdx`.

## Out of scope

This PR does **not** change the default. The maintainer note in #1650 says *"we should enable only strictly defined"* — that's a behaviour change that probably deserves its own PR (and possibly a deprecation cycle), separate from adding the CLI surface. Happy to follow up if you'd like the default flipped here.

## Test plan

```sh
pnpm test --no-coverage --no-typecheck packages/likec4/src/cli/serve/serve.spec.ts
# Tests  6 passed (6)

pnpm --filter likec4 typecheck   # clean
pnpm lint:errors-only             # 0 errors
pnpm fmt                          # applied
```

New propagation tests:

- [x] `serve` handler propagates `allowedHosts` array to `viteDev`
- [x] `serve` handler leaves `allowedHosts` undefined when not provided (preserves the "allow all" default)