### PR TITLE
fix(diagram): expose diagram text to screen readers

### DIFF
--- a/.changeset/fix-diagram-screen-reader-labels.md
+++ b/.changeset/fix-diagram-screen-reader-labels.md
@@ -1,0 +1,5 @@
+---
+'@likec4/diagram': patch
+---
+
+Fixes [#2988](https://github.com/likec4/likec4/issues/2988): diagrams now expose LikeC4 node and relationship text to assistive technologies and allow focused nodes and relationships to be activated from the keyboard.

--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -21,6 +21,7 @@ tests/*.spec.ts
 !tests/markdown-image.spec.ts
 !tests/manual-layout-views.spec.ts
 !tests/webcomponent-overlay.spec.ts
+!tests/diagram-a11y.spec.ts
 
 pnpm-lock.yaml
 package-lock.json

--- a/e2e/tests/diagram-a11y.spec.ts
+++ b/e2e/tests/diagram-a11y.spec.ts
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import { expect, test } from '@playwright/test'
+import { canvas } from '../helpers/selectors'
+import { TIMEOUT_CANVAS } from '../helpers/timeouts'
+
+const PROJECT = 'e2e'
+const VIEW = 'index'
+
+function exportUrl(viewId: string): string {
+  return `/project/${encodeURIComponent(PROJECT)}/export/${encodeURIComponent(viewId)}/?padding=22`
+}
+
+function viewUrl(viewId: string): string {
+  return `/project/${encodeURIComponent(PROJECT)}/view/${encodeURIComponent(viewId)}/`
+}
+
+test.describe('Diagram accessibility (#2988)', () => {
+  test('exposes LikeC4 node and relationship text to the accessibility tree', async ({ page }) => {
+    await page.goto(exportUrl(VIEW))
+    await expect(canvas(page)).toBeVisible({ timeout: TIMEOUT_CANVAS })
+
+    const customer = page.locator('.react-flow__node[data-id="customer"]')
+    await expect(customer).toHaveAttribute('tabindex', '0')
+    await expect(customer).toHaveAttribute('aria-label', /Cloud System Customer/)
+    await expect(customer).toHaveAttribute('aria-label', /The regular customer/)
+
+    // The composed aria-label is the single source of the node's text. The
+    // decorative shape/icon and the visible title/description are hidden from
+    // assistive tech, so they must not reappear as separate nodes in the tree
+    // (otherwise a screen reader announces the text twice). This is the export
+    // view, so the node has no interactive action buttons — keyboard reach of
+    // those buttons is covered by the activation tests below.
+    const customerTree = await customer.ariaSnapshot()
+    expect(customerTree).not.toMatch(/^\s*- text:/m)
+    expect(customerTree).not.toMatch(/^\s*- paragraph:/m)
+
+    const relationship = page.locator('.react-flow__edge[data-id="kzb1r3"]')
+    await expect(relationship).toHaveAttribute('tabindex', '0')
+    await expect(relationship).toHaveAttribute('aria-label', /Relationship from/)
+    await expect(relationship).toHaveAttribute('aria-label', /Cloud System Customer/)
+
+    const snapshot = await canvas(page).ariaSnapshot()
+    await test.info().attach('diagram-a11y-snapshot', {
+      body: snapshot,
+      contentType: 'text/yaml',
+    })
+    expect(snapshot).toContain('Cloud System Customer')
+    expect(snapshot).toContain('Relationship from')
+  })
+
+  for (const key of ['Enter', 'Space']) {
+    test(`activates a focused relationship with ${key}`, async ({ page }) => {
+      await page.goto(viewUrl(VIEW))
+      await expect(canvas(page)).toBeVisible({ timeout: TIMEOUT_CANVAS })
+
+      const relationship = page.locator('.react-flow__edge[data-id="kzb1r3"]')
+      await relationship.focus()
+      await page.keyboard.press(key)
+
+      await expect(page.getByText('DIRECT RELATIONSHIPS')).toBeVisible()
+    })
+  }
+
+  for (const key of ['Enter', 'Space']) {
+    test(`navigates from a focused node action with ${key}`, async ({ page }) => {
+      await page.goto(viewUrl(VIEW))
+      await expect(canvas(page)).toBeVisible({ timeout: TIMEOUT_CANVAS })
+
+      const cloud = page.locator('.react-flow__node[data-id="cloud"]')
+      await cloud.focus()
+      await page.keyboard.press(key)
+
+      const navigateButton = cloud.getByRole('button', { name: 'Navigate to view' })
+      await expect(navigateButton).toBeVisible()
+      await page.keyboard.press('Tab')
+      await expect(navigateButton).toBeFocused()
+      await page.keyboard.press(key)
+
+      await expect(page).toHaveURL(/\/project\/e2e\/view\/cloud\//)
+      await expect(canvas(page)).toBeVisible({ timeout: TIMEOUT_CANVAS })
+    })
+  }
+})

--- a/e2e/tests/markdown-image.spec.ts
+++ b/e2e/tests/markdown-image.spec.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { expect, test } from '@playwright/test'
 import { canvas } from '../helpers/selectors'
 import { TIMEOUT_CANVAS } from '../helpers/timeouts'
@@ -13,8 +20,11 @@ test('markdown image in description renders in element details (#2505)', async (
   await page.goto('/project/e2e/view/index/')
   await expect(canvas(page)).toBeVisible({ timeout: TIMEOUT_CANVAS })
 
-  // Click the cloud node's details button
-  await page.locator('[data-id="cloud"] .details-button button').click()
+  const cloud = page.locator('[data-id="cloud"]')
+  await cloud.hover()
+  const detailsButton = cloud.getByRole('button', { name: 'Open details' })
+  await detailsButton.focus()
+  await page.keyboard.press('Enter')
 
   // Wait for the element details dialog
   const dialog = page.locator('dialog[open]')

--- a/e2e/tests/static-build-relationship-popover.spec.ts
+++ b/e2e/tests/static-build-relationship-popover.spec.ts
@@ -24,5 +24,6 @@ test('static build embed pages show relationship popup on edge hover (#2962)', a
   await relationship.hover()
 
   await expect(page.getByText(RELATIONSHIP_POPOVER_TEXT)).toBeVisible()
-  await expect(page.getByRole('button', { name: /browse relationships/i })).toBeVisible()
+  await expect(page.getByRole('button', { name: /^browse relationships$/i })).toHaveCount(1)
+  await expect(page.getByRole('button', { name: /^browse relationships$/i })).toBeVisible()
 })

--- a/packages/diagram/src/LikeC4Diagram.props.ts
+++ b/packages/diagram/src/LikeC4Diagram.props.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import type * as t from '@likec4/core/types'
 import type {
   DiagramEdge,
@@ -65,6 +72,7 @@ export type OverrideReactFlowProps = Pick<
   | 'panOnScrollMode'
   | 'zoomOnDoubleClick'
   | 'nodeDragThreshold'
+  | 'edgesFocusable'
 >
 
 export type PaddingUnit = 'px' | '%'

--- a/packages/diagram/src/base-primitives/compound/CompoundActionButton.tsx
+++ b/packages/diagram/src/base-primitives/compound/CompoundActionButton.tsx
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { cx } from '@likec4/styles/css'
 import { actionBtn } from '@likec4/styles/recipes'
 import { ActionIcon } from '@mantine/core'
@@ -13,6 +20,7 @@ import { compoundActionBtn } from './actionbtns.css'
 type CompoundActionButtonProps = Simplify<
   BaseNodeProps & {
     icon?: ReactNode
+    ariaLabel?: string
     onClick: (e: ReactMouseEvent) => void
   }
 >
@@ -39,15 +47,18 @@ const variants = {
 }
 
 export function CompoundActionButton({
+  selected = false,
   data: {
     hovered: isHovered = false,
   },
   icon,
+  ariaLabel = 'Navigate to view',
   onClick,
 }: CompoundActionButtonProps) {
   // Debounce first "isHovered"
   const debounced = useDebouncedValue(isHovered, isHovered ? 130 : 0)
   const isHoverDebounced = debounced[0] && isHovered
+  const isActionVisible = selected || isHoverDebounced
 
   let variant: keyof typeof variants = isHoverDebounced ? 'hovered' : 'normal'
 
@@ -70,7 +81,9 @@ export function CompoundActionButton({
           }),
           actionBtn({ variant: 'transparent' }),
         )}
-        tabIndex={-1}
+        tabIndex={isActionVisible ? 0 : -1}
+        inert={isActionVisible ? undefined : true}
+        aria-label={ariaLabel}
         // Otherwise node receives click event and is selected
         onClick={onClick}
         onDoubleClick={stopPropagation}

--- a/packages/diagram/src/base-primitives/compound/CompoundDetailsButton.tsx
+++ b/packages/diagram/src/base-primitives/compound/CompoundDetailsButton.tsx
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { cx } from '@likec4/styles/css'
 import { actionBtn } from '@likec4/styles/recipes'
 import { ActionIcon } from '@mantine/core'
@@ -13,6 +20,7 @@ import { compoundActionBtn } from './actionbtns.css'
 type CompoundDetailsButtonProps = Simplify<
   BaseNodeProps & {
     icon?: ReactNode
+    ariaLabel?: string
     onClick: (e: ReactMouseEvent) => void
   }
 >
@@ -35,15 +43,18 @@ const variants = {
 }
 
 export function CompoundDetailsButton({
+  selected = false,
   data: {
     hovered: isHovered = false,
   },
   icon,
+  ariaLabel = 'Open details',
   onClick,
 }: CompoundDetailsButtonProps) {
   // Debounce first "isHovered"
   const debounced = useDebouncedValue(isHovered, isHovered ? 130 : 0)
   const isHoverDebounced = debounced[0] && isHovered
+  const isActionVisible = selected || isHoverDebounced
 
   const variant: keyof typeof variants = isHoverDebounced ? 'hovered' : 'normal'
 
@@ -65,7 +76,9 @@ export function CompoundDetailsButton({
           }),
           actionBtn({ variant: 'transparent' }),
         )}
-        tabIndex={-1}
+        tabIndex={isActionVisible ? 0 : -1}
+        inert={isActionVisible ? undefined : true}
+        aria-label={ariaLabel}
         onClick={onClick}
         onDoubleClick={stopPropagation}>
         {icon ?? <IconId stroke={1.8} style={{ width: '75%' }} />}

--- a/packages/diagram/src/base-primitives/compound/CompoundTitle.tsx
+++ b/packages/diagram/src/base-primitives/compound/CompoundTitle.tsx
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import type { Color, ComputedNodeStyle, NodeId } from '@likec4/core/types'
 import { IconRenderer } from '../../context/IconRenderer'
 
@@ -11,16 +18,22 @@ type RequiredData = {
 
 type CompoundTitleProps = {
   data: RequiredData
+  /**
+   * Opt-in: hide the title from assistive technologies. The main diagram sets
+   * this because the compound node's accessible label already conveys the
+   * title, so re-exposing it here would cause a duplicate announcement.
+   */
+  'aria-hidden'?: boolean | undefined
 }
 
-export function CompoundTitle({ data }: CompoundTitleProps) {
+export function CompoundTitle({ data, 'aria-hidden': ariaHidden }: CompoundTitleProps) {
   const elementIcon = IconRenderer({
     element: data,
     className: 'likec4-compound-icon',
   })
 
   return (
-    <div className={'likec4-compound-title-container'}>
+    <div className={'likec4-compound-title-container'} aria-hidden={ariaHidden}>
       {elementIcon}
       <div className={'likec4-compound-title'}>
         {data.title}

--- a/packages/diagram/src/base-primitives/edge/EdgeActionButton.tsx
+++ b/packages/diagram/src/base-primitives/edge/EdgeActionButton.tsx
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { cx } from '@likec4/styles/css'
 import { edgeActionBtn } from '@likec4/styles/recipes'
 import { ActionIcon } from '@mantine/core'
@@ -7,16 +14,18 @@ import { stopPropagation } from '../../utils/xyflow'
 
 type EdgeActionBtnProps = {
   icon?: ReactNode
+  ariaLabel?: string
   onClick: (e: ReactMouseEvent) => void
 }
 
-export function EdgeActionButton({ icon, onClick }: EdgeActionBtnProps) {
+export function EdgeActionButton({ icon, ariaLabel = 'Navigate to view', onClick }: EdgeActionBtnProps) {
   return (
     <ActionIcon
       className={cx('nodrag nopan', edgeActionBtn())}
       onPointerDownCapture={stopPropagation}
       onClick={onClick}
       role="button"
+      aria-label={ariaLabel}
       onDoubleClick={stopPropagation}
     >
       {icon ?? <IconZoomScan />}

--- a/packages/diagram/src/base-primitives/element/ElementActionButtons.tsx
+++ b/packages/diagram/src/base-primitives/element/ElementActionButtons.tsx
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { cx } from '@likec4/styles/css'
 import { actionBtn, actionButtons } from '@likec4/styles/recipes'
 import { ActionIcon } from '@mantine/core'
@@ -84,6 +91,7 @@ export function ElementActionButtons({
     default:
       variant = 'normal'
   }
+  const isActionVisible = isHovered || selected
 
   return (
     <div className={actionButtons()}>
@@ -108,7 +116,9 @@ export function ElementActionButtons({
             whileHover={{
               scale: 1.3,
             }}
-            tabIndex={-1}
+            tabIndex={isActionVisible ? 0 : -1}
+            inert={isActionVisible ? undefined : true}
+            aria-label={button.ariaLabel ?? button.key ?? 'Element action'}
             onClick={button.onClick}
             // Otherwise node receives click event and is selected
             onDoubleClick={stopPropagation}
@@ -124,6 +134,7 @@ export function ElementActionButtons({
 export namespace ElementActionButtons {
   export type Item = {
     key?: string
+    ariaLabel?: string
     icon?: ReactNode
     onClick: (e: ReactMouseEvent) => void
   }

--- a/packages/diagram/src/base-primitives/element/ElementData.tsx
+++ b/packages/diagram/src/base-primitives/element/ElementData.tsx
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import type { ComputedNodeStyle, MarkdownOrString, NodeId } from '@likec4/core'
 import type { ColorLiteral, LikeC4Styles } from '@likec4/core/styles'
 import { type Color, RichText } from '@likec4/core/types'
@@ -216,9 +223,14 @@ const Description = forwardRef<
  * </ElementData.Root>
  * ```
  */
-export function ElementData({ data }: ElementDataProps) {
+export function ElementData(
+  { data, 'aria-hidden': ariaHidden }: ElementDataProps & { 'aria-hidden'?: boolean | undefined },
+) {
   return (
-    <Root data={data}>
+    // `aria-hidden` is opt-in: the main diagram passes it because the node's
+    // accessible label already conveys this text, so re-exposing the visible
+    // title/description/icon would make a screen reader announce it twice.
+    <Root data={data} aria-hidden={ariaHidden}>
       <Icon data={data} />
       <Content>
         <Title data={data} />

--- a/packages/diagram/src/base-primitives/element/ElementDetailsButton.tsx
+++ b/packages/diagram/src/base-primitives/element/ElementDetailsButton.tsx
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { css, cx } from '@likec4/styles/css'
 import { Box } from '@likec4/styles/jsx'
 import { actionBtn } from '@likec4/styles/recipes'
@@ -12,6 +19,7 @@ type ElementDetailsButtonProps = {
   selected?: boolean
   data: BaseNodeData
   icon?: ReactNode
+  ariaLabel?: string
   onClick: (e: ReactMouseEvent) => void
 }
 
@@ -74,6 +82,7 @@ export function ElementDetailsButton({
     hovered: isHovered = false,
   },
   icon,
+  ariaLabel = 'Open details',
   onClick,
 }: ElementDetailsButtonProps) {
   let variant: keyof typeof variants
@@ -87,6 +96,7 @@ export function ElementDetailsButton({
     default:
       variant = 'normal'
   }
+  const isActionVisible = isHovered || selected
   return (
     <Box className={cx(container, 'details-button')}>
       <ActionIcon
@@ -102,7 +112,9 @@ export function ElementDetailsButton({
         whileTap="whileTap"
         onClick={onClick}
         onDoubleClick={stopPropagation}
-        tabIndex={-1}
+        tabIndex={isActionVisible ? 0 : -1}
+        inert={isActionVisible ? undefined : true}
+        aria-label={ariaLabel}
       >
         {icon ?? <IconId stroke={1.8} style={{ width: '75%' }} />}
       </ActionIcon>

--- a/packages/diagram/src/base-primitives/element/ElementShape.tsx
+++ b/packages/diagram/src/base-primitives/element/ElementShape.tsx
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { nonexhaustive } from '@likec4/core'
 import type { ComputedNodeStyle, ElementShape, ShapeSize } from '@likec4/core/types'
 import { elementShapeRecipe } from '@likec4/styles/recipes'
@@ -368,9 +375,13 @@ export function ElementShape(
   const borderStyle = data.style?.border ?? 'none'
   const withBorder = borderStyle !== 'none'
 
+  // The shape is purely decorative — the node's text is exposed through its
+  // accessible label, so hide the shape from assistive technologies to avoid
+  // announcing it as an unlabeled image.
   if (data.shape === 'rectangle') {
     return (
       <div
+        aria-hidden
         style={{
           borderStyle,
         }}
@@ -393,11 +404,11 @@ export function ElementShape(
   return (
     <>
       {isMultiple && (
-        <svg className={className} data-likec4-shape-multiple="true" viewBox={`0 0 ${w} ${h}`}>
+        <svg aria-hidden className={className} data-likec4-shape-multiple="true" viewBox={`0 0 ${w} ${h}`}>
           <ShapeSvg shape={data.shape} size={data.style?.size} w={w} h={h} />
         </svg>
       )}
-      <svg className={className} viewBox={`0 0 ${w} ${h}`}>
+      <svg aria-hidden className={className} viewBox={`0 0 ${w} ${h}`}>
         <ShapeSvgOutline shape={data.shape} w={w} h={h} />
         <ShapeSvg shape={data.shape} size={data.style?.size} w={w} h={h} />
       </svg>

--- a/packages/diagram/src/base/BaseXYFlow.tsx
+++ b/packages/diagram/src/base/BaseXYFlow.tsx
@@ -27,6 +27,58 @@ import { MaxZoom, MinZoom } from './const'
 import { getKeyboardZoomAction } from './keyboardZoom'
 import type { BaseEdge, BaseNode } from './types'
 
+// React Flow renders a single, shared description element that every node (and
+// every edge) references via `aria-describedby`, so this wording must hold for
+// any focusable element. Enter/Space always selects the focused element and
+// reveals its contextual actions; per-element `aria-label`s describe what those
+// actions do (e.g. "Opens view ...").
+const likec4AriaLabelConfig = {
+  'node.a11yDescription.default': 'Press Enter or Space to select this node and reveal its actions.',
+  'node.a11yDescription.keyboardDisabled': 'Keyboard activation is disabled.',
+  'edge.a11yDescription.default': 'Press Enter or Space to select this relationship and reveal its actions.',
+}
+
+function activateFocusedElement(event: KeyboardEvent) {
+  if (event.repeat || (event.key !== 'Enter' && event.key !== ' ')) {
+    return
+  }
+  const target = event.target
+  if (!(target instanceof Element)) {
+    return
+  }
+  const interactive = target.closest(
+    'a,button,input,textarea,select,[role="button"],[role="link"],[contenteditable="true"]',
+  )
+  if (
+    interactive
+    && !interactive.classList.contains('react-flow__node')
+    && !interactive.classList.contains('react-flow__edge')
+  ) {
+    return
+  }
+  const flowElement = target.closest<HTMLElement | SVGElement>(
+    '.react-flow__node[data-id], .react-flow__edge[data-id]',
+  )
+  const view = flowElement?.ownerDocument.defaultView
+  if (!flowElement || !view) {
+    return
+  }
+  event.preventDefault()
+  // Keep propagation so React Flow still updates selection and aria-live state.
+  const rect = flowElement.getBoundingClientRect()
+  flowElement.dispatchEvent(
+    new view.MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      button: 0,
+      clientX: rect.left + rect.width / 2,
+      clientY: rect.top + rect.height / 2,
+      detail: 1,
+      view,
+    }),
+  )
+}
+
 export type BaseXYFlowProps<NodeType extends BaseNode, EdgeType extends BaseEdge> = Simplify<
   & {
     pannable: boolean
@@ -81,6 +133,10 @@ export function BaseXYFlow<
     onNodeMouseLeave,
     onEdgeMouseEnter,
     onEdgeMouseLeave,
+    onKeyDownCapture,
+    ariaLabelConfig,
+    nodesFocusable = nodesDraggable || nodesSelectable,
+    edgesFocusable = false,
     ...props
   }: BaseXYFlowProps<NodeType, EdgeType>,
 ) {
@@ -161,9 +217,13 @@ export function BaseXYFlow<
         selectionKeyCode: null,
       })}
       elementsSelectable={nodesSelectable}
-      nodesFocusable={nodesDraggable || nodesSelectable}
-      edgesFocusable={false}
+      nodesFocusable={nodesFocusable}
+      edgesFocusable={edgesFocusable}
       nodesDraggable={nodesDraggable}
+      ariaLabelConfig={{
+        ...likec4AriaLabelConfig,
+        ...ariaLabelConfig,
+      }}
       nodeDragThreshold={4}
       nodeClickDistance={3}
       paneClickDistance={3}
@@ -230,6 +290,12 @@ export function BaseXYFlow<
       })}
       onNodeDoubleClick={stopPropagation}
       onEdgeDoubleClick={stopPropagation}
+      onKeyDownCapture={useCallbackRef((event) => {
+        onKeyDownCapture?.(event)
+        if (!event.defaultPrevented) {
+          activateFocusedElement(event)
+        }
+      })}
       {...props}
       aria-label={ariaLabel}
       tabIndex={tabIndex}

--- a/packages/diagram/src/base/updateEdges.spec.ts
+++ b/packages/diagram/src/base/updateEdges.spec.ts
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import { describe, expect, it } from 'vitest'
+import type { BaseEdge } from './types'
+import { updateEdges } from './updateEdges'
+
+type TestEdge = BaseEdge<{
+  label: string
+}>
+
+function createEdge(
+  id: string,
+  overrides: Partial<TestEdge> = {},
+): TestEdge {
+  return {
+    id,
+    type: 'default',
+    source: 'source',
+    target: 'target',
+    data: {
+      label: id,
+    },
+    ...overrides,
+  }
+}
+
+describe('updateEdges', () => {
+  it('updates ariaLabel property', () => {
+    const current = [createEdge('edge1', { ariaLabel: 'Old label' })]
+    const update = [createEdge('edge1', { ariaLabel: 'New label' })]
+
+    const result = updateEdges(current, update)
+
+    expect(result).not.toBe(current)
+    expect(result[0]?.ariaLabel).toBe('New label')
+    expect(result[0]?.data).toBe(current[0]?.data)
+  })
+
+  it('updates ariaRole property', () => {
+    const current = [createEdge('edge1', { ariaRole: 'group' })]
+    const update = [createEdge('edge1', { ariaRole: 'button' })]
+
+    const result = updateEdges(current, update)
+
+    expect(result).not.toBe(current)
+    expect(result[0]?.ariaRole).toBe('button')
+    expect(result[0]?.data).toBe(current[0]?.data)
+  })
+})

--- a/packages/diagram/src/base/updateEdges.ts
+++ b/packages/diagram/src/base/updateEdges.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { deepEqual as eq } from 'fast-equals'
 import { hasSubObject, isDefined, isShallowEqual, pickBy } from 'remeda'
 import type { BaseEdge } from './types'
@@ -54,6 +61,8 @@ function _update<E extends BaseEdge>(current: E[], updated: E[]): E[] {
       && eq(existing.selectable, update.selectable ?? existing.selectable)
       && eq(existing.focusable, update.focusable ?? existing.focusable)
       && eq(existing.animated, update.animated ?? existing.animated)
+      && eq(existing.ariaLabel, update.ariaLabel ?? existing.ariaLabel)
+      && eq(existing.ariaRole, update.ariaRole ?? existing.ariaRole)
       && eq(existing.className, update.className)
       && eq(existing.zIndex, update.zIndex ?? existing.zIndex)
       && eq(existing.label, update.label)

--- a/packages/diagram/src/base/updateNodes.spec.ts
+++ b/packages/diagram/src/base/updateNodes.spec.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { type NodeHandle, Position } from '@xyflow/system'
 import { describe, expect, it } from 'vitest'
 import type { BaseNode } from './types'
@@ -395,6 +402,30 @@ describe('updateNodes', () => {
 
       expect(result).not.toBe(current)
       expect(result[0]?.selectable).toBe(false)
+      // preserves existing node data
+      expect(result[0]?.data).toBe(current[0]?.data)
+    })
+
+    it('updates ariaLabel property', () => {
+      const current = [createNode('node1', { ariaLabel: 'Old label' })]
+      const update = [createNode('node1', { ariaLabel: 'New label' })]
+
+      const result = updateNodes(current, update)
+
+      expect(result).not.toBe(current)
+      expect(result[0]?.ariaLabel).toBe('New label')
+      // preserves existing node data
+      expect(result[0]?.data).toBe(current[0]?.data)
+    })
+
+    it('updates ariaRole property', () => {
+      const current = [createNode('node1', { ariaRole: 'group' })]
+      const update = [createNode('node1', { ariaRole: 'button' })]
+
+      const result = updateNodes(current, update)
+
+      expect(result).not.toBe(current)
+      expect(result[0]?.ariaRole).toBe('button')
       // preserves existing node data
       expect(result[0]?.data).toBe(current[0]?.data)
     })

--- a/packages/diagram/src/base/updateNodes.ts
+++ b/packages/diagram/src/base/updateNodes.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { getNodeDimensions } from '@xyflow/system'
 import { deepEqual as eq, shallowEqual as isShallowEqual } from 'fast-equals'
 import { hasSubObject, isDefined, pickBy } from 'remeda'
@@ -54,6 +61,8 @@ function _update<N extends BaseNode>(current: N[], updated: N[]): N[] {
       && eq(existing.selectable, update.selectable ?? existing.selectable)
       && eq(existing.focusable, update.focusable ?? existing.focusable)
       && eq(existing.draggable, update.draggable ?? existing.draggable)
+      && eq(existing.ariaLabel, update.ariaLabel ?? existing.ariaLabel)
+      && eq(existing.ariaRole, update.ariaRole ?? existing.ariaRole)
       && eq(existing.dragHandle, update.dragHandle)
       && eq(existing.className, update.className)
       && eq(existing.zIndex, update.zIndex ?? existing.zIndex)

--- a/packages/diagram/src/likec4diagram/DiagramXYFlow.tsx
+++ b/packages/diagram/src/likec4diagram/DiagramXYFlow.tsx
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { type EdgeId, type NodeId, nonNullable } from '@likec4/core'
 import { cx } from '@likec4/styles/css'
 import { useDebouncedCallback, useTimeout } from '@mantine/hooks'
@@ -287,6 +294,8 @@ export function LikeC4DiagramXYFlow({
       }}
       nodesDraggable={nodesDraggable}
       nodesSelectable={nodesSelectable}
+      nodesFocusable
+      edgesFocusable
       elevateEdgesOnSelect={!enableReadOnly}
       zIndexMode="manual"
       {...(nodesDraggable && layoutConstraints)}

--- a/packages/diagram/src/likec4diagram/custom/edges/RelationshipEdge.tsx
+++ b/packages/diagram/src/likec4diagram/custom/edges/RelationshipEdge.tsx
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import type { EdgeId } from '@likec4/core/types'
 import { css, cx as clsx } from '@likec4/styles/css'
 import { useRafEffect } from '@react-hookz/web'
@@ -320,6 +327,7 @@ export const RelationshipEdge = memoEdge<Types.EdgeProps<'relationship'>>((props
               edgeProps={props}>
               {navigateTo && (
                 <EdgeActionButton
+                  ariaLabel="Navigate to view"
                   onClick={e => {
                     e.stopPropagation()
                     diagram.navigateTo(navigateTo)

--- a/packages/diagram/src/likec4diagram/custom/edges/SequenceStepEdge.tsx
+++ b/packages/diagram/src/likec4diagram/custom/edges/SequenceStepEdge.tsx
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { getSmoothStepPath } from '@xyflow/system'
 import { EdgeActionButton, EdgeContainer, EdgeLabel, EdgeLabelContainer, EdgePath } from '../../../base-primitives'
 import { useEnabledFeatures } from '../../../context/DiagramFeatures'
@@ -56,6 +63,7 @@ export function SequenceStepEdge(props: Types.EdgeProps<'seq-step'>) {
         <EdgeLabel edgeProps={props}>
           {enableNavigateTo && navigateTo && (
             <EdgeActionButton
+              ariaLabel="Navigate to view"
               onClick={e => {
                 e.stopPropagation()
                 diagram.navigateTo(navigateTo)

--- a/packages/diagram/src/likec4diagram/custom/nodes/CompoundActions.tsx
+++ b/packages/diagram/src/likec4diagram/custom/nodes/CompoundActions.tsx
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import type { NodeId } from '@likec4/core'
 import { CompoundActionButton } from '../../../base-primitives'
 import { useEnabledFeatures } from '../../../context/DiagramFeatures'
@@ -14,6 +21,7 @@ export const CompoundActions = (props: CompoundActionsProps) => {
   if (navigateTo && enableNavigateTo) {
     return (
       <CompoundActionButton
+        ariaLabel="Navigate to view"
         onClick={(e) => {
           e.stopPropagation()
           diagram.navigateTo(navigateTo, props.id as NodeId)

--- a/packages/diagram/src/likec4diagram/custom/nodes/ElementActions.tsx
+++ b/packages/diagram/src/likec4diagram/custom/nodes/ElementActions.tsx
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { IconTransform, IconZoomScan } from '@tabler/icons-react'
 import { useMemo } from 'react'
 import { hasAtLeast } from 'remeda'
@@ -6,6 +13,7 @@ import { ElementActionButtons } from '../../../base-primitives'
 import type { BaseNodeData } from '../../../base/types'
 import { useEnabledFeatures } from '../../../context/DiagramFeatures'
 import { useDiagram } from '../../../hooks/useDiagram'
+import { readableText } from '../../../utils'
 import type { Types } from '../../types'
 
 type WithExtraButtons = {
@@ -34,7 +42,7 @@ type WithExtraButtons = {
 export type ElementActionsProps =
   & SimplifyDeep<{
     selected?: boolean
-    data: Pick<Types.ElementNodeData, 'id' | 'modelFqn' | 'navigateTo'> & BaseNodeData
+    data: Pick<Types.ElementNodeData, 'id' | 'modelFqn' | 'navigateTo' | 'title'> & BaseNodeData
   }>
   & WithExtraButtons
 
@@ -69,13 +77,15 @@ export function ElementActions({
 }: ElementActionsProps) {
   const { enableNavigateTo, enableRelationshipBrowser } = useEnabledFeatures()
   const diagram = useDiagram()
-  const { id, navigateTo, modelFqn } = props.data
+  const { id, navigateTo, modelFqn, title } = props.data
   let buttons = useMemo(() => {
     const buttons = [] as ElementActionButtons.Item[]
+    const labelTitle = readableText(title) || id
 
     if (navigateTo && enableNavigateTo) {
       buttons.push({
         key: 'navigate',
+        ariaLabel: 'Navigate to view',
         icon: <IconZoomScan />,
         onClick: (e) => {
           e.stopPropagation()
@@ -86,6 +96,7 @@ export function ElementActions({
     if (enableRelationshipBrowser) {
       buttons.push({
         key: 'relationships',
+        ariaLabel: `Browse ${labelTitle} relationships`,
         icon: <IconTransform />,
         onClick: (e) => {
           e.stopPropagation()
@@ -94,7 +105,7 @@ export function ElementActions({
       })
     }
     return buttons
-  }, [enableNavigateTo, enableRelationshipBrowser, modelFqn, navigateTo, id, diagram])
+  }, [enableNavigateTo, enableRelationshipBrowser, modelFqn, navigateTo, id, title, diagram])
 
   if (extraButtons && hasAtLeast(extraButtons, 1)) {
     buttons = [...buttons, ...extraButtons]
@@ -107,7 +118,7 @@ export function ElementActions({
 export type DeploymentElementActionsProps =
   & SimplifyDeep<{
     selected?: boolean
-    data: Pick<Types.DeploymentElementNodeData, 'id' | 'modelFqn' | 'navigateTo'> & BaseNodeData
+    data: Pick<Types.DeploymentElementNodeData, 'id' | 'modelFqn' | 'navigateTo' | 'title'> & BaseNodeData
   }>
   & WithExtraButtons
 
@@ -142,14 +153,16 @@ export const DeploymentElementActions = ({
 }: DeploymentElementActionsProps) => {
   const { enableNavigateTo, enableRelationshipBrowser } = useEnabledFeatures()
   const diagram = useDiagram()
-  const { id, navigateTo, modelFqn } = props.data
+  const { id, navigateTo, modelFqn, title } = props.data
 
   let buttons = useMemo(() => {
     const buttons = [] as ElementActionButtons.Item[]
+    const labelTitle = readableText(title) || id
 
     if (navigateTo && enableNavigateTo) {
       buttons.push({
         key: 'navigate',
+        ariaLabel: 'Navigate to view',
         icon: <IconZoomScan />,
         onClick: (e) => {
           e.stopPropagation()
@@ -160,6 +173,7 @@ export const DeploymentElementActions = ({
     if (enableRelationshipBrowser && !!modelFqn) {
       buttons.push({
         key: 'relationships',
+        ariaLabel: `Browse ${labelTitle} relationships`,
         icon: <IconTransform />,
         onClick: (e) => {
           e.stopPropagation()
@@ -168,7 +182,7 @@ export const DeploymentElementActions = ({
       })
     }
     return buttons
-  }, [enableNavigateTo, enableRelationshipBrowser, modelFqn, navigateTo, id])
+  }, [enableNavigateTo, enableRelationshipBrowser, modelFqn, navigateTo, id, title, diagram])
 
   if (extraButtons && hasAtLeast(extraButtons, 1)) {
     buttons = [...buttons, ...extraButtons]

--- a/packages/diagram/src/likec4diagram/custom/nodes/SequenceActorNode.tsx
+++ b/packages/diagram/src/likec4diagram/custom/nodes/SequenceActorNode.tsx
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import type { Fqn } from '@likec4/core/types'
 import { css } from '@likec4/styles/css'
 import { Box } from '@likec4/styles/jsx'
@@ -109,7 +116,7 @@ export function SequenceActorNode(props: Types.NodeProps<'seq-actor'>) {
       <ElementNodeContainer nodeProps={props}>
         {enableCompareWithLatest && <NodeDrifts nodeProps={props} />}
         <ElementShape {...props} />
-        <ElementData {...props} />
+        <ElementData {...props} aria-hidden />
         {hasModelFqn(props) && (
           <>
             <ElementActions {...props} />

--- a/packages/diagram/src/likec4diagram/custom/nodes/nodes.tsx
+++ b/packages/diagram/src/likec4diagram/custom/nodes/nodes.tsx
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import type { Fqn, NodeId } from '@likec4/core'
 import { css } from '@likec4/styles/css'
 import {
@@ -95,7 +102,7 @@ export function ElementNode(props: Types.NodeProps<'element'>) {
     <ElementNodeContainer nodeProps={props}>
       {enableCompareWithLatest && <NodeDrifts nodeProps={props} />}
       <ElementShape {...props} />
-      <ElementData {...props} />
+      <ElementData {...props} aria-hidden />
       {enableElementTags && <ElementTags {...props} />}
       <ElementActions {...props} />
       {enableElementDetails && <ElementDetailsButtonWithHandler {...props} />}
@@ -113,7 +120,7 @@ export function DeploymentNode(props: Types.NodeProps<'deployment'>) {
     <ElementNodeContainer nodeProps={props}>
       {enableCompareWithLatest && <NodeDrifts nodeProps={props} />}
       <ElementShape {...props} />
-      <ElementData {...props} />
+      <ElementData {...props} aria-hidden />
       {enableElementTags && <ElementTags {...props} />}
       <DeploymentElementActions {...props} />
       {enableElementDetails && <ElementDetailsButtonWithHandler {...props} />}
@@ -144,7 +151,7 @@ export function CompoundElementNode(props: Types.NodeProps<'compound-element'>) 
       nodeProps={props}
     >
       {enableCompareWithLatest && <NodeDrifts nodeProps={props} />}
-      <CompoundTitle {...props} />
+      <CompoundTitle {...props} aria-hidden />
       <CompoundActions {...props} />
       {enableElementDetails && <CompoundDetailsButtonWithHandler {...props} />}
       {!enableReadOnly && <CompoundElementToolbar {...props} />}
@@ -162,7 +169,7 @@ export function CompoundDeploymentNode(props: Types.NodeProps<'compound-deployme
       nodeProps={props}
     >
       {enableCompareWithLatest && <NodeDrifts nodeProps={props} />}
-      <CompoundTitle {...props} />
+      <CompoundTitle {...props} aria-hidden />
       <CompoundActions {...props} />
       {enableElementDetails && <CompoundDetailsButtonWithHandler {...props} />}
       {!enableReadOnly && <CompoundDeploymentToolbar {...props} />}
@@ -180,7 +187,7 @@ export function ViewGroupNode(props: Types.NodeProps<'view-group'>) {
       nodeProps={props}
     >
       {enableCompareWithLatest && <NodeDrifts nodeProps={props} />}
-      <CompoundTitle {...props} />
+      <CompoundTitle {...props} aria-hidden />
       <DefaultHandles direction={props.data.viewLayoutDir} />
     </CompoundNodeContainer>
   )

--- a/packages/diagram/src/likec4diagram/xyflow-diagram/diagram-view.spec.ts
+++ b/packages/diagram/src/likec4diagram/xyflow-diagram/diagram-view.spec.ts
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import { type DiagramEdge, type DiagramNode, type DiagramView, GroupElementKind, scalar } from '@likec4/core'
+import { describe, expect, it } from 'vitest'
+import { diagramToXY } from './diagram-view'
+
+type TestView = Pick<DiagramView, 'id' | 'nodes' | 'edges' | '_type' | 'autoLayout'>
+
+function testNode(id: string, overrides: Partial<DiagramNode> = {}): DiagramNode {
+  const nodeId = scalar.NodeId(id)
+  const node: DiagramNode = {
+    id: nodeId,
+    parent: null,
+    children: [],
+    inEdges: [],
+    outEdges: [],
+    x: 0,
+    y: 0,
+    width: 300,
+    height: 200,
+    labelBBox: { x: 0, y: 0, width: 100, height: 24 },
+    kind: 'component',
+    modelRef: scalar.Fqn(id),
+    title: id,
+    description: null,
+    technology: null,
+    color: 'primary',
+    shape: 'rectangle',
+    style: {},
+    level: 0,
+    tags: [],
+    ...overrides,
+  }
+  if (node.kind === GroupElementKind) {
+    const { modelRef: _modelRef, deploymentRef: _deploymentRef, ...groupNode } = node
+    return groupNode
+  }
+  return node
+}
+
+function testEdge(
+  id: string,
+  source: DiagramNode,
+  target: DiagramNode,
+  overrides: Partial<DiagramEdge> = {},
+): DiagramEdge {
+  return {
+    id: scalar.EdgeId(id),
+    parent: null,
+    source: source.id,
+    target: target.id,
+    label: null,
+    technology: null,
+    relations: [],
+    color: 'primary',
+    line: 'solid',
+    points: [
+      [0, 0],
+      [100, 100],
+    ],
+    ...overrides,
+  }
+}
+
+function testView(nodes: DiagramNode[], edges: DiagramEdge[]): TestView {
+  return {
+    _type: 'element',
+    id: scalar.ViewId('index'),
+    autoLayout: { direction: 'TB' },
+    nodes,
+    edges,
+  }
+}
+
+describe('diagramToXY accessibility', () => {
+  it('adds screen-reader labels to element nodes and relationship edges', () => {
+    const customer = testNode('customer', {
+      title: 'Customer',
+      kind: 'actor',
+      technology: 'Browser',
+      description: { txt: 'Places orders' },
+      navigateTo: scalar.ViewId('customer'),
+    })
+    const web = testNode('web', {
+      title: 'Web Application',
+      technology: 'React',
+    })
+    const relationship = testEdge('customer-web', customer, web, {
+      label: 'uses',
+      technology: 'HTTPS',
+      notes: { txt: 'Authenticated traffic' },
+      navigateTo: scalar.ViewId('customer-web'),
+    })
+
+    const { xynodes, xyedges } = diagramToXY({
+      view: testView([customer, web], [relationship]),
+      currentViewId: undefined,
+      where: null,
+    })
+
+    expect(xynodes.find(n => n.id === 'customer')?.ariaLabel).toBe(
+      'Customer. Node kind: actor. Technology: Browser. Description: Places orders. Opens view customer.',
+    )
+    expect(xyedges[0]?.ariaLabel).toBe(
+      'Relationship from Customer to Web Application. Label: uses. Technology: HTTPS. Notes: Authenticated traffic. Opens view customer-web.',
+    )
+  })
+
+  it('uses readable plain text in screen-reader labels', () => {
+    const customer = testNode('customer', {
+      title: '',
+      description: { md: '**Places orders** with [checkout](https://example.com)' },
+    })
+    const web = testNode('web', {
+      title: 'Web Application',
+    })
+    const relationship = testEdge('customer-web', customer, web, {
+      notes: { md: '**Authenticated** traffic with [OAuth](https://example.com)' },
+    })
+
+    const { xynodes, xyedges } = diagramToXY({
+      view: testView([customer, web], [relationship]),
+      currentViewId: undefined,
+      where: null,
+    })
+
+    expect(xynodes.find(n => n.id === 'customer')?.ariaLabel).toBe(
+      'customer. Node kind: component. Description: Places orders with checkout.',
+    )
+    expect(xyedges[0]?.ariaLabel).toBe(
+      'Relationship from customer to Web Application. Notes: Authenticated traffic with OAuth.',
+    )
+  })
+
+  it('labels relationship descriptions and notes separately', () => {
+    const customer = testNode('customer', {
+      title: 'Customer',
+    })
+    const web = testNode('web', {
+      title: 'Web Application',
+    })
+    const relationship = testEdge('customer-web', customer, web, {
+      description: { txt: 'Uses checkout' },
+      notes: { txt: 'Reviewed by architecture' },
+    })
+
+    const { xyedges } = diagramToXY({
+      view: testView([customer, web], [relationship]),
+      currentViewId: undefined,
+      where: null,
+    })
+
+    expect(xyedges[0]?.ariaLabel).toBe(
+      'Relationship from Customer to Web Application. Description: Uses checkout. Notes: Reviewed by architecture.',
+    )
+  })
+
+  it('adds screen-reader labels to view groups', () => {
+    const child = testNode('web', {
+      parent: scalar.NodeId('group'),
+      title: 'Web Application',
+    })
+    const group = testNode('group', {
+      kind: GroupElementKind,
+      title: 'Checkout',
+      children: [child.id],
+      notes: { txt: 'Important boundary' },
+    })
+
+    const { xynodes } = diagramToXY({
+      view: testView([group, child], []),
+      currentViewId: undefined,
+      where: null,
+    })
+
+    expect(xynodes.find(n => n.id === 'group')?.ariaLabel).toBe(
+      'Checkout. Group. Contains 1 node. Notes: Important boundary.',
+    )
+  })
+})

--- a/packages/diagram/src/likec4diagram/xyflow-diagram/diagram-view.ts
+++ b/packages/diagram/src/likec4diagram/xyflow-diagram/diagram-view.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import {
   type DiagramEdge,
   type DiagramNode,
@@ -15,7 +22,54 @@ import {
 } from '@likec4/core'
 import { hasAtLeast, pick } from 'remeda'
 import { ZIndexes } from '../../base/const'
+import { readableText } from '../../utils'
 import type { Types } from '../types'
+
+function sentence(parts: Array<string | null | undefined>): string {
+  return parts.filter((part): part is string => !!part).map(part => part.endsWith('.') ? part : `${part}.`).join(' ')
+}
+
+function nodeAriaLabel(node: DiagramNode): string {
+  const title = readableText(node.title) ?? node.id
+  const description = readableText(node.description)
+  const notes = readableText(node.notes)
+
+  if (node.kind === GroupElementKind) {
+    const childCount = node.children.length
+    return sentence([
+      title,
+      'Group',
+      `Contains ${childCount} ${childCount === 1 ? 'node' : 'nodes'}`,
+      notes && `Notes: ${notes}`,
+    ])
+  }
+
+  return sentence([
+    title,
+    `Node kind: ${node.kind}`,
+    node.technology && `Technology: ${node.technology}`,
+    description && `Description: ${description}`,
+    notes && `Notes: ${notes}`,
+    node.navigateTo && `Opens view ${node.navigateTo}`,
+  ])
+}
+
+function edgeAriaLabel(edge: DiagramEdge, source: DiagramNode, target: DiagramNode): string {
+  const sourceTitle = readableText(source.title) ?? source.id
+  const targetTitle = readableText(target.title) ?? target.id
+  const label = readableText(edge.label)
+  const description = readableText(edge.description)
+  const notes = readableText(edge.notes)
+
+  return sentence([
+    `Relationship from ${sourceTitle} to ${targetTitle}`,
+    label && `Label: ${label}`,
+    edge.technology && `Technology: ${edge.technology}`,
+    description && `Description: ${description}`,
+    notes && `Notes: ${notes}`,
+    edge.navigateTo && `Opens view ${edge.navigateTo}`,
+  ])
+}
 
 /**
  * Convert a diagram view to XY flow nodes and edges.
@@ -109,6 +163,7 @@ export function diagramToXY(opts: {
         width: node.width,
         height: node.height,
       },
+      ariaLabel: nodeAriaLabel(node),
       initialWidth: node.width,
       initialHeight: node.height,
       hidden: node.kind !== GroupElementKind && !visiblePredicate(node),
@@ -255,6 +310,7 @@ export function diagramToXY(opts: {
       type: 'relationship',
       source: ns + source,
       target: ns + target,
+      ariaLabel: edgeAriaLabel(edge, nodeById(source), nodeById(target)),
       zIndex: ZIndexes.Edge,
       hidden: !visiblePredicate(edge),
       deletable,

--- a/packages/diagram/src/utils/index.ts
+++ b/packages/diagram/src/utils/index.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 export { Vector, vector } from '@likec4/core/geometry'
 export type { VectorValue } from '@likec4/core/geometry'
 export {
@@ -17,5 +24,6 @@ export {
   stopPropagation,
 } from './xyflow'
 
+export { readableText } from './readableText'
 export { roundDpr } from './roundDpr'
 export { pickViewBounds } from './view-bounds'

--- a/packages/diagram/src/utils/readableText.ts
+++ b/packages/diagram/src/utils/readableText.ts
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import { type MarkdownOrString, RichText } from '@likec4/core'
+
+const WHITESPACE = /\s+/g
+
+/**
+ * Flattens a markdown or plain string value into a single line of
+ * screen-reader friendly text: renders markdown to plain text, collapses
+ * runs of whitespace and trims. Returns `null` when the value yields no text.
+ *
+ * Use this whenever model text (titles, labels, descriptions, notes) is
+ * surfaced to assistive technologies, so that markdown syntax and stray
+ * whitespace never leak into an `aria-label`.
+ */
+export function readableText(value: MarkdownOrString | string | null | undefined): string | null {
+  return RichText.from(value).text?.replace(WHITESPACE, ' ').trim() || null
+}


### PR DESCRIPTION
Fixes #2988.

## Summary
- Add LikeC4-specific accessible labels for nodes, groups, and relationships using their visible architecture text.
- Make diagram nodes and relationships keyboard-focusable and activatable with Enter/Space, including static/export diagrams.
- Make visible node and relationship action buttons reachable by keyboard without changing the diagram package layering.
- Keep relationship `Description:` and `Notes:` distinct in screen-reader labels.

## Evidence
- TDD red check: the new `diagramToXY` accessibility test failed before the implementation because React Flow nodes had no `ariaLabel`.
- TDD red check: the relationship description/notes unit test failed before the follow-up fix because descriptions were dropped when notes were present.
- Acceptance check for #2988: focus a relationship and activate details with Enter and Space.
- Acceptance check for #2988 node navigation: focus the `cloud` node, activate it with Enter and Space, Tab to its `Navigate to view` action, activate it, and assert `/view/cloud/` loads.
- `pnpm --dir e2e test tests/diagram-a11y.spec.ts` - 5 passed.
- `pnpm exec vitest run --no-isolate packages/diagram/src/likec4diagram/xyflow-diagram/diagram-view.spec.ts` - 4 passed.
- `node_modules/.bin/vitest run --no-isolate packages/diagram/src/likec4diagram/xyflow-diagram/diagram-view.spec.ts packages/diagram/src/base/updateNodes.spec.ts packages/diagram/src/base/updateEdges.spec.ts`
- `node_modules/.bin/tsc --build packages/diagram/tsconfig.json --verbose`
- `node_modules/.bin/oxlint --type-aware ...` on touched files
- `pnpm --dir e2e exec tsc --noEmit --strict --module ESNext --target ESNext --moduleResolution Bundler --skipLibCheck tests/diagram-a11y.spec.ts`
- `pnpm exec dprint check packages/diagram/src/likec4diagram/xyflow-diagram/diagram-view.ts packages/diagram/src/likec4diagram/xyflow-diagram/diagram-view.spec.ts e2e/tests/diagram-a11y.spec.ts`
- `git diff --check`

## Notes
This is not a visual rendering change, so the PR uses accessibility assertions and a Playwright aria snapshot test instead of before/after screenshots.

## Design notes
A few decisions worth a maintainer's eye:

- **Keyboard activation reuses the existing click path.** React Flow's built-in Enter/Space only toggles node/edge *selection* (`elementSelectionKeys`); it never fires `onNodeClick` / `onEdgeClick`. To give keyboard users parity with mouse users, `activateFocusedElement` (in `base/BaseXYFlow.tsx`) synthesizes a bubbling `click` on the focused node/edge so the existing click handlers run. This keeps the generic `base/` layer decoupled from the diagram's XState machine and avoids duplicating "what activation does". The alternative — routing keyboard activation through the machine by extracting the per-element activate logic and calling it from both `onNodeClick` and a keydown handler — is also viable and arguably more idiomatic; happy to switch to that if you'd rather not dispatch a synthetic DOM event.

- **Node activation means parity with a mouse click, not direct navigation.** In LikeC4 a single click on a node selects it and reveals its action buttons; navigation happens by activating the "Navigate to view" button. The keyboard flow mirrors this exactly (Enter/Space selects and reveals the actions, Tab to the button, activate). So #2988's "navigate by selecting a node" is addressed as full keyboard/mouse parity rather than a new single-key navigate gesture.

- **Group contents are exposed via flat tab order.** React Flow renders nodes as a flat DOM list, so a screen-reader user reaches a group's children by tabbing — each child is independently focusable and labelled — rather than by descending a hierarchy. The group's own label announces its child count.
