### PR TITLE
docs: expand Emacs setup with Eglot and lsp-mode configs

### DIFF
--- a/.changeset/docs-emacs-lsp-setup.md
+++ b/.changeset/docs-emacs-lsp-setup.md
@@ -1,0 +1,5 @@
+---
+'@likec4/docs-astro': patch
+---
+
+Expand the Emacs section in the editors docs with a complete setup using `@likec4/lsp` — covers both [Eglot](https://github.com/joaotavora/eglot) (Emacs 29+) and [lsp-mode](https://emacs-lsp.github.io/lsp-mode/), with a `likec4-mode` definition for `.c4` / `.likec4` files. Resolves #2268.

--- a/apps/docs/src/content/docs/tooling/editors.mdx
+++ b/apps/docs/src/content/docs/tooling/editors.mdx
@@ -93,7 +93,7 @@ Installation:
 
 There's no MELPA package yet, but you can wire up the [`@likec4/lsp`](#standalone-language-server) standalone language server in a few lines.
 
-First, define a minor wrapper mode so the LSP client knows which buffers to attach to:
+First, define a major wrapper mode (derived from `prog-mode`) so the LSP client knows which buffers to attach to:
 
 ```elisp
 ;; Major mode for .c4 / .likec4 files

--- a/apps/docs/src/content/docs/tooling/editors.mdx
+++ b/apps/docs/src/content/docs/tooling/editors.mdx
@@ -91,15 +91,59 @@ Installation:
 
 ## Emacs
 
-Use `@likec4/lsp` with [lsp-mode](https://emacs-lsp.github.io/lsp-mode/) or [eglot](https://github.com/joaotavora/eglot):
+There's no MELPA package yet, but you can wire up the [`@likec4/lsp`](#standalone-language-server) standalone language server in a few lines.
+
+First, define a minor wrapper mode so the LSP client knows which buffers to attach to:
 
 ```elisp
-;; eglot
-(add-to-list 'eglot-server-programs
-             '((likec4-mode) . ("likec4-lsp" "--stdio")))
+;; Major mode for .c4 / .likec4 files
+(define-derived-mode likec4-mode prog-mode "LikeC4"
+  "Major mode for LikeC4 architecture diagram files."
+  (setq-local comment-start "// ")
+  (setq-local comment-start-skip "//+ *")
+  (setq-local comment-end ""))
+
+(add-to-list 'auto-mode-alist '("\\.c4\\'"     . likec4-mode))
+(add-to-list 'auto-mode-alist '("\\.likec4\\'" . likec4-mode))
 ```
 
-See [#2268](https://github.com/likec4/likec4/issues/2268) for discussion on Emacs support.
+Then pick one of the two LSP clients:
+
+### Eglot (built-in since Emacs 29)
+
+```elisp
+(use-package eglot
+  :ensure t
+  :hook ((likec4-mode . eglot-ensure)))
+
+(with-eval-after-load 'eglot
+  (add-to-list 'eglot-server-programs
+               '(likec4-mode . ("likec4-lsp" "--stdio"))))
+```
+
+### lsp-mode
+
+```elisp
+(use-package lsp-mode
+  :ensure t
+  :commands lsp
+  :hook ((likec4-mode . lsp))
+  :init (setq lsp-keymap-prefix "C-c l")
+  :config (setq lsp-enable-snippet t))
+
+(with-eval-after-load 'lsp-mode
+  (add-to-list 'lsp-language-id-configuration
+               '(likec4-mode . "likec4"))
+  (lsp-register-client
+   (make-lsp-client
+    :new-connection (lsp-stdio-connection '("likec4-lsp" "--stdio"))
+    :activation-fn (lsp-activate-on "likec4")
+    :server-id 'likec4-lsp)))
+```
+
+Either approach gives you validation, semantic syntax highlighting, completion, go-to-definition, hover docs, and safe renames — same surface as the [Neovim plugin](#neovim).
+
+Thanks to [@vincent067](https://github.com/vincent067) for the original setup in [#2268](https://github.com/likec4/likec4/issues/2268).
 
 ## Zed
 


### PR DESCRIPTION
## Checklist

- [x] I've thoroughly read the latest [contribution guidelines](https://github.com/likec4/likec4/blob/main/CONTRIBUTING.md).
- [x] I've rebased my branch onto `main` **before** creating this PR.
- [x] I've added tests to cover my changes (if applicable). _(docs-only, no tests)_
- [x] I've verified `pnpm typecheck` and `pnpm test`. _(no source changes; docs unaffected by either)_
- [x] I've added [changesets](https://changesets-docs.vercel.app/).
- [x] My change requires documentation updates.
- [x] I've updated the documentation accordingly.

## Summary

Resolves #2268.

The existing Emacs section in `apps/docs/.../editors.mdx` is a one-line `eglot-server-programs` stub plus a "see #2268 for discussion" link. This PR replaces it with a complete walkthrough so new Emacs users can copy-paste a working setup.

The content is based on @vincent067's [post in #2268](https://github.com/likec4/likec4/issues/2268#issuecomment-4137178686) — @davydkov asked for it to be added to the docs there. Adapted from his original to use the standalone `likec4-lsp` binary from [`@likec4/lsp`](https://github.com/likec4/likec4/tree/main/packages/lsp), which is what the rest of this page recommends (instead of `likec4 lsp` from the main CLI).

## What's added

- A `likec4-mode` major-mode definition deriving from `prog-mode`, wired to `.c4` / `.likec4` via `auto-mode-alist`.
- Eglot config (built-in since Emacs 29).
- lsp-mode config.
- Credit to @vincent067 with a link to the issue thread.

## Test plan

- [x] Visually inspected the rendered section — code blocks, headings, internal links (`#standalone-language-server`, `#neovim`) all resolve.
- [x] Confirmed `likec4-lsp --stdio` command matches the binary documented in the page's "Standalone Language Server" section.