### PR TITLE
fix(playground): keep Fork button visible on narrow screens

### DIFF
--- a/apps/playground/src/routes/share.$shareId/view/$viewId.tsx
+++ b/apps/playground/src/routes/share.$shareId/view/$viewId.tsx
@@ -86,7 +86,17 @@ const ForkPlaygroundWorkspace = ({ workspace: { workspaceId: _id, ...workspace }
     createNew,
   }] = useWorkspaces()
   return (
-    <Box className="react-flow__panel top right">
+    <Box
+      className="react-flow__panel top right"
+      css={{
+        // On narrow screens the navigation toolbar spans the full width and would
+        // cover the Fork button, so push it below the toolbar. Once there is enough
+        // room (`@/md`) the toolbar no longer overlaps and the default offset is used.
+        marginTop: '[40px]',
+        '@/md': {
+          marginTop: '[15px]',
+        },
+      }}>
       <HStack gap="xs">
         <Button
           variant="default"


### PR DESCRIPTION
Closes #2931

## Problem

On the shared-playground view, the **Fork** button is a `top right` react-flow panel. On narrow viewports the diagram's navigation toolbar spans the full width (it only collapses to a compact top-left bar at the `@/sm` container breakpoint), so the toolbar covers the Fork button — on a small window / phone it's hidden and hard to press, as reported.

## Fix

Offset the Fork panel below the toolbar on narrow screens, and restore the default react-flow panel margin (`15px`) from `@/md` upward, where the toolbar is compact and no longer overlaps. Desktop layout is unchanged (no extra gap).

```tsx
<Box
  className="react-flow__panel top right"
  css={{
    marginTop: '[40px]',
    '@/md': { marginTop: '[15px]' },
  }}>
```

Scoped entirely to the playground share route ([`view/$viewId.tsx`](https://github.com/likec4/likec4/blob/main/apps/playground/src/routes/share.%24shareId/view/%24viewId.tsx)); no change to the shared diagram component.

## Testing

Verified locally against the dev server: created a forkable share, then narrowed the window — the Fork button now sits clearly below the toolbar and stays reachable; widening back to desktop shows it at the normal top-right position with no extra gap.
