### PR TITLE
Fix deployment metadata filters in view predicates

### DIFF
--- a/.changeset/fix-deployment-metadata-filters.md
+++ b/.changeset/fix-deployment-metadata-filters.md
@@ -1,0 +1,6 @@
+---
+'@likec4/core': patch
+---
+
+Fix deployment relationship filters so source and target metadata predicates use deployed instance metadata.
+Instance metadata replaces, not merges with, model element metadata, matching existing deployment model semantics.

--- a/apps/docs/src/content/docs/dsl/Deployment/views.mdx
+++ b/apps/docs/src/content/docs/dsl/Deployment/views.mdx
@@ -68,14 +68,17 @@ But they refer to deployment nodes and instances.
 </Aside>
 
 ### Filtering
-Filtering in deployment views use the same principles as in normal views but takes into account deployment nodes, relations and tags defined in deployment model.
+Filtering in deployment views use the same principles as in normal views but takes into account deployment nodes, relations, tags and metadata defined in deployment model.
 When condition on element is checked the following rules are applied:
-- For a deployment instances tags are combined from tags defined in model and tags defined in deployment model
+- For deployment instances, tags are combined from tags defined in model and tags defined in deployment model
 - For a child of deployment instance the tags defined on child in model are used
 - For a deployment node the tags defined in deployment model are used
-- For a deployment instances the kind of the model element is used
+- For deployment instances, the kind of the model element is used
 - For a child of deployment instance the kind of this child is used
 - For a deployment node the kind of this deployment node is used
+- For deployment instances, metadata defined in deployment model replaces metadata from the model element
+- For relationship endpoints, `source.metadata.*` and `target.metadata.*` use the same deployed instance metadata rules
+- For deployment nodes, metadata defined in deployment model is used
 - Tags are not inherited from parent nodes/elements
 
 ```likec4
@@ -122,6 +125,33 @@ views {
       where source.tag is #sigma // does not include any relations
     include eu.* -> prod.db
       where source.tag is #sigma // includes relations "rel2"
+  }
+}
+```
+
+Metadata predicates can be used with `include` and `exclude` as well:
+
+```likec4
+deployment {
+  environment prod {
+    instanceOf backend {
+      metadata {
+        zone 'public'
+      }
+    }
+    instanceOf database {
+      metadata {
+        zone 'restricted'
+      }
+    }
+  }
+}
+
+views {
+  deployment view prod {
+    include * -> *
+    exclude * -> *
+      where target.metadata.zone is "restricted"
   }
 }
 ```

--- a/apps/docs/src/content/docs/dsl/Views/predicates.mdx
+++ b/apps/docs/src/content/docs/dsl/Views/predicates.mdx
@@ -487,6 +487,21 @@ include
     where target.metadata.environment is "staging"
 ```
 
+The same metadata filters work with `exclude` predicates:
+
+```likec4
+// remove relationships with protocol="http"
+exclude * -> *
+  where metadata.protocol is "http"
+
+// remove relationships targeting staging elements
+exclude * -> *
+  where target.metadata.environment is "staging"
+```
+
+In deployment views, `source.metadata.*` and `target.metadata.*` follow the deployment metadata rules.
+Metadata defined on a deployed instance replaces the metadata from its model element.
+
 ## Global predicate groups
 
 If you find yourself repeating the same predicates in multiple views, you can define them as global group:

--- a/packages/core/src/compute-view/deployment-view/predicates/__test__/exclude-metadata.filter.spec.ts
+++ b/packages/core/src/compute-view/deployment-view/predicates/__test__/exclude-metadata.filter.spec.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 //
+// Copyright (c) 2023-2026 Denis Davydkov
 // Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import { describe, it } from 'vitest'

--- a/packages/core/src/compute-view/deployment-view/predicates/__test__/exclude-metadata.filter.spec.ts
+++ b/packages/core/src/compute-view/deployment-view/predicates/__test__/exclude-metadata.filter.spec.ts
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import { describe, it } from 'vitest'
+import { Builder } from '../../../../builder'
+import type {
+  AnyTypes,
+  DeploymentRulesBuilderOp,
+  DeploymentViewBuilder,
+  Types,
+  ViewPredicate,
+} from '../../../../builder'
+import type { WhereOperator } from '../../../../types'
+import { TestHelper } from '../../__test__/TestHelper'
+
+type DeploymentWhereExpr<T extends AnyTypes> = Extract<Types.ToExpression<T>, { where: unknown }>
+type DeploymentExpr<T extends AnyTypes> = ViewPredicate.DeploymentExpression<T> | Types.ToExpression<T>
+
+function excludeWhere<T extends AnyTypes>(
+  expr: DeploymentExpr<T>,
+  condition: WhereOperator<Types.ToAux<T>>,
+): DeploymentRulesBuilderOp<T> {
+  return (b: DeploymentViewBuilder<T>) =>
+    b.exclude({
+      where: {
+        expr: b.$expr(expr) as DeploymentWhereExpr<T>['where']['expr'],
+        condition,
+      },
+    } as DeploymentWhereExpr<T>)
+}
+
+describe('deployment view exclude where metadata', () => {
+  const builder = Builder
+    .specification({
+      elements: {
+        app: {},
+        database: {},
+      },
+      deployments: {
+        node: {},
+      },
+      relationships: {
+        async: {},
+        sync: {},
+      },
+      metadataKeys: ['lifecycle', 'protocol', 'zone'],
+    })
+    .model(({ app, database, rel }, m) =>
+      m(
+        app('client', { metadata: { zone: 'model-public' } }),
+        app('api', { metadata: { zone: 'public' } }),
+        database('db', { metadata: { zone: 'public' } }),
+        app('legacy'),
+        rel('client', 'api', { title: 'call', kind: 'sync', metadata: { protocol: 'https' } }),
+        rel('api', 'db', { title: 'write', kind: 'async', metadata: { protocol: 'http' } }),
+        rel('api', 'legacy', { title: 'notify', kind: 'sync', metadata: { protocol: 'grpc' } }),
+      )
+    )
+    .deployment((_, d) =>
+      d(
+        _.node('prod').with(
+          _.instanceOf('client', 'client'),
+          _.instanceOf('api', 'api', { metadata: { lifecycle: 'active', zone: 'public' } }),
+          _.instanceOf('db', 'db', { metadata: { lifecycle: 'deprecated', zone: 'restricted' } }),
+          _.instanceOf('legacy', 'legacy', { metadata: { lifecycle: 'deprecated', zone: 'restricted' } }),
+        ),
+      )
+    )
+
+  const t = TestHelper.from(builder)
+
+  it('excludes deployment instances by metadata value', () => {
+    t.expectComputedView(
+      t.$include('prod.*'),
+      excludeWhere('prod.*', { metadata: { key: 'lifecycle', value: 'deprecated' } }),
+    ).toHave({
+      nodes: ['prod.client', 'prod.api'],
+      edges: ['prod.client -> prod.api'],
+    })
+  })
+
+  it('excludes deployment relationships by relationship metadata', () => {
+    t.expectComputedView(
+      t.$include('* -> *'),
+      excludeWhere('* -> *', { metadata: { key: 'protocol', value: 'http' } }),
+    ).toHave({
+      nodes: ['prod.client', 'prod.api', 'prod.legacy'],
+      edges: ['prod.client -> prod.api', 'prod.api -> prod.legacy'],
+    })
+  })
+
+  it('excludes deployment relationships by source metadata', () => {
+    t.expectComputedView(
+      t.$include('* -> *'),
+      excludeWhere('* -> *', {
+        participant: 'source',
+        operator: { metadata: { key: 'lifecycle', value: 'active' } },
+      }),
+    ).toHave({
+      nodes: ['prod.client', 'prod.api'],
+      edges: ['prod.client -> prod.api'],
+    })
+  })
+
+  it('falls back to logical element metadata when an instance has no metadata', () => {
+    t.expectComputedView(
+      t.$include('* -> *'),
+      excludeWhere('* -> *', {
+        participant: 'source',
+        operator: { metadata: { key: 'zone', value: 'model-public' } },
+      }),
+    ).toHave({
+      nodes: ['prod.api', 'prod.db', 'prod.legacy'],
+      edges: ['prod.api -> prod.db', 'prod.api -> prod.legacy'],
+    })
+  })
+
+  it('uses deployment instance metadata instead of logical element metadata', () => {
+    t.expectComputedView(
+      t.$include('* -> *'),
+      excludeWhere('* -> *', {
+        participant: 'target',
+        operator: { metadata: { key: 'zone', value: 'public' } },
+      }),
+    ).toHave({
+      nodes: ['prod.api', 'prod.db', 'prod.legacy'],
+      edges: ['prod.api -> prod.db', 'prod.api -> prod.legacy'],
+    })
+  })
+
+  it('excludes deployment relationships by target metadata', () => {
+    t.expectComputedView(
+      t.$include('* -> *'),
+      excludeWhere('* -> *', {
+        participant: 'target',
+        operator: { metadata: { key: 'zone', value: 'restricted' } },
+      }),
+    ).toHave({
+      nodes: ['prod.client', 'prod.api'],
+      edges: ['prod.client -> prod.api'],
+    })
+  })
+})

--- a/packages/core/src/compute-view/deployment-view/predicates/utils.ts
+++ b/packages/core/src/compute-view/deployment-view/predicates/utils.ts
@@ -257,14 +257,15 @@ function toFilterable<M extends AnyAux>(
   relationEndpoint: ElementModel<M> | DeploymentRelationEndpoint<M>,
   connectionEndpoint: DeploymentRelationEndpoint<M>,
 ): Filterable<M> {
-  if (isElementModel<M>(relationEndpoint)) { // Element itself. Extend with tags of the deployed instance (TODO)
+  if (isElementModel<M>(relationEndpoint)) {
     const deployedInstance = isDeploymentElementModel<M>(connectionEndpoint) && isDeployedInstance(connectionEndpoint)
       ? connectionEndpoint
       : null
     return {
       kind: relationEndpoint.kind,
       tags: [...relationEndpoint.tags, ...(deployedInstance?.tags ?? [])],
-      metadata: relationEndpoint.metadata,
+      // Deployed instance metadata intentionally replaces, not merges with, model element metadata.
+      metadata: deployedInstance?.metadata ?? relationEndpoint.metadata,
     }
   }
   if (isNestedElementOfDeployedInstanceModel(relationEndpoint)) { // Nested element. Has no own instance. No need to extend

--- a/packages/core/src/compute-view/element-view/exclude-where.spec.ts
+++ b/packages/core/src/compute-view/element-view/exclude-where.spec.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 //
+// Copyright (c) 2023-2026 Denis Davydkov
 // Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import { describe, it } from 'vitest'

--- a/packages/core/src/compute-view/element-view/exclude-where.spec.ts
+++ b/packages/core/src/compute-view/element-view/exclude-where.spec.ts
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import { describe, it } from 'vitest'
+import { Builder } from '../../builder'
+import type { AnyTypes, ElementViewBuilder, ElementViewRulesBuilder, Types, ViewPredicate } from '../../builder'
+import { FqnExpr, RelationExpr } from '../../types'
+import type { Expression, WhereOperator } from '../../types'
+import { TestHelper } from './__test__/TestHelper'
+
+type ElementExpr<T extends AnyTypes> = ViewPredicate.Expression<T> | Expression<Types.ToAux<T>>
+
+function includeWhere<T extends AnyTypes>(
+  expr: ElementExpr<T>,
+  condition: WhereOperator<Types.ToAux<T>>,
+): ElementViewRulesBuilder<T> {
+  return (b: ElementViewBuilder<T>) => {
+    const parsed = b.$expr(expr)
+    if (FqnExpr.is(parsed)) {
+      return b.include({
+        where: {
+          expr: parsed,
+          condition,
+        },
+      })
+    }
+    if (RelationExpr.is(parsed)) {
+      return b.include({
+        where: {
+          expr: parsed,
+          condition,
+        },
+      })
+    }
+    throw new Error('Expected an element or relationship expression')
+  }
+}
+
+function excludeWhere<T extends AnyTypes>(
+  expr: ElementExpr<T>,
+  condition: WhereOperator<Types.ToAux<T>>,
+): ElementViewRulesBuilder<T> {
+  return (b: ElementViewBuilder<T>) => {
+    const parsed = b.$expr(expr)
+    if (FqnExpr.is(parsed)) {
+      return b.exclude({
+        where: {
+          expr: parsed,
+          condition,
+        },
+      })
+    }
+    if (RelationExpr.is(parsed)) {
+      return b.exclude({
+        where: {
+          expr: parsed,
+          condition,
+        },
+      })
+    }
+    throw new Error('Expected an element or relationship expression')
+  }
+}
+
+describe('element view exclude where', () => {
+  const builder = Builder
+    .specification({
+      elements: {
+        app: {},
+        database: {},
+      },
+      relationships: {
+        async: {},
+        sync: {},
+      },
+      metadataKeys: ['lifecycle', 'owner', 'team', 'protocol', 'regions'],
+    })
+    .model(({ app, database }, m) =>
+      m(
+        app('client', { metadata: { owner: 'web', team: 'web' } }),
+        app('api', { metadata: { owner: 'platform', team: 'core', regions: ['eu', 'us'] } }),
+        database('db', { metadata: { lifecycle: 'deprecated', owner: 'data', team: 'core' } }),
+        app('legacy', { metadata: { lifecycle: 'deprecated', owner: 'legacy', team: 'legacy' } }),
+        app('unowned', { metadata: { team: 'core' } }),
+      )
+    )
+    .model(({ rel }, m) =>
+      m(
+        rel('client', 'api', { title: 'call', kind: 'sync', metadata: { protocol: 'https' } }),
+        rel('api', 'db', { title: 'write', kind: 'async', metadata: { protocol: 'http' } }),
+        rel('legacy', 'api', { title: 'legacy call', kind: 'sync', metadata: { protocol: 'http' } }),
+        rel('api', 'unowned', { title: 'audit', kind: 'sync', metadata: { protocol: 'grpc' } }),
+      )
+    )
+
+  const t = TestHelper.from(builder)
+
+  it('excludes elements by metadata value and removes their relationships', () => {
+    t.expectComputedView(
+      t.$include('*'),
+      excludeWhere('*', { metadata: { key: 'lifecycle', value: 'deprecated' } }),
+    ).toHave({
+      nodes: ['client', 'api', 'unowned'],
+      edges: ['client -> api', 'api -> unowned'],
+    })
+  })
+
+  it('excludes elements without required metadata', () => {
+    t.expectComputedView(
+      t.$include('*'),
+      excludeWhere('*', { not: { metadata: { key: 'owner' } } }),
+    ).toHave({
+      nodes: ['client', 'legacy', 'api', 'db'],
+      edges: ['client -> api', 'api -> db', 'legacy -> api'],
+    })
+  })
+
+  it('matches array metadata values when excluding elements', () => {
+    t.expectComputedView(
+      t.$include('*'),
+      excludeWhere('*', { metadata: { key: 'regions', value: 'eu' } }),
+    ).toHave({
+      nodes: ['client', 'db', 'legacy', 'unowned'],
+      edges: [],
+    })
+  })
+
+  it('excludes relationships by kind without removing explicitly included endpoints', () => {
+    t.expectComputedView(
+      t.$include('client', 'api', 'db'),
+      t.$include('client -> api'),
+      t.$include('api -> db'),
+      excludeWhere('api -> db', { kind: 'async' }),
+    ).toHave({
+      nodes: ['client', 'api', 'db'],
+      edges: ['client -> api'],
+    })
+  })
+
+  it('excludes relationships by relationship metadata', () => {
+    t.expectComputedView(
+      includeWhere('* -> *', { metadata: { key: 'protocol' } }),
+      excludeWhere('* -> *', { metadata: { key: 'protocol', value: 'http' } }),
+    ).toHave({
+      nodes: ['client', 'api', 'unowned'],
+      edges: ['client -> api', 'api -> unowned'],
+    })
+  })
+
+  it('excludes relationships by source metadata', () => {
+    t.expectComputedView(
+      t.$include('* -> *'),
+      excludeWhere('* -> *', {
+        participant: 'source',
+        operator: { metadata: { key: 'team', value: 'legacy' } },
+      }),
+    ).toHave({
+      nodes: ['client', 'api', 'db', 'unowned'],
+      edges: ['client -> api', 'api -> db', 'api -> unowned'],
+    })
+  })
+})

--- a/skills/likec4-dsl/SKILL.md
+++ b/skills/likec4-dsl/SKILL.md
@@ -214,6 +214,22 @@ views {
 
 Interpretation anchor: in a scoped view, `include *` means the scoped element plus its **direct children** as the base include set; neighbors can still appear through scoped relationship visibility.
 
+### Metadata predicates
+
+```likec4
+include * where metadata.region is "eu"
+include * where metadata.regions is "eu"
+exclude * where not metadata.owner
+exclude * -> * where metadata.protocol is "http"
+exclude * -> * where target.metadata.zone is "restricted"
+```
+
+Truth card:
+
+- Array containment: `metadata.regions is "eu"` matches if the array contains `"eu"`.
+- Scope: unqualified `metadata.*` filters the matched element or relationship itself; `source.metadata.*` / `target.metadata.*` filters endpoints.
+- Deployment views: instance tags are cumulative; instance metadata replaces logical metadata as a whole when present, otherwise logical metadata is the fallback.
+
 ### Deployment-view styling guardrail
 
 For strict repair prompts about deployment views, the safe answer is **local `style ... {}` inside the deployment view**.
@@ -268,7 +284,7 @@ To discover available icons, use the CLI: `likec4 list-icons` (text, one per lin
 
 Maps logical model elements to physical infrastructure nodes using `instanceOf`. Uses `deploymentNode` kinds from specification. Inherits all logical model relationships automatically; additional deployment-level relationships can be defined inline.
 
-Named vs. anonymous instances, multi-environment fixture, deployment relationships, and selection guidance → `references/deployment.md`
+Named vs. anonymous instances, multi-environment fixture, deployment relationships, and deployment filter metadata rules → `references/deployment.md`
 
 ## Views
 
@@ -388,20 +404,20 @@ When a model errors or an eval answer seems wrong, load `references/troubleshoot
 
 Load a reference file when the task involves the corresponding topic. Claude reads SKILL.md first; these files are loaded on demand only when needed.
 
-| File                                         | Purpose — load when...                                                                                   |
-| -------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| `references/specification.md`                | Writing/editing `specification { }` blocks, defining element/deploymentNode/relationship/tag/color kinds |
-| `references/model.md`                        | Writing/editing `model { }` blocks, element hierarchy, relationships, `extend` patterns, property names  |
-| `references/deployment.md`                   | Writing/editing `deployment { }` blocks, `instanceOf`, named instances, multi-environment topology       |
-| `references/style-tokens-colors.md`          | Applying colors, shapes, icons, or relationship line styles; need exact token names                      |
-| `references/views.md`                        | Writing views, include/exclude rules, style rules in views, groups, autoLayout, global predicates        |
-| `references/predicates.md`                   | Complex `where` conditions, `with` overrides, global predicate groups, reusable predicates               |
-| `references/include-predicates-wildcards.md` | Wildcard confusion suspected (`*` vs `_` vs `**`); need exact scoped-view semantics                      |
-| `references/dynamic-views.md`                | Writing dynamic views: steps, return arrows, chained steps, parallel blocks, `variant sequence`          |
-| `references/identifier-validity.md`          | Identifier vs FQN confusion; "dots in names" errors; understanding FQN construction                      |
-| `references/relationships-bidirectional.md`  | Bidirectional relationship syntax and `<->` view predicate patterns                                      |
-| `references/bridge-leanix-drawio.md`         | LeanIX bridge · `drawio --profile leanix` · round-trip · mapping · MCP vs bridge · sync/artifacts/managed cells |
-| `references/cli.md`                          | Full CLI reference: serve, build, export, codegen, mcp, format; flag disambiguation                      |
-| `references/configuration.md`                | Project config options, multi-project setup, include/exclude paths, generators                           |
-| `references/examples.md`                     | Compact real-world examples: extend, groups, globals, dynamic views, deployment, rank                    |
-| `references/troubleshooting.md`              | Errors, unexpected output, eval failures — 6 error tables, 5-step debug workflow, 7 best practices       |
+| File                                         | Purpose — load when...                                                                                                          |
+| -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `references/specification.md`                | Writing/editing `specification { }` blocks, defining element/deploymentNode/relationship/tag/color kinds                        |
+| `references/model.md`                        | Writing/editing `model { }` blocks, element hierarchy, relationships, `extend` patterns, property names                         |
+| `references/deployment.md`                   | Writing/editing `deployment { }` blocks, `instanceOf`, named instances, multi-environment topology, deployment metadata filters |
+| `references/style-tokens-colors.md`          | Applying colors, shapes, icons, or relationship line styles; need exact token names                                             |
+| `references/views.md`                        | Writing views, include/exclude rules, style rules in views, groups, autoLayout, global predicates                               |
+| `references/predicates.md`                   | Complex `where` conditions, metadata filters, `with` overrides, global predicate groups, reusable predicates                    |
+| `references/include-predicates-wildcards.md` | Wildcard confusion suspected (`*` vs `_` vs `**`); need exact scoped-view semantics                                             |
+| `references/dynamic-views.md`                | Writing dynamic views: steps, return arrows, chained steps, parallel blocks, `variant sequence`                                 |
+| `references/identifier-validity.md`          | Identifier vs FQN confusion; "dots in names" errors; understanding FQN construction                                             |
+| `references/relationships-bidirectional.md`  | Bidirectional relationship syntax and `<->` view predicate patterns                                                             |
+| `references/bridge-leanix-drawio.md`         | LeanIX bridge · `drawio --profile leanix` · round-trip · mapping · MCP vs bridge · sync/artifacts/managed cells                 |
+| `references/cli.md`                          | Full CLI reference: serve, build, export, codegen, mcp, format; flag disambiguation                                             |
+| `references/configuration.md`                | Project config options, multi-project setup, include/exclude paths, generators                                                  |
+| `references/examples.md`                     | Compact real-world examples: extend, groups, globals, dynamic views, deployment, rank                                           |
+| `references/troubleshooting.md`              | Errors, unexpected output, eval failures — 6 error tables, 5-step debug workflow, 7 best practices                              |

--- a/skills/likec4-dsl/evals/evals-public.json
+++ b/skills/likec4-dsl/evals/evals-public.json
@@ -162,6 +162,26 @@
       "id": 31,
       "prompt": "Assume existing relationships: `api -[async]-> service 'GetData'`, `api -[sync]-> service 'GetData'`, and `api -[async]-> service 'PostData'`. Classify each matcher as `correct`, `ambiguous`, or `wrong` (one line each): (1) `extend api -[async]-> service 'GetData' { metadata { timeout '5s' } }`; (2) `extend api -[async]-> service { metadata { timeout '5s' } }`; (3) `extend api -> service 'GetData' { metadata { timeout '5s' } }`. After classification lines, provide the single exact unambiguous extension snippet.",
       "files": []
+    },
+    {
+      "id": 32,
+      "prompt": "Assume these relationships already exist: `client -> api 'call' { metadata { protocol 'https' } }` and `api -> db 'write' { metadata { protocol 'http' } }`. Show a minimal view that includes all relationships but excludes only relationships whose own metadata has `protocol` equal to `http`. Use `metadata.protocol`, not `source.metadata` or `target.metadata`.",
+      "files": []
+    },
+    {
+      "id": 33,
+      "prompt": "Assume `api` has `metadata { zone 'public' }`, `db` has `metadata { zone 'restricted' }`, and relationships already connect them. Show a minimal view that includes all relationships but excludes relationships whose target element metadata has `zone` equal to `restricted`. Use an endpoint metadata filter.",
+      "files": []
+    },
+    {
+      "id": 34,
+      "prompt": "In a deployment view, logical `api` has `metadata { zone 'model-public' }`; one deployed `api` instance has no metadata, and another deployed `api` instance has `metadata { zone 'instance-private' }`. For relationship filters using `where source.metadata.zone is ...`, state which metadata value each instance uses and give one sentence with the deployment metadata rule. Be explicit about fallback versus replacement.",
+      "files": []
+    },
+    {
+      "id": 35,
+      "prompt": "Show one minimal element view that keeps only services with array metadata `regions` containing `eu` and then removes any included element without an `owner` metadata key. Use `metadata.regions is \"eu\"` and `not metadata.owner` exactly.",
+      "files": []
     }
   ]
 }

--- a/skills/likec4-dsl/evals/grading-spec.json
+++ b/skills/likec4-dsl/evals/grading-spec.json
@@ -452,6 +452,55 @@
         "The final snippet includes metadata field `timeout '5s'`."
       ],
       "grading_guidance": "Prioritize matcher-identity reasoning (source/target/kind/title). Answers that call (2) fully correct or call (3) acceptable should lose clearly, even if they provide a plausible final snippet."
+    },
+    {
+      "id": 32,
+      "expected_output": "The response provides a minimal view with `include * -> *` followed by `exclude * -> * where metadata.protocol is \"http\"` (quote style may vary), and it treats `metadata.protocol` as relationship-own metadata rather than endpoint metadata.",
+      "files": [],
+      "expectations": [
+        "The snippet includes all relationships with a relationship predicate such as `include * -> *`.",
+        "The exclusion uses `exclude * -> * where metadata.protocol is \"http\"` or an equivalent multi-line form.",
+        "The response does not use `source.metadata.protocol` or `target.metadata.protocol` for this own-relationship metadata case.",
+        "The response is primarily a usable LikeC4 view snippet."
+      ],
+      "grading_guidance": "The distinction between relationship metadata and endpoint metadata is the main signal. Do not give full credit if the answer filters `source.metadata` or `target.metadata` when the prompt explicitly asks for the relationship's own metadata."
+    },
+    {
+      "id": 33,
+      "expected_output": "The response provides a minimal view with `include * -> *` followed by `exclude * -> * where target.metadata.zone is \"restricted\"` (quote style may vary), using endpoint metadata on the target.",
+      "files": [],
+      "expectations": [
+        "The snippet includes relationships before excluding from them.",
+        "The exclusion uses `target.metadata.zone is \"restricted\"` or an equivalent multi-line form.",
+        "The response uses endpoint metadata rather than relationship-own `metadata.zone`.",
+        "The response is primarily a usable LikeC4 view snippet."
+      ],
+      "grading_guidance": "The target endpoint qualifier is required. Answers that use unqualified `metadata.zone` are filtering the relationship itself and should lose clearly."
+    },
+    {
+      "id": 34,
+      "expected_output": "The response states that the deployed instance without metadata falls back to logical metadata value `model-public`, while the instance with metadata uses `instance-private` and replaces the logical metadata for predicate filtering. It includes one clear rule sentence distinguishing fallback from replacement.",
+      "files": [],
+      "expectations": [
+        "The no-instance-metadata case uses `model-public`.",
+        "The instance-metadata case uses `instance-private`.",
+        "The response explicitly says instance metadata replaces logical element metadata when present.",
+        "The response explicitly says logical element metadata is used as fallback when the deployed instance has no metadata.",
+        "The rule is framed for deployment-view relationship endpoint filters such as `source.metadata.zone`."
+      ],
+      "grading_guidance": "Do not accept answers that claim deployment metadata merges key-by-key with logical metadata. The key contrast is fallback when absent versus replacement when present."
+    },
+    {
+      "id": 35,
+      "expected_output": "The response provides one minimal element view using `include * where kind is service and metadata.regions is \"eu\"` (or equivalent ordering) and `exclude * where not metadata.owner`.",
+      "files": [],
+      "expectations": [
+        "The view includes services using `kind is service`.",
+        "The include filter uses `metadata.regions is \"eu\"` to express array containment.",
+        "The view removes elements missing owner metadata with `exclude * where not metadata.owner`.",
+        "The response provides one minimal view snippet rather than prose-only guidance."
+      ],
+      "grading_guidance": "The eval checks both array containment syntax and missing-key syntax. Accept equivalent line breaks and quote style, but not invented operators such as `contains` or `exists`."
     }
   ],
   "default_execution_checks": [

--- a/skills/likec4-dsl/references/deployment.md
+++ b/skills/likec4-dsl/references/deployment.md
@@ -3,10 +3,13 @@
 The `deployment` block maps logical model elements to physical infrastructure nodes using `instanceOf`. It uses `deploymentNode` kinds from the specification.
 
 **Key rules:**
+
 - Deployment inherits ALL relationships from the logical model automatically.
 - Additional deployment-level relationships can be defined inline (same syntax as in model).
 - Use named instances (`id = instanceOf ELEMENT`) when multiple instances of the same element exist within the same deployment node.
 - Anonymous `instanceOf ELEMENT` (no name) is fine when there is only one instance per node.
+- In deployment-view filters, instance tags are cumulative with logical element tags.
+- In deployment-view filters, instance metadata replaces logical element metadata when present; otherwise logical metadata is the fallback.
 
 ## Syntax
 
@@ -99,11 +102,36 @@ deployment {
 }
 ```
 
+## Deployment View Filtering
+
+Deployment views use normal `where` filters, with deployment-aware endpoint values:
+
+- Deployment instance tags = logical element tags + instance tags.
+- Deployment instance kind = logical element kind.
+- Deployment instance metadata replaces logical metadata as a whole when present, otherwise logical metadata is the fallback.
+- Nested children of a deployed instance use the logical child tags, kind, and metadata.
+- Deployment node tags, kind, and metadata come from the deployment model.
+- Tags are not inherited from parent deployment nodes.
+
+Relationship endpoint filters use those same rules:
+
+```likec4
+views {
+  deployment view prod {
+    include * -> *
+    exclude * -> *
+      where target.metadata.zone is "restricted"
+  }
+}
+```
+
+Use unqualified `metadata.*` for the relationship's own metadata; use `source.metadata.*` or `target.metadata.*` for endpoint metadata.
+
 ## Named vs. Anonymous: When It Matters
 
-| Scenario | Use |
-|---|---|
-| Single instance of element in node | Anonymous: `instanceOf cloud.api` |
-| Multiple instances of same element in same node | Named: `primary = instanceOf cloud.api` |
-| Strict eval requires named instance identifier | Named: `IDENTIFIER = instanceOf ELEMENT` |
-| Deployment view needs to distinguish replicas | Named: each gets a unique node in the diagram |
+| Scenario                                        | Use                                           |
+| ----------------------------------------------- | --------------------------------------------- |
+| Single instance of element in node              | Anonymous: `instanceOf cloud.api`             |
+| Multiple instances of same element in same node | Named: `primary = instanceOf cloud.api`       |
+| Strict eval requires named instance identifier  | Named: `IDENTIFIER = instanceOf ELEMENT`      |
+| Deployment view needs to distinguish replicas   | Named: each gets a unique node in the diagram |

--- a/skills/likec4-dsl/references/dynamic-views.md
+++ b/skills/likec4-dsl/references/dynamic-views.md
@@ -131,6 +131,7 @@ dynamic view with-notes {
 ```
 
 **Available properties inside step body:**
+
 - `title` — alternative or longer title
 - `technology` — technology/protocol used
 - `description` — detailed description
@@ -181,12 +182,12 @@ dynamic view checkout-sequence {
 
 ### Comparing flow vs. sequence rendering
 
-| Aspect | Flow Diagram | Sequence Diagram (variant sequence) |
-|--------|--------------|-------------------------------------|
-| Layout | Left-to-right or top-down flow | Top-to-bottom lifelines |
-| Return arrows | Style varies | Dashed lines standard |
-| Parallel feel | Horizontal alignment | Time-based with spacing |
-| Best for | System interactions | Message exchange protocols |
+| Aspect        | Flow Diagram                   | Sequence Diagram (variant sequence) |
+| ------------- | ------------------------------ | ----------------------------------- |
+| Layout        | Left-to-right or top-down flow | Top-to-bottom lifelines             |
+| Return arrows | Style varies                   | Dashed lines standard               |
+| Parallel feel | Horizontal alignment           | Time-based with spacing             |
+| Best for      | System interactions            | Message exchange protocols          |
 
 ## Response Arrow Patterns (exactness)
 
@@ -262,27 +263,27 @@ dynamic view payment-decision {
 
 ## Anti-Patterns to Avoid
 
-| Anti-pattern | Problem | Solution |
-|---|---|---|
-| Nested `parallel { parallel { ... } }` | Syntax error; flatten as required | Put all concurrent steps in one `parallel {}` |
-| Chaining inside `parallel` | Ambiguous timing | Move chains to separate sequential steps |
-| Too many steps in one view | Diagram becomes unreadable | Split into sub-views with `navigateTo` |
-| Using `<-` for side-by-side actions | Implies return; violates sequence semantics | Use forward `->` or group with `parallel` |
-| Forgetting `variant sequence` when UML needed | Wrong rendering | Add `variant sequence` if sequence diagram required |
+| Anti-pattern                                  | Problem                                     | Solution                                            |
+| --------------------------------------------- | ------------------------------------------- | --------------------------------------------------- |
+| Nested `parallel { parallel { ... } }`        | Syntax error; flatten as required           | Put all concurrent steps in one `parallel {}`       |
+| Chaining inside `parallel`                    | Ambiguous timing                            | Move chains to separate sequential steps            |
+| Too many steps in one view                    | Diagram becomes unreadable                  | Split into sub-views with `navigateTo`              |
+| Using `<-` for side-by-side actions           | Implies return; violates sequence semantics | Use forward `->` or group with `parallel`           |
+| Forgetting `variant sequence` when UML needed | Wrong rendering                             | Add `variant sequence` if sequence diagram required |
 
 ## Predicate Filters in Dynamic Views
 
-Dynamic views do **not** directly support predicate filtering like element views do. Instead:
+Dynamic views do not use predicates to generate or filter interaction steps. Steps must be listed explicitly.
 
-1. **Explicitly list steps** — name each source and target.
-2. **Use tags/metadata for filtering decisions** — in notes or documentation.
-3. **Create separate flows** for different subsets of elements.
+You may still use normal include predicates to add context elements that do not participate in steps:
 
 ```likec4
 dynamic view critical-flow {
-  // Only include critical services (documented in spec)
   frontend -> api "request"
   api -> db "query"
+
+  include cloud.* where tag is #critical
+  include cloud.* where metadata.region is "eu"
 }
 
 dynamic view with-cache {
@@ -297,6 +298,7 @@ dynamic view with-cache {
 Full LikeC4 dynamic view docs: https://likec4.dev/dsl/views/dynamic/
 
 Common scenarios:
+
 - **Authentication flow** — customer → login → auth-service → database
 - **CQRS pattern** — command → service → write-db (parallel: query-handler → read-db)
 - **Webhook callback** — external-system → api (parallel within with navigateTo service-webhook-handler)

--- a/skills/likec4-dsl/references/examples.md
+++ b/skills/likec4-dsl/references/examples.md
@@ -226,8 +226,10 @@ views {
     // By metadata
     include cloud.* where metadata.region is "eu"
 
-    // Relationship filtering
+    // Relationship filtering, including own vs endpoint metadata
     include cloud.* -> amazon.* where source.tag is #critical
+    exclude * -> * where metadata.protocol is "http"
+    exclude * -> * where target.metadata.zone is "restricted"
 
     // Wildcard with expansion
     include cloud._                  // direct children only

--- a/skills/likec4-dsl/references/predicates.md
+++ b/skills/likec4-dsl/references/predicates.md
@@ -6,7 +6,7 @@ Predicates are view rules that define what elements and relationships to include
 - Element predicates - used to select elements
 - Relationship predicates - used to select relationships
 - Filter predicates - used to apply filters to element and relationship predicates
-- Custom predicates - used to override properties of elements/relationships (can be used with `include` only)'
+- Custom predicates - used to override properties of elements/relationships (can be used with `include` only)
 
 Syntax:
 
@@ -46,47 +46,7 @@ Expressions inside `exclude` clause match against the accumulated result of prev
 - `<element_ref>._` - selects direct children of `<element_ref>` that have relationships with accumulated result
 - `<element_ref>.**` - selects **all recursive descendants** of `<element_ref>` that have relationships with accumulated result
 
-#### Wildcard depth selectors: `*` vs `**`
-
-Understanding the difference between `*` and `**` is crucial for correct view scoping:
-
-| Selector | Meaning | Example | Result |
-|----------|---------|---------|--------|
-| `*` | Direct children **only** (1 level) | `parent.*` | Selects immediate children of parent |
-| `**` | All descendants (recursive, all levels) | `parent.**` | Selects children, grandchildren, and all nested elements |
-
-```likec4
-// Example model structure:
-// backend
-//   ├── api (service)
-//   │   └── handlers (component)
-//   │       └── authHandler
-//   └── db (database)
-
-views {
-  // Selects ONLY: api, db (direct children of backend)
-  view direct-only {
-    include backend.*
-  }
-
-  // Selects: api, db, handlers, authHandler (all descendants)
-  view all-descendants {
-    include backend.**
-  }
-
-  // ❌ Common mistake: expecting * to include nested elements
-  view wrong-expectation {
-    include backend.*        // This does NOT include handlers or authHandler!
-    style backend.handlers { color red }  // handlers won't be styled
-  }
-
-  // ✅ Correct: use ** when you need all nested elements
-  view correct {
-    include backend.**       // Includes everything under backend
-    style backend.handlers { color red }  // Now handlers IS included
-  }
-}
-```
+For detailed wildcard edge cases (`*` vs `_` vs `**`), load `references/include-predicates-wildcards.md`.
 
 ### Wildcard expression
 
@@ -112,20 +72,36 @@ If expression matches, predicate adds matched relationships together with matchi
 
 After expression is evaluated and selected elements/relationships, filter conditions are applied to refine the selection.
 
-By tag: `* where tag is #primary` or `* where tag is not #primary`
-By kind: `* where kind is component` or `* where kind is not component`
+Core filters:
 
-Complex:
+- Tags: `* where tag is #primary` / `* where tag is not #primary`
+- Kind: `* where kind is component` / `* where kind is not component`
+- Metadata value: `* where metadata.region is "eu"`
+- Missing metadata key: `* where not metadata.owner`
+- Arrays: `metadata.regions is "eu"` matches if the array contains `"eu"`
+- Booleans: `metadata.critical is true`
+- Combine with `and`, `or`, and parentheses
 
-- `* where kind is component and tag is #primary`
-- `* where (tag is #primary or tag is #secondary) and kind is component`
+For relationship expressions:
 
-If filter applies to relationship expressions, you can filter source/target elements:
+- `* -> * where tag is #http` - relationship tag
+- `* -> * where metadata.protocol is "grpc"` - relationship metadata
+- `* -> * where source.tag is #primary` - source element tag
+- `* -> * where target.kind is component` - target element kind
+- `* -> * where source.metadata.zone is "public"` - source element metadata
+- `* -> * where target.metadata.zone is "restricted"` - target element metadata
 
-- `* -> * where tag is #http` - filters relationships by tag
-- `* -> * where source.tag is #primary` - filters relationships by tag on source element
-- `* -> * where target.tag is #primary` - filters relationships by tag on target element
-- `* -> * where source.kind is component or target.kind is component` - filters relationships by source or target kind
+The same filters work in `exclude`, for example:
+
+```likec4
+exclude * where not metadata.owner
+exclude * -> * where metadata.protocol is "http"
+exclude * -> * where target.metadata.zone is "restricted"
+```
+
+Use the same `where` forms with `include`.
+
+In deployment views, instance tags are cumulative; instance metadata replaces logical metadata as a whole when present, otherwise logical metadata is the fallback.
 
 ## Customize Predicates
 

--- a/skills/likec4-dsl/references/views.md
+++ b/skills/likec4-dsl/references/views.md
@@ -227,6 +227,7 @@ Parallel blocks can be nested and mixed with sequential steps.
 The `variant sequence` keyword renders the dynamic view as a UML sequence diagram. This is especially useful for API call sequences and protocol flows.
 
 **Key syntax points:**
+
 - Use `variant sequence` at the start of the dynamic view block
 - Use `->` for forward/call direction
 - Use `<-` for backward/return direction (not `->` with different semantics)
@@ -248,6 +249,7 @@ dynamic view api-sequence {
 ```
 
 **Common mistake:** Using `->` for returns instead of `<-`. The arrow direction indicates message flow:
+
 - `a -> b` means "a sends to b" (request/call)
 - `a <- b` means "b sends to a" (response/return)
 
@@ -269,7 +271,7 @@ dynamic view correct {
 
 ## Include in Dynamic Views
 
-Dynamic views support the same predicates as element views, used to add context elements that don't participate in steps:
+Dynamic views support element-view predicates for context elements that do not participate in steps. Predicates do not generate or filter the step sequence itself.
 
 ```likec4
 dynamic view flow {


### PR DESCRIPTION
## Summary

- Fix deployment relationship metadata filters so `source.metadata.*` and `target.metadata.*` use deployed instance metadata when present, with logical metadata as fallback.
- Add focused coverage for metadata-based `exclude` rules in element and deployment views, including relationship metadata, endpoint metadata, arrays, and missing keys.
- Update the user docs and the `likec4-dsl` AI skill/evals so agents explain relationship metadata filters and deployment metadata semantics correctly.

## Root cause

Deployment model-backed relationship filters resolved endpoint metadata from the logical model element only, so deployment-specific instance metadata was ignored for `source.metadata.*` and `target.metadata.*` predicates.

## Screenshots

### View predicates docs

| Before | After |
| --- | --- |
| ![predicates-before.png](https://github.com/user-attachments/assets/33cbbce1-70d6-4bc9-9cf1-5ba0ed8e0a16) | ![predicates-after.png](https://github.com/user-attachments/assets/041bf9a6-9326-4cd9-946b-71fed2ccefc8) |

### Deployment views docs

| Before | After |
| --- | --- |
| ![deployment-before.png](https://github.com/user-attachments/assets/fba212fb-3de0-4dd6-8b31-4f3409eae7f6) | ![deployment-after.png](https://github.com/user-attachments/assets/5f6647ae-9d9d-4063-8dd1-ac24959568c2) |

## Validation

- `node_modules/.bin/vitest run packages/core/src/compute-view/element-view/exclude-where.spec.ts packages/core/src/compute-view/deployment-view/predicates/__test__/exclude-metadata.filter.spec.ts --no-isolate`
- `node_modules/.bin/vitest run packages/core/src/compute-view/element-view packages/core/src/compute-view/deployment-view --no-isolate`
- `node_modules/.bin/tsc -b packages/core/tsconfig.json --pretty false`
- `node_modules/.bin/astro check` from `apps/docs`
- `node_modules/.bin/nano-staged`
- `node_modules/.bin/dprint check` for the changed `skills/likec4-dsl` files
- Skill eval sanity: 36 public/grading eval pairs matched, with no hidden grading fields leaked into `evals-public.json`
- Matching external skill benchmark harness self-test passed for the `likec4-dsl` eval artifacts
- Opened the updated docs pages locally and captured before/after screenshots
