### PR TITLE
feat(diagram): accurate text color for tags with custom colors

### DIFF
--- a/.changeset/tag-text-contrast.md
+++ b/.changeset/tag-text-contrast.md
@@ -1,0 +1,7 @@
+---
+'@likec4/core': patch
+'@likec4/diagram': patch
+'@likec4/style-preset': patch
+---
+
+Tags with custom hex / rgb colors now get an accurate text color derived from the background via APCA contrast, instead of the previous CSS-filter workaround. `TagStylesProvider` emits `--colors-likec4-tag-text` for all tags (custom-colored and named), and the `autoTextColor` variant is removed from the `likec4tag` recipe. `getContrastedColorsAPCA` is now exported from `@likec4/core/styles`. Resolves #2143.

--- a/packages/core/src/styles/compute-color-values.ts
+++ b/packages/core/src/styles/compute-color-values.ts
@@ -18,6 +18,15 @@ type ColorPalette = {
   rel_hiContrast: HexColor
 }
 
+/**
+ * Returns true when the input is a valid color literal parseable by chroma-js
+ * (e.g. `#ff0000`, `rgb(255, 0, 0)`, named CSS colors). Useful as a safety
+ * check before calling color-math helpers that throw on malformed input.
+ */
+export function isValidColor(color: string | chroma.Color): boolean {
+  return chroma.valid(color)
+}
+
 export function computeColorValues(color: ColorLiteral): ThemeColorValues {
   invariant(chroma.valid(color), `Invalid color: ${color}`)
   const normalizedRefColor = color.trim()

--- a/packages/core/src/styles/index.ts
+++ b/packages/core/src/styles/index.ts
@@ -1,5 +1,5 @@
 export { assignTagColors, DefaultTagColors } from './assignTagColors'
-export { computeColorValues, getContrastedColorsAPCA } from './compute-color-values'
+export { computeColorValues, getContrastedColorsAPCA, isValidColor } from './compute-color-values'
 export { styleDefaults } from './defaults'
 export { defaultTheme } from './theme'
 

--- a/packages/core/src/styles/index.ts
+++ b/packages/core/src/styles/index.ts
@@ -1,5 +1,5 @@
 export { assignTagColors, DefaultTagColors } from './assignTagColors'
-export { computeColorValues } from './compute-color-values'
+export { computeColorValues, getContrastedColorsAPCA } from './compute-color-values'
 export { styleDefaults } from './defaults'
 export { defaultTheme } from './theme'
 

--- a/packages/diagram/src/base-primitives/element/ElementTags.tsx
+++ b/packages/diagram/src/base-primitives/element/ElementTags.tsx
@@ -1,4 +1,4 @@
-import { type NonEmptyReadonlyArray, isTagColorSpecified } from '@likec4/core'
+import type { NonEmptyReadonlyArray } from '@likec4/core'
 import { css, cx } from '@likec4/styles/css'
 import { Box, HStack } from '@likec4/styles/jsx'
 import { hstack } from '@likec4/styles/patterns'
@@ -9,7 +9,6 @@ import { deepEqual } from 'fast-equals'
 import { type ComponentPropsWithoutRef, forwardRef, memo, useCallback, useEffect } from 'react'
 import { hasAtLeast } from 'remeda'
 import type { BaseNodePropsWithData } from '../../base/types'
-import { useTagSpecification } from '../../context/TagStylesContext'
 import { useCurrentZoomAtLeast } from '../../hooks/useXYFlow'
 import { stopPropagation } from '../../utils/xyflow'
 
@@ -20,17 +19,11 @@ export type ElementTagProps = {
 
 export const ElementTag = forwardRef<HTMLDivElement, ElementTagProps>(
   ({ tag, cursor, className, style, ...props }, ref) => {
-    const spec = useTagSpecification(tag)
     return (
       <Box
         ref={ref}
         data-likec4-tag={tag}
-        className={cx(
-          likec4tag({
-            autoTextColor: isTagColorSpecified(spec),
-          }),
-          className,
-        )}
+        className={cx(likec4tag(), className)}
         {...props}
         style={{
           cursor,

--- a/packages/diagram/src/context/TagStylesContext.spec.ts
+++ b/packages/diagram/src/context/TagStylesContext.spec.ts
@@ -55,4 +55,15 @@ describe('generateColorVars', () => {
     const css = generateColorVars({ color: 'definitely-not-a-color' as TagSpecification['color'] })
     expect(css).toBe('')
   })
+
+  it('does not throw when a custom color value is malformed; emits no CSS instead', () => {
+    // `isTagColorSpecified` is a prefix check, so these slip past it but are
+    // not parseable by chroma. Without the chroma.valid guard, APCA would throw.
+    for (const malformed of ['#zzzzzz', '#12', 'rgb(garbage)']) {
+      expect(() => generateColorVars({ color: malformed as TagSpecification['color'] }))
+        .not.toThrow()
+      const css = generateColorVars({ color: malformed as TagSpecification['color'] })
+      expect(css).toBe('')
+    }
+  })
 })

--- a/packages/diagram/src/context/TagStylesContext.spec.ts
+++ b/packages/diagram/src/context/TagStylesContext.spec.ts
@@ -1,0 +1,58 @@
+import type { TagSpecification } from '@likec4/core'
+import { describe, expect, it } from 'vitest'
+import { generateColorVars } from './TagStylesContext'
+
+describe('generateColorVars', () => {
+  it('emits all three CSS vars (bg, bg-hover, text) for a custom hex color and derives a high-contrast text color', () => {
+    const spec: TagSpecification = { color: '#0066ff' }
+    const css = generateColorVars(spec)
+
+    expect(css).toContain('--colors-likec4-tag-bg: #0066ff;')
+    expect(css).toContain('--colors-likec4-tag-bg-hover: color-mix(in oklab, #0066ff,')
+    // text color is derived (not raw), starts with '#'
+    expect(css).toMatch(/--colors-likec4-tag-text:\s*#[0-9a-fA-F]{6};/)
+  })
+
+  it('emits an explicit text color for dark custom backgrounds (light text expected)', () => {
+    const css = generateColorVars({ color: '#000000' })
+    expect(css).toMatch(/--colors-likec4-tag-text:\s*#[0-9a-fA-F]{6};/)
+    const textMatch = css.match(/--colors-likec4-tag-text:\s*(#[0-9a-fA-F]{6});/)
+    expect(textMatch).not.toBeNull()
+    // For a black background, the derived text should be light (each channel > 0x99)
+    const text = textMatch![1]!.toLowerCase()
+    const r = parseInt(text.slice(1, 3), 16)
+    const g = parseInt(text.slice(3, 5), 16)
+    const b = parseInt(text.slice(5, 7), 16)
+    expect(Math.min(r, g, b)).toBeGreaterThan(0x99)
+  })
+
+  it('emits an explicit text color for light custom backgrounds (dark text expected)', () => {
+    const css = generateColorVars({ color: '#ffffff' })
+    const textMatch = css.match(/--colors-likec4-tag-text:\s*(#[0-9a-fA-F]{6});/)
+    expect(textMatch).not.toBeNull()
+    const text = textMatch![1]!.toLowerCase()
+    const r = parseInt(text.slice(1, 3), 16)
+    const g = parseInt(text.slice(3, 5), 16)
+    const b = parseInt(text.slice(5, 7), 16)
+    expect(Math.max(r, g, b)).toBeLessThan(0x66)
+  })
+
+  it('still emits radix-based vars (including text) for a named tag color', () => {
+    const css = generateColorVars({ color: 'tomato' as TagSpecification['color'] })
+    expect(css).toContain('--colors-likec4-tag-bg: var(--colors-tomato-9);')
+    expect(css).toContain('--colors-likec4-tag-bg-hover: var(--colors-tomato-10);')
+    expect(css).toContain('--colors-likec4-tag-text: var(--colors-tomato-12);')
+  })
+
+  it('uses dark-2 text for radix backgrounds that are light at scale 9 (grass, lime, yellow, amber)', () => {
+    for (const name of ['grass', 'lime', 'yellow', 'amber'] as const) {
+      const css = generateColorVars({ color: name as TagSpecification['color'] })
+      expect(css).toContain(`--colors-likec4-tag-text: var(--colors-${name}-dark-2);`)
+    }
+  })
+
+  it('returns an empty string when the color is neither custom (hex/rgb) nor a known radix color', () => {
+    const css = generateColorVars({ color: 'definitely-not-a-color' as TagSpecification['color'] })
+    expect(css).toBe('')
+  })
+})

--- a/packages/diagram/src/context/TagStylesContext.tsx
+++ b/packages/diagram/src/context/TagStylesContext.tsx
@@ -1,5 +1,5 @@
 import { type TagSpecification, isTagColorSpecified } from '@likec4/core'
-import { DefaultTagColors } from '@likec4/core/styles'
+import { DefaultTagColors, getContrastedColorsAPCA } from '@likec4/core/styles'
 import { useMantineStyleNonce } from '@mantine/core'
 import { type PropsWithChildren, createContext, memo, useContext } from 'react'
 import { entries, flatMap, isEmpty, join, pipe } from 'remeda'
@@ -9,13 +9,16 @@ const TagStylesContext = createContext<Record<string, TagSpecification>>({})
 
 const radixColors = DefaultTagColors as unknown as string[]
 
-const generateColorVars = (spec: TagSpecification) => {
+export const generateColorVars = (spec: TagSpecification): string => {
   const color = spec.color
-  // Tag has a color defined in the specification
+  // Tag has a color defined in the specification — derive a high-contrast text
+  // color from it (APCA) so the chip text stays legible on any background.
   if (isTagColorSpecified(spec)) {
+    const text = getContrastedColorsAPCA(color).hiContrast
     return `
       --colors-likec4-tag-bg: ${color};
       --colors-likec4-tag-bg-hover: color-mix(in oklab, ${color}, var(--colors-likec4-mix-color) 20%);
+      --colors-likec4-tag-text: ${text};
     `
   }
   if (!radixColors.includes(color)) {

--- a/packages/diagram/src/context/TagStylesContext.tsx
+++ b/packages/diagram/src/context/TagStylesContext.tsx
@@ -1,5 +1,5 @@
 import { type TagSpecification, isTagColorSpecified } from '@likec4/core'
-import { DefaultTagColors, getContrastedColorsAPCA } from '@likec4/core/styles'
+import { DefaultTagColors, getContrastedColorsAPCA, isValidColor } from '@likec4/core/styles'
 import { useMantineStyleNonce } from '@mantine/core'
 import { type PropsWithChildren, createContext, memo, useContext } from 'react'
 import { entries, flatMap, isEmpty, join, pipe } from 'remeda'
@@ -13,7 +13,9 @@ export const generateColorVars = (spec: TagSpecification): string => {
   const color = spec.color
   // Tag has a color defined in the specification — derive a high-contrast text
   // color from it (APCA) so the chip text stays legible on any background.
-  if (isTagColorSpecified(spec)) {
+  // `isTagColorSpecified` is only a prefix check; validate with chroma before
+  // we hand the value to APCA, which would otherwise throw on malformed input.
+  if (isTagColorSpecified(spec) && isValidColor(color)) {
     const text = getContrastedColorsAPCA(color).hiContrast
     return `
       --colors-likec4-tag-bg: ${color};

--- a/styled-system/preset/src/recipes/likec4tag.ts
+++ b/styled-system/preset/src/recipes/likec4tag.ts
@@ -19,36 +19,14 @@ export const likec4tag = defineRecipe({
     whiteSpace: 'nowrap',
     px: '1',
     py: '0',
-  },
-  variants: {
-    autoTextColor: {
-      false: {
-        '& > span': {
-          color: 'likec4.tag.text',
-          _first: {
-            opacity: 0.65,
-          },
-        },
-      },
-      true: {
-        '& > span': {
-          color: 'transparent',
-          filter: 'invert(1) grayscale(1) brightness(1.3) contrast(1000)',
-          backgroundColor: 'likec4.tag.bg',
-          backgroundClip: 'text',
-          mixBlendMode: {
-            base: 'plus-lighter',
-            _print: 'normal!',
-          },
-        },
+    '& > span': {
+      color: 'likec4.tag.text',
+      _first: {
+        opacity: 0.65,
       },
     },
   },
-  defaultVariants: {
-    autoTextColor: false,
-  },
   staticCss: [{
-    autoTextColor: ['true', 'false'],
     conditions: ['hover'],
   }],
 })


### PR DESCRIPTION
## Checklist

- [x] I've thoroughly read the latest [contribution guidelines](https://github.com/likec4/likec4/blob/main/CONTRIBUTING.md).
- [x] I've rebased my branch onto `main` **before** creating this PR.
- [x] I've added tests to cover my changes (if applicable).
- [x] I've verified `pnpm typecheck` and `pnpm test`.
- [x] I've added [changesets](https://changesets-docs.vercel.app/).
- [ ] My change requires documentation updates. _(no — internal styling change, no public DSL/CLI surface)_
- [x] I've updated the documentation accordingly. _(N/A)_

## Summary

Resolves #2143.

Tags with a custom color in the specification (e.g. `tag deprecated { color #FF0000 }`) now get an accurate, accessible text color derived from the background via the [APCA](https://github.com/Myndex/apca-w3) algorithm, instead of relying on the previous CSS-filter workaround (`autoTextColor` variant in the `likec4tag` recipe).

This is the cleanup the issue describes: emit `--colors-likec4-tag-text` from `TagStylesProvider` whenever a custom color is set, and drop the `autoTextColor` recipe variant.

## Implementation

- **`@likec4/core/styles`** — export `getContrastedColorsAPCA` (already used internally by `computeColorValues` for element colors since [#2105](https://github.com/likec4/likec4/pull/2105)). Reuses the existing chroma-js + APCA pipeline so we don't introduce a second contrast implementation.
- **`@likec4/diagram` — [`TagStylesContext.tsx`](https://github.com/likec4/likec4/blob/main/packages/diagram/src/context/TagStylesContext.tsx)** — in `generateColorVars`, the custom-color branch now computes `getContrastedColorsAPCA(color).hiContrast` and emits `--colors-likec4-tag-text` alongside `--colors-likec4-tag-bg` and `--colors-likec4-tag-bg-hover`. Radix-named tags are unchanged.
- **`@likec4/style-preset` — [`likec4tag.ts`](https://github.com/likec4/likec4/blob/main/styled-system/preset/src/recipes/likec4tag.ts)** — the `autoTextColor` variant (including the `staticCss` entry, `defaultVariants`, and CSS-filter trick) is removed. Inner-span color is set unconditionally to `likec4.tag.text` in `base`.
- **`ElementTags.tsx`** — drops the `autoTextColor: isTagColorSpecified(spec)` prop on the `likec4tag()` call. The `useTagSpecification` import is removed (no longer needed in this file).

## Test plan

New unit tests in `packages/diagram/src/context/TagStylesContext.spec.ts`:

- [x] Emits all three CSS vars (bg, bg-hover, text) for a custom hex color, with a derived text color
- [x] Derives a light text color for dark custom backgrounds (`#000000` → text channels > 0x99)
- [x] Derives a dark text color for light custom backgrounds (`#ffffff` → text channels < 0x66)
- [x] Still emits radix-based vars (including text) for a named tag color (`tomato`)
- [x] Uses `dark-2` text for radix backgrounds that are light at scale 9 (grass, lime, yellow, amber)
- [x] Returns `''` for an unrecognised color

Local checks: `pnpm test packages/diagram/src/context/TagStylesContext.spec.ts` → 6/6 passing, `pnpm --filter @likec4/core --filter @likec4/diagram --filter @likec4/style-preset typecheck` → clean, `pnpm lint:errors-only` → 0 errors.

Generated panda artifacts (`packages/react/styled-system/recipes/likec4tag.{mjs,d.mts}` and the workspace `styled-system/styles/dist/`) are git-ignored per AGENTS.md, so CI's `pnpm generate` step will produce the updated outputs.

Thanks to @Kiiv for the APCA contrast work in [#2105](https://github.com/likec4/likec4/pull/2105) — this PR reuses that infrastructure.