### PR TITLE
fix: align Docker image Playwright browsers with bundled version

### DIFF
--- a/.changeset/fix-png-export-with-docker.md
+++ b/.changeset/fix-png-export-with-docker.md
@@ -1,0 +1,5 @@
+---
+'likec4': patch
+---
+
+Fix `export png`/`export jpg` failing in the Docker image with `browserType.launch: Executable doesn't exist`. The bundled Playwright and the installed Chromium browsers are now kept in sync. Fixes [#2961](https://github.com/likec4/likec4/issues/2961)

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -32,9 +32,18 @@ jobs:
       - uses: actions/checkout@v6
       - name: Read version
         run: |
-          echo "LIKEC4_VER=$(jq -r .version package.json)" >> "$GITHUB_ENV"
+          LIKEC4_VER="$(jq -r '.version' package.json)"
+          if [ -z "$LIKEC4_VER" ] || [ "$LIKEC4_VER" = "null" ]; then
+            echo "::error::Failed to resolve LIKEC4_VER from package.json"
+            exit 1
+          fi
+          echo "LIKEC4_VER=$LIKEC4_VER" >> "$GITHUB_ENV"
           echo "Resolved LIKEC4_VER=$LIKEC4_VER"
-          PLAYWRIGHT_VER=$(grep -oE 'playwright@[0-9]+\.[0-9]+\.[0-9]+' pnpm-lock.yaml | head -1 | cut -d@ -f2)
+          PLAYWRIGHT_VER="$(grep -oE 'playwright@[0-9]+\.[0-9]+\.[0-9]+' pnpm-lock.yaml | head -1 | cut -d@ -f2)"
+          if [ -z "$PLAYWRIGHT_VER" ]; then
+            echo "::error::Failed to resolve PLAYWRIGHT_VER from pnpm-lock.yaml"
+            exit 1
+          fi
           echo "PLAYWRIGHT_VER=$PLAYWRIGHT_VER" >> "$GITHUB_ENV"
           echo "Resolved PLAYWRIGHT_VER=$PLAYWRIGHT_VER"
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     tags:
-      - "v*"
+      - 'v*'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
@@ -33,6 +33,10 @@ jobs:
       - name: Read version
         run: |
           echo "LIKEC4_VER=$(jq -r .version package.json)" >> "$GITHUB_ENV"
+          echo "Resolved LIKEC4_VER=$LIKEC4_VER"
+          PLAYWRIGHT_VER=$(grep -oE 'playwright@[0-9]+\.[0-9]+\.[0-9]+' pnpm-lock.yaml | head -1 | cut -d@ -f2)
+          echo "PLAYWRIGHT_VER=$PLAYWRIGHT_VER" >> "$GITHUB_ENV"
+          echo "Resolved PLAYWRIGHT_VER=$PLAYWRIGHT_VER"
 
       - name: Set up Docker
         uses: docker/setup-docker-action@v4
@@ -85,6 +89,7 @@ jobs:
             likec4/likec4
           build-args: |
             LIKEC4_VER=${{ env.LIKEC4_VER }}
+            PLAYWRIGHT_VER=${{ env.PLAYWRIGHT_VER }}
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true
           cache-from: type=registry,ref=${{ env.REGISTRY_IMAGE }}:${{ env.CACHE_TAG }}
           cache-to: type=registry,ref=${{ env.REGISTRY_IMAGE }}:${{ env.CACHE_TAG }},mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,9 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Copy Graphviz binaries
 COPY --from=graphviz /install /
 
-ARG PLAYWRIGHT_VER=1.58.2
+# Overridden by .github/workflows/docker.yaml with the exact version likec4 depends on.
+# Keep this default in sync with the `playwright` catalog entry in pnpm-workspace.yaml.
+ARG PLAYWRIGHT_VER=1.60.0
 # Install runtime dependencies
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@likec4/core": "file:../packages/core/package.tgz",
     "@likec4/icons": "file:../packages/icons/package.tgz",
-    "@playwright/test": "^1.58.2",
+    "@playwright/test": "^1.60.0",
     "@types/node": "~22.19.17",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,8 +152,8 @@ catalogs:
       specifier: ^2.1.0
       version: 2.1.0
     playwright:
-      specifier: ^1.58.2
-      version: 1.58.2
+      specifier: 1.60.0
+      version: 1.60.0
     tsx:
       specifier: 4.22.4
       version: 4.22.4
@@ -1830,7 +1830,7 @@ importers:
         version: 2.1.0
       playwright:
         specifier: 'catalog:'
-        version: 1.58.2
+        version: 1.60.0
       react-compiler-runtime:
         specifier: catalog:react
         version: 1.0.0(react@19.2.6)
@@ -2818,7 +2818,7 @@ importers:
         version: 2.0.3
       playwright:
         specifier: 'catalog:'
-        version: 1.58.2
+        version: 1.60.0
       pretty-ms:
         specifier: ^9.3.0
         version: 9.3.0
@@ -9585,13 +9585,13 @@ packages:
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
 
-  playwright-core@1.58.2:
-    resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.58.2:
-    resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -18954,11 +18954,11 @@ snapshots:
       exsolve: 1.0.8
       pathe: 2.0.3
 
-  playwright-core@1.58.2: {}
+  playwright-core@1.60.0: {}
 
-  playwright@1.58.2:
+  playwright@1.60.0:
     dependencies:
-      playwright-core: 1.58.2
+      playwright-core: 1.60.0
     optionalDependencies:
       fsevents: 2.3.2
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -52,7 +52,7 @@ catalog:
   oxlint: 1.59.0
   oxlint-tsgolint: 0.20.0
   pako: ^2.1.0
-  playwright: ^1.58.2
+  playwright: 1.60.0
   tsx: 4.22.4
   turbo: 2.9.16
   typescript: 6.0.3


### PR DESCRIPTION
Fixes #2961

### Problem

`likec4 export png` (and `jpg`) fail inside the published Docker image:

```
browserType.launch: Executable doesn't exist at
/root/.cache/ms-playwright/chromium_headless_shell-1217/chrome-headless-shell-linux64/chrome-headless-shell
```

The `likec4` package bundles `playwright` as a runtime dependency, and that bundled version dictates which **Chromium revision** it launches (via `import('playwright')` → `chromium.executablePath()`). The Dockerfile, however, installed the browser binaries with a **hand-maintained, hardcoded** `PLAYWRIGHT_VER`. When the two drifted apart (it sat at `1.53.1`, while released images needed revs `1217` / `1223`), the browser revision likec4 looked for was never downloaded. Reporter currently works around it by symlinking the expected revision dir.

### Fix

- **`.github/workflows/docker.yaml`** — derive the exact Playwright version from `pnpm-lock.yaml` and pass it as the `PLAYWRIGHT_VER` build arg, so the installed browser always matches likec4's bundled Playwright.
- **`pnpm-workspace.yaml`** — pin the `playwright` catalog entry to an exact version (`1.60.0`) instead of `^1.58.2`, so the published `likec4` package depends on exactly that version with no install-time drift. `e2e` and the lockfile are updated accordingly.
- **`Dockerfile`** — keep `ARG PLAYWRIGHT_VER` as a default for local builds, with a comment noting the CI workflow overrides it.

### Verification

- Workflow extraction returns the expected version: `grep -oE 'playwright@[0-9]+\.[0-9]+\.[0-9]+' pnpm-lock.yaml | head -1 | cut -d@ -f2`
- `docker.yaml` validated as well-formed YAML.
- Full end-to-end confirmation: trigger the `docker` workflow (`workflow_dispatch`), check the build log line `Resolved PLAYWRIGHT_VER=…`, then run `likec4 export png` against the resulting image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)