### PR TITLE
fix(language-server): apply manual layouts in layoutedModel()

### DIFF
--- a/.changeset/fix-layouted-model-manual-layouts.md
+++ b/.changeset/fix-layouted-model-manual-layouts.md
@@ -1,0 +1,7 @@
+---
+'@likec4/language-server': patch
+---
+
+fix: `layoutedModel()` now applies manual layouts
+
+`layoutedModel()` used `layoutAllViews()`, which returns fresh auto-layouts and ignores manual layouts. As a result, consumers such as the `codegen react` CLI command produced views without the manual layout applied. It now uses `diagrams()`, which merges manual layouts via `withLayoutType()`.

--- a/packages/language-server/src/LikeC4LanguageServices.ts
+++ b/packages/language-server/src/LikeC4LanguageServices.ts
@@ -257,15 +257,14 @@ export class DefaultLikeC4LanguageServices implements LikeC4LanguageServices {
     if (!model) {
       throw new Error('Failed to compute model, empty project?')
     }
-    const layouted = await this.views.layoutAllViews(projectId, cancelToken)
+    // Use `diagrams()` rather than `layoutAllViews()` so that manual layouts are applied.
+    // `layoutAllViews()` returns fresh auto-layouts only, while `diagrams()` merges manual
+    // layouts via `withLayoutType(..., 'manual')`. See https://github.com/likec4/likec4/issues/2553
+    const diagrams = await this.views.diagrams(projectId, cancelToken)
     return LikeC4Model.create({
       ...model.$data,
       _stage: 'layouted' as const,
-      views: pipe(
-        layouted,
-        map(prop('diagram')),
-        indexBy(prop('id')),
-      ),
+      views: indexBy(diagrams, prop('id')),
     })
   }
 

--- a/packages/language-server/src/model/__tests__/issue-2553.spec.ts
+++ b/packages/language-server/src/model/__tests__/issue-2553.spec.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, it, vi } from 'vitest'
+import { createTestServices } from '../../test'
+
+// https://github.com/likec4/likec4/issues/2553
+// `layoutedModel()` used `layoutAllViews()`, which returns fresh auto-layouts and ignores
+// manual layouts — so `codegen react` (and other `layoutedModel()` consumers) produced
+// views without manual layouts. The fix routes view resolution through `diagrams()`, which
+// merges manual layouts via `withLayoutType(..., 'manual')`.
+//
+// This is a call-path regression guard: it asserts `layoutedModel()` goes through the
+// manual-layout-aware `diagrams()` path. A full behavioral test would need to wire up the
+// `ManualLayouts` service with a snapshot, for which the suite has no existing harness.
+describe('Issue 2553 - layoutedModel routes through diagrams()', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  const source = `
+    specification {
+      element system
+    }
+    model {
+      a = system 'A'
+      b = system 'B'
+      a -> b
+    }
+    views {
+      view index {
+        include *
+      }
+    }
+  `
+
+  it('layoutedModel() resolves views via diagrams() (the manual-layout-aware path)', async ({ expect }) => {
+    const { services, validate } = createTestServices()
+    await validate(source)
+
+    const diagramsSpy = vi.spyOn(services.likec4.Views, 'diagrams')
+
+    const model = await services.likec4.LanguageServices.layoutedModel()
+
+    // The layouted views are still produced correctly
+    expect(model.view('index')).toBeDefined()
+
+    // If `layoutedModel()` regresses to `layoutAllViews()`, `diagrams()` is no longer called
+    // and manual layouts stop being applied.
+    expect(diagramsSpy).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Closes #2553

## Problem

`layoutedModel()` resolved views with `layoutAllViews()`, which returns fresh **auto**-layouts and ignores manual layouts. So every consumer of `layoutedModel()` — the `codegen react` CLI command, the Vite virtual model module, and the `FetchLayoutedModel` RPC — produced views *without* manual layouts applied. This also contradicts the method's own doc comment: *"Applies manual layouts if available."*

## Fix

Switch `layoutedModel()` to `this.views.diagrams()`. Both methods delegate to the same private `_layoutAllViews()`, but `diagrams()` additionally merges manual layouts via `withLayoutType(..., 'manual')` and returns `LayoutedView[]` directly (so the `map(prop('diagram'))` step is dropped).

```ts
const diagrams = await this.views.diagrams(projectId, cancelToken)
return LikeC4Model.create({
  ...model.$data,
  _stage: 'layouted' as const,
  views: indexBy(diagrams, prop('id')),
})
```

This matches the approach @davydkov [agreed with on the issue](https://github.com/likec4/likec4/issues/2553).

## Test

Adds a regression test that guards the call path: `layoutedModel()` must route view resolution through `diagrams()` (the manual-layout-aware path). It fails if `layoutedModel()` regresses to `layoutAllViews()`.

> Note: this is a call-path guard rather than a full behavioral test — a behavioral test would need to wire up the `ManualLayouts` service with a snapshot, for which the suite has no existing harness. Happy to add a deeper test if you'd prefer.

## Verification
- New test passes with the fix and fails when reverted to `layoutAllViews()` (confirmed locally).
- Existing `packages/language-server` `LikeC4Views.spec.ts` and `packages/likec4` `LikeC4.spec.ts` (a `layoutedModel()` consumer) still pass.
