### PR TITLE
fix: inline favicon in --output-single-file build (no more 404)

### DIFF
--- a/.changeset/single-file-favicon-data-uri.md
+++ b/.changeset/single-file-favicon-data-uri.md
@@ -1,0 +1,5 @@
+---
+'likec4': patch
+---
+
+Fix favicon 404 in `likec4 build --output-single-file`. The single-file build inlines JS/CSS but left the favicon `<link rel="icon">` as an external reference to a hashed asset, which the post-build cleanup then removed — leaving a dangling reference that 404s wherever the standalone HTML is served. The favicon is now inlined as a base64 data URI before cleanup, so the single HTML file stays self-contained. Only `--output-single-file` is affected; the regular multi-file build is unchanged.

--- a/packages/likec4/src/vite/vite-build.spec.ts
+++ b/packages/likec4/src/vite/vite-build.spec.ts
@@ -1,8 +1,8 @@
-import { mkdir, mkdtemp, readdir, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { removeAllButPreserved } from './vite-build'
+import { inlineSingleFileFavicon, removeAllButPreserved } from './vite-build'
 
 describe('removeAllButPreserved', () => {
   let outDir: string
@@ -43,5 +43,83 @@ describe('removeAllButPreserved', () => {
     await writeFile(join(outDir, 'index.html'), '<html></html>')
     removeAllButPreserved(outDir, ['index.html'])
     expect(await readdir(outDir)).toEqual(['index.html'])
+  })
+})
+
+describe('inlineSingleFileFavicon', () => {
+  let outDir: string
+
+  beforeEach(async () => {
+    outDir = await mkdtemp(join(tmpdir(), 'likec4-favicon-'))
+  })
+
+  afterEach(async () => {
+    await rm(outDir, { recursive: true, force: true })
+  })
+
+  const writeIndex = (head: string) =>
+    writeFile(join(outDir, 'index.html'), `<!doctype html><html><head>${head}</head><body></body></html>`)
+  const readIndex = () => readFile(join(outDir, 'index.html'), 'utf8')
+
+  it('inlines an external svg favicon as a base64 data URI', async () => {
+    await writeFile(join(outDir, 'favicon-CeB0sGK2.svg'), '<svg/>')
+    await writeIndex('<link rel="icon" type="image/svg+xml" href="./favicon-CeB0sGK2.svg">')
+
+    inlineSingleFileFavicon(outDir)
+
+    const html = await readIndex()
+    // base64('<svg/>') === 'PHN2Zy8+' — spec literal, NOT recomputed with the impl's formula
+    expect(html).toContain('data:image/svg+xml;base64,PHN2Zy8+')
+    expect(html).not.toContain('favicon-CeB0sGK2.svg')
+  })
+
+  it('uses image/x-icon mime and preserves the exact binary bytes for .ico', async () => {
+    const icoBytes = Buffer.from([0x00, 0x00, 0x01, 0x00, 0xff, 0xfe, 0x7a])
+    await writeFile(join(outDir, 'favicon.ico'), icoBytes)
+    await writeIndex('<link rel="icon" href="./favicon.ico">')
+
+    inlineSingleFileFavicon(outDir)
+
+    const html = await readIndex()
+    const match = html.match(/data:image\/x-icon;base64,([A-Za-z0-9+/=]+)/)
+    expect(match).not.toBeNull()
+    // roundtrip-decode must equal the original bytes → catches utf8-mangling / truncation
+    expect(Buffer.from(match![1]!, 'base64')).toEqual(icoBytes)
+    expect(html).not.toContain('href="./favicon.ico"')
+  })
+
+  it('is a no-op when there is no favicon link', async () => {
+    await writeIndex('<title>LikeC4</title>')
+    const before = await readIndex()
+
+    inlineSingleFileFavicon(outDir)
+
+    expect(await readIndex()).toEqual(before)
+  })
+
+  it('leaves a remote favicon href untouched', async () => {
+    await writeIndex('<link rel="icon" href="https://likec4.dev/favicon.svg">')
+    const before = await readIndex()
+
+    inlineSingleFileFavicon(outDir)
+
+    expect(await readIndex()).toEqual(before)
+  })
+
+  it('is a no-op (does not throw) when the referenced favicon file is missing', async () => {
+    await writeIndex('<link rel="icon" type="image/svg+xml" href="./favicon-missing.svg">')
+    const before = await readIndex()
+
+    expect(() => inlineSingleFileFavicon(outDir)).not.toThrow()
+    expect(await readIndex()).toEqual(before)
+  })
+
+  it('is idempotent when the favicon is already a data URI', async () => {
+    await writeIndex('<link rel="icon" type="image/svg+xml" href="data:image/svg+xml;base64,PHN2Zy8+">')
+    const before = await readIndex()
+
+    inlineSingleFileFavicon(outDir)
+
+    expect(await readIndex()).toEqual(before)
   })
 })

--- a/packages/likec4/src/vite/vite-build.ts
+++ b/packages/likec4/src/vite/vite-build.ts
@@ -1,7 +1,7 @@
-import { copyFileSync, existsSync, readdirSync, rmSync } from 'node:fs'
+import { copyFileSync, existsSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { mkdtemp } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join, resolve } from 'node:path'
+import { extname, join, resolve } from 'node:path'
 import k from 'tinyrainbow'
 import type { SetOptional } from 'type-fest'
 import type { Logger } from 'vite'
@@ -30,6 +30,64 @@ export function removeAllButPreserved(outDir: string, preserved: readonly string
   }
 }
 
+const FaviconMimeByExt: Record<string, string> = {
+  '.svg': 'image/svg+xml',
+  '.ico': 'image/x-icon',
+  '.png': 'image/png',
+  '.gif': 'image/gif',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+}
+
+/**
+ * Makes the `--output-single-file` build truly self-contained: rewrites the
+ * favicon `<link rel="icon" href="…">` in `index.html` to a base64 data URI.
+ *
+ * Vite intentionally does not inline favicons (and `vite-plugin-singlefile`
+ * only inlines `<script>`/`<style>`), so the link stays an external reference
+ * to a hashed asset — which the subsequent `removeAllButPreserved` cleanup then
+ * deletes, leaving a dangling reference that 404s. Inlining the asset here, just
+ * before cleanup, keeps the single HTML file portable.
+ *
+ * Operates on likec4's own generated `index.html`, which has a single
+ * `<link rel="icon">`. No-op when there is no such link, the href is remote
+ * (`http(s)`/`//`) or already a `data:` URI, or the referenced file is missing.
+ */
+export function inlineSingleFileFavicon(outDir: string): void {
+  const indexHtml = resolve(outDir, 'index.html')
+  if (!existsSync(indexHtml)) {
+    return
+  }
+  const html = readFileSync(indexHtml, 'utf8')
+
+  const linkTag = /<link\b[^>]*\brel=(["'])icon\1[^>]*>/i.exec(html)?.[0]
+  if (!linkTag) {
+    return
+  }
+  const hrefPattern = /\bhref=(["'])([^"']*)\1/i
+  const href = hrefPattern.exec(linkTag)?.[2]
+  if (!href || href.startsWith('data:') || /^(https?:)?\/\//i.test(href)) {
+    return
+  }
+
+  const assetPath = resolve(outDir, href.replace(/^\.?\//, ''))
+  if (!existsSync(assetPath)) {
+    return
+  }
+  const mime = FaviconMimeByExt[extname(assetPath).toLowerCase()] ?? 'application/octet-stream'
+  const dataUri = `data:${mime};base64,${readFileSync(assetPath).toString('base64')}`
+
+  const inlinedTag = linkTag.replace(hrefPattern, (_m, quote: string) => `href=${quote}${dataUri}${quote}`)
+  writeFileSync(indexHtml, html.replace(linkTag, inlinedTag))
+}
+
+/**
+ * Runs the production Vite build of the LikeC4 static site into the configured
+ * `outDir`: validates the project's views, optionally builds the web-component
+ * bundle (skipped for single-file output), and emits the app. For
+ * `--output-single-file` it inlines the favicon and strips the temporary Vite
+ * assets, leaving a self-contained `index.html` (also copied to `404.html`).
+ */
 export async function viteBuild({
   buildWebcomponent = true,
   webcomponentPrefix = 'likec4',
@@ -157,6 +215,9 @@ export async function viteBuild({
       config.customLogger.warn(k.yellow('outDir was not empty, skipping cleanup'))
       return
     }
+    // Inline the favicon before cleanup removes the asset it references,
+    // so the single HTML file stays self-contained (no dangling 404).
+    inlineSingleFileFavicon(config.build.outDir)
     removeAllButPreserved(config.build.outDir, ['index.html', ...userPublicEntries])
   }
 


### PR DESCRIPTION
Closes #3029

## What

`likec4 build --output-single-file` ([docs](https://likec4.dev/tooling/cli/#build-static-website)) produced a standalone HTML with a **dangling favicon reference that 404s**: `index.html` kept `<link rel="icon" href="./favicon-<hash>.svg">`, but that asset is not present next to the single file.

## Why

- `vite-plugin-singlefile` inlines `<script>` / `<style>` only; the favicon `<link>` stays an external reference (Vite intentionally never inlines favicons — vitejs/vite#19140).
- The single-file cleanup `removeAllButPreserved` (`packages/likec4/src/vite/vite-build.ts`) then deletes every output file except `index.html`, removing the favicon asset and leaving the dangling reference → 404 wherever the standalone file is served.

## How

New helper `inlineSingleFileFavicon(outDir)`, called in the `--output-single-file` branch **just before** `removeAllButPreserved`. It rewrites the favicon `<link>` href to a base64 data URI, so the single HTML file is truly self-contained. No-op for remote / `data:` / missing favicons. The regular multi-file build is unchanged.

Verified end-to-end: a single-file build now emits `<link rel="icon" href="data:image/svg+xml;base64,…">` and no external favicon reference; output is still one self-contained file.

## Checklist

- [x] I've thoroughly read the latest [contribution guidelines](https://github.com/likec4/likec4/blob/main/CONTRIBUTING.md).
- [x] I've rebased my branch onto `main` **before** creating this PR.
- [x] I've added tests to cover my changes (if applicable).
- [x] I've verified `pnpm typecheck` and `pnpm test`.
- [x] I've added [changesets](https://changesets-docs.vercel.app/) (you can use `/changeset-generator` SKILL).
- [ ] My change requires documentation updates.
- [ ] I've updated the documentation accordingly (or will do in follow-up PR).
