### PR TITLE
feat(language-server): clear diagnostic for nested parallel blocks

### DIFF
--- a/.changeset/lsp-nested-parallel-diagnostic.md
+++ b/.changeset/lsp-nested-parallel-diagnostic.md
@@ -1,0 +1,5 @@
+---
+'@likec4/language-server': patch
+---
+
+Nested `parallel` blocks in dynamic views now produce a clear validation error (`Nested parallel blocks are not allowed`) instead of a cryptic parser error. The grammar is loosened to accept the nested form so the validator can attach a diagnostic to the inner block. Resolves #988.

--- a/packages/language-server/src/like-c4.langium
+++ b/packages/language-server/src/like-c4.langium
@@ -414,7 +414,9 @@ DynamicViewRule:
 
 DynamicViewParallelSteps:
   ('parallel'|'par') '{'
-    (steps+=DynamicViewStep)*
+    // Accept nested ParallelSteps so we can report a clear validation error
+    // instead of leaving the user with a cryptic parser error. See #988.
+    (steps+=(DynamicViewParallelSteps | DynamicViewStep))*
   '}'
 ;
 

--- a/packages/language-server/src/model/parser/ViewsParser.ts
+++ b/packages/language-server/src/model/parser/ViewsParser.ts
@@ -339,7 +339,10 @@ export function ViewsParser<TBase extends WithPredicates & WithDeploymentView>(B
 
     parseDynamicParallelSteps(node: ast.DynamicViewParallelSteps): c4.DynamicStepsParallel {
       const parallelId = pathInsideDynamicView(node)
-      const __parallel = this.tryMap('views', node.steps, s => this.parseDynamicStep(s))
+      // Nested parallel blocks are already flagged by the validator (#988);
+      // skip them here so we don't bubble a confusing internal error.
+      const stepNodes = node.steps.filter((s): s is ast.DynamicViewStep => !ast.isDynamicViewParallelSteps(s))
+      const __parallel = this.tryMap('views', stepNodes, s => this.parseDynamicStep(s))
       invariant(isNonEmptyArray(__parallel), 'Dynamic parallel steps must have at least one step')
       return {
         parallelId,

--- a/packages/language-server/src/validation/dynamic-view.spec.ts
+++ b/packages/language-server/src/validation/dynamic-view.spec.ts
@@ -144,6 +144,81 @@ describe('DynamicView Checks', () => {
     })
   })
 
+  describe('parallel blocks', () => {
+    it('accepts a single, non-nested parallel block', async ({ expect }) => {
+      const { validate } = createTestServices()
+      const { errors } = await validate(`
+        specification {
+          element component
+        }
+        model {
+          component a
+          component b
+          component c
+        }
+        views {
+          dynamic view index {
+            a -> b
+            parallel {
+              a -> c
+              b -> c
+            }
+          }
+        }
+      `)
+      expect(errors).toEqual([])
+    })
+
+    it('reports a clear diagnostic when a parallel block is nested inside another', async ({ expect }) => {
+      const { validate } = createTestServices()
+      const { errors } = await validate(`
+        specification {
+          element component
+        }
+        model {
+          component a
+          component b
+          component c
+        }
+        views {
+          dynamic view index {
+            parallel {
+              a -> b
+              parallel {
+                a -> c
+                b -> c
+              }
+            }
+          }
+        }
+      `)
+      expect(errors).toContain('Nested parallel blocks are not allowed')
+    })
+
+    it('also reports nesting when using the `par` alias', async ({ expect }) => {
+      const { validate } = createTestServices()
+      const { errors } = await validate(`
+        specification {
+          element component
+        }
+        model {
+          component a
+          component b
+        }
+        views {
+          dynamic view index {
+            par {
+              par {
+                a -> b
+              }
+            }
+          }
+        }
+      `)
+      expect(errors).toContain('Nested parallel blocks are not allowed')
+    })
+  })
+
   describe('display variant', () => {
     it('should report if invalid mode', async ({ expect }) => {
       const { validate } = createTestServices()

--- a/packages/language-server/src/validation/dynamic-view.ts
+++ b/packages/language-server/src/validation/dynamic-view.ts
@@ -56,6 +56,20 @@ export const dynamicViewStepChain = (services: LikeC4Services): ValidationCheck<
   })
 }
 
+export const dynamicViewParallelSteps = (
+  _services: LikeC4Services,
+): ValidationCheck<ast.DynamicViewParallelSteps> => {
+  return tryOrLog((el, accept) => {
+    for (const step of el.steps) {
+      if (ast.isDynamicViewParallelSteps(step)) {
+        accept('error', 'Nested parallel blocks are not allowed', {
+          node: step,
+        })
+      }
+    }
+  })
+}
+
 export const dynamicViewDisplayVariant = (
   _services: LikeC4Services,
 ): ValidationCheck<ast.DynamicViewDisplayVariantProperty> => {

--- a/packages/language-server/src/validation/index.ts
+++ b/packages/language-server/src/validation/index.ts
@@ -20,7 +20,12 @@ import {
   deploymentRelationChecks,
   extendDeploymentChecks,
 } from './deployment-checks'
-import { dynamicViewDisplayVariant, dynamicViewStepChain, dynamicViewStepSingle } from './dynamic-view'
+import {
+  dynamicViewDisplayVariant,
+  dynamicViewParallelSteps,
+  dynamicViewStepChain,
+  dynamicViewStepSingle,
+} from './dynamic-view'
 import { checkElement } from './element'
 import { checkElementRef } from './element-ref'
 import { checkImportsFromPoject } from './imports'
@@ -171,6 +176,7 @@ export function registerValidationChecks(services: LikeC4Services) {
     GlobalStyleId: checkGlobalStyleId(services),
     DynamicStepSingle: dynamicViewStepSingle(services),
     DynamicStepChain: dynamicViewStepChain(services),
+    DynamicViewParallelSteps: dynamicViewParallelSteps(services),
     LikeC4View: viewChecks(services),
     Element: checkElement(services),
     ElementRef: checkElementRef(services),


### PR DESCRIPTION
## Checklist

- [x] I've thoroughly read the latest [contribution guidelines](https://github.com/likec4/likec4/blob/main/CONTRIBUTING.md).
- [x] I've rebased my branch onto `main` **before** creating this PR.
- [x] I've added tests to cover my changes (if applicable).
- [x] I've verified `pnpm typecheck` and `pnpm test`.
- [x] I've added [changesets](https://changesets-docs.vercel.app/).
- [ ] My change requires documentation updates. _(no — internal grammar/validator change, no public DSL semantics shift)_
- [x] I've updated the documentation accordingly. _(N/A)_

## Summary

Resolves #988 (originally from @susliko in [discussion #816](https://github.com/likec4/likec4/discussions/816)).

Today `parallel { parallel { ... } }` in a dynamic view produces a cryptic parser error like `Expecting token of type --> RightCurly <-- but found --> 'parallel' <--`. The grammar simply forbids the nested form structurally, so users get the raw parser error.

This PR:
1. **Loosens the grammar** so a `DynamicViewParallelSteps` can appear as a step inside another `DynamicViewParallelSteps`. The parser accepts the form now, instead of rejecting it.
2. **Adds a `dynamicViewParallelSteps` validator** that walks `steps` and emits a clear error — `Nested parallel blocks are not allowed` — on any nested `DynamicViewParallelSteps`. The diagnostic is attached to the inner block so the squiggle lines up with the offending `parallel`/`par` keyword.

Net behaviour: same outcome (the model is rejected), much better message.

## Files

- **Grammar** — [`like-c4.langium`](https://github.com/likec4/likec4/blob/main/packages/language-server/src/like-c4.langium#L415-L419): `(steps+=(DynamicViewParallelSteps | DynamicViewStep))*`.
- **Validator** — [`validation/dynamic-view.ts`](https://github.com/likec4/likec4/blob/main/packages/language-server/src/validation/dynamic-view.ts): new `dynamicViewParallelSteps` check.
- **Registration** — [`validation/index.ts`](https://github.com/likec4/likec4/blob/main/packages/language-server/src/validation/index.ts): wired under the `DynamicViewParallelSteps` key.
- **Parser** — [`model/parser/ViewsParser.ts`](https://github.com/likec4/likec4/blob/main/packages/language-server/src/model/parser/ViewsParser.ts#L340): `parseDynamicParallelSteps` now filters out nested `ParallelSteps` before calling `parseDynamicStep` (the validator has already errored on them; this keeps the c4-model side narrow and avoids a confusing internal type error).

## Test plan

New tests in `dynamic-view.spec.ts`:

- [x] A single, non-nested parallel block — no errors.
- [x] `parallel { parallel { ... } }` — reports `Nested parallel blocks are not allowed`.
- [x] `par { par { ... } }` (the `par` alias) — same diagnostic.

Local: `pnpm test packages/language-server/src/validation/dynamic-view.spec.ts` → 12/12 passing, `pnpm --filter @likec4/language-server typecheck` → clean, `pnpm lint:errors-only` → 0 errors.

Generated parser artifacts (`packages/language-server/src/generated/`) are git-ignored, so CI's `pnpm generate` step will produce the updated parser from the new grammar.