### PR TITLE
feat: define relationship properties in specification

### DIFF
--- a/.changeset/relationship-spec-properties.md
+++ b/.changeset/relationship-spec-properties.md
@@ -1,0 +1,18 @@
+---
+'@likec4/core': minor
+'@likec4/language-server': minor
+---
+
+Allow defining `title`, `description` and links on relationship kinds in the `specification`, the same way as for element kinds. These properties are inherited by every relationship of that kind and can be overridden per relationship.
+
+```likec4
+specification {
+  relationship async {
+    title 'Asynchronous'
+    description 'Communication over a message broker'
+    link https://example.com/async
+  }
+}
+```
+
+Closes [#2260](https://github.com/likec4/likec4/issues/2260)

--- a/apps/docs/src/content/docs/dsl/relationships.mdx
+++ b/apps/docs/src/content/docs/dsl/relationships.mdx
@@ -108,6 +108,24 @@ or from a business perspective (delegation, informing, accountability, etc.).
 
 You can define whichever relationship types best fit your context.
 
+A relationship kind can also define default properties — `title`, `description`, `technology`, `notation` and [links](#links) — inherited by every relationship of that kind (a relationship may override any of them):
+
+```likec4
+specification {
+  relationship async {
+    title 'Asynchronous'
+    technology 'Kafka'
+  }
+}
+model {
+  // inherits title 'Asynchronous' and technology 'Kafka'
+  system1 .async system2
+
+  // overrides the title, keeps the inherited technology
+  system1 .async system3 'publishes events'
+}
+```
+
 <Aside type='tip'>
   With kinds you can customize the styling of the relationships, see [styling](/dsl/styling#relationship)
 </Aside>

--- a/apps/docs/src/content/docs/dsl/specification.mdx
+++ b/apps/docs/src/content/docs/dsl/specification.mdx
@@ -51,15 +51,34 @@ specification {
 
 ## Relationship
 
+Relationship kinds may define properties (`title`, `description`, `technology`, `notation`, links) and visual styles:
+
 ```likec4
 specification {
   relationship async {
+    title 'Asynchronous'
+    description 'Communication over a message broker'
+    technology 'Kafka'
+    notation 'Async'
+    link https://example.com/async
     multiple true
     line dotted
     color amber
   }
   relationship subscribes
   relationship is-downstream-of
+}
+```
+
+These properties are inherited by every relationship of that kind, unless the relationship overrides them:
+
+```likec4
+model {
+  // inherits the title and style defined for the 'async' kind
+  ui .async backend
+
+  // overrides the title, keeps the inherited style
+  ui .async db 'reads from'
 }
 ```
 

--- a/packages/core/src/types/model-spec.ts
+++ b/packages/core/src/types/model-spec.ts
@@ -66,8 +66,12 @@ export function isTagColorSpecified(spec: string | TagSpecification): spec is { 
 }
 
 export interface RelationshipSpecification {
+  title?: string
+  // long description
+  description?: scalar.MarkdownOrString
   technology?: string
   notation?: string
+  links?: NonEmptyArray<Link>
   color?: Color
   line?: RelationshipLineType
   head?: RelationshipArrowType

--- a/packages/language-server/src/__tests__/specification.spec.ts
+++ b/packages/language-server/src/__tests__/specification.spec.ts
@@ -408,6 +408,59 @@ describe('specification', () => {
         }
       }`
 
+    test('spec with relationshipkind defining title').valid`
+      specification {
+        relationship async {
+          title "Asynchronous"
+        }
+        relationship sync {
+          title: "Synchronous";
+        }
+      }`
+
+    test('spec with relationshipkind defining description').valid`
+      specification {
+        relationship async {
+          description "Asynchronous communication"
+        }
+      }`
+
+    test('spec with relationshipkind defining link').valid`
+      specification {
+        relationship async {
+          link https://example.com/async
+        }
+      }`
+
+    test('spec with relationshipkind defining title, description, link, technology, notation and style').valid`
+      specification {
+        relationship async {
+          title "Asynchronous"
+          description "Asynchronous communication"
+          link https://example.com/async
+          technology "Kafka"
+          notation "Async"
+          color red
+          line dotted
+        }
+        // Different order
+        relationship sync {
+          line solid
+          notation "Sync"
+          technology "REST"
+          link https://example.com/sync
+          description "Synchronous communication"
+          title "Synchronous"
+        }
+      }`
+
+    test('invalid relationshipkind with empty title').invalid`
+      specification {
+        relationship async {
+          title
+        }
+      }`
+
     test('spec with invalid relationshipkind color').invalid`
       specification {
         relationship async {

--- a/packages/language-server/src/ast.ts
+++ b/packages/language-server/src/ast.ts
@@ -73,18 +73,7 @@ export interface ParsedAstSpecification {
     color?: c4.ColorLiteral
   }>
   elements: Record<c4.ElementKind, c4.ElementSpecification>
-  relationships: Record<
-    c4.RelationshipKind,
-    {
-      technology?: string
-      notation?: string
-      color?: c4.Color
-      line?: c4.RelationshipLineType
-      head?: c4.RelationshipArrowType
-      tail?: c4.RelationshipArrowType
-      multiple?: boolean
-    }
-  >
+  relationships: Record<c4.RelationshipKind, c4.RelationshipSpecification>
   colors: Record<
     c4.CustomColor,
     {

--- a/packages/language-server/src/like-c4.langium
+++ b/packages/language-server/src/like-c4.langium
@@ -82,6 +82,7 @@ SpecificationColor:
 SpecificationRelationshipKind:
   'relationship' kind=RelationshipKind ('{'
     props+=(
+      LinkProperty |
       RelationshipStyleProperty |
       SpecificationRelationshipStringProperty |
       MultipleProperty
@@ -90,7 +91,7 @@ SpecificationRelationshipKind:
 ;
 
 SpecificationRelationshipStringProperty:
-  key=('technology' | 'notation') ':'? value=MarkdownOrString ';'?;
+  key=('title' | 'description' | 'technology' | 'notation') ':'? value=MarkdownOrString ';'?;
 
 // Imports -------------------------------------
 

--- a/packages/language-server/src/model/__tests__/model-builder.spec.ts
+++ b/packages/language-server/src/model/__tests__/model-builder.spec.ts
@@ -946,6 +946,102 @@ describe('LikeC4ModelBuilder', () => {
     expect(viewsWithReadableEdges(model)).toMatchSnapshot()
   })
 
+  it('builds model with relationship spec with title, description and link', async ({ expect }) => {
+    const { validate, buildModel } = createTestServices()
+    const { diagnostics } = await validate(`
+    specification {
+      element person
+      relationship async {
+        title 'Asynchronous'
+        description 'Async communication'
+        link https://example.com/async
+      }
+    }
+    model {
+      person user1
+      person user2
+
+      user1 .async user2
+    }
+    `)
+    expect(diagnostics).toHaveLength(0)
+    const model = await buildModel()
+    expect(model).toBeDefined()
+    expect(values(model.relations)[0]).toMatchObject({
+      source: {
+        model: 'user1',
+      },
+      target: {
+        model: 'user2',
+      },
+      kind: 'async',
+      title: 'Asynchronous',
+      description: { txt: 'Async communication' },
+      links: [{ url: 'https://example.com/async' }],
+    })
+  })
+
+  it('relationship own properties override specification defaults', async ({ expect }) => {
+    const { validate, buildModel } = createTestServices()
+    const { diagnostics } = await validate(`
+    specification {
+      element person
+      relationship async {
+        title 'Asynchronous'
+        description 'Async communication'
+      }
+    }
+    model {
+      person user1
+      person user2
+
+      user1 .async user2 'explicit title' {
+        description 'explicit description'
+      }
+    }
+    `)
+    expect(diagnostics).toHaveLength(0)
+    const model = await buildModel()
+    expect(values(model.relations)[0]).toMatchObject({
+      kind: 'async',
+      title: 'explicit title',
+      description: { txt: 'explicit description' },
+    })
+  })
+
+  // Deployment relations inherit spec title automatically (parser omits unset title)
+  it('builds deployment relationship inheriting title from specification', async ({ expect }) => {
+    const { validate, buildModel } = createTestServices()
+    const { diagnostics } = await validate(`
+    specification {
+      element component
+      relationship async {
+        title 'Asynchronous'
+      }
+      deploymentNode node
+    }
+    model {
+      component sys
+    }
+    deployment {
+      node n1 {
+        sys1 = instanceOf sys
+      }
+      node n2 {
+        sys2 = instanceOf sys
+      }
+
+      n1 .async n2
+    }
+    `)
+    expect(diagnostics).toHaveLength(0)
+    const model = await buildModel()
+    expect(values(model.deployments.relations)[0]).toMatchObject({
+      kind: 'async',
+      title: 'Asynchronous',
+    })
+  })
+
   it('builds model with styled relationship', async ({ expect }) => {
     const { validate, buildModel } = createTestServices()
     const { diagnostics } = await validate(`

--- a/packages/language-server/src/model/builder/MergedSpecification.ts
+++ b/packages/language-server/src/model/builder/MergedSpecification.ts
@@ -186,6 +186,7 @@ export class MergedSpecification {
     kind,
     links,
     id,
+    title,
     ...model
   }: ParsedAstRelation): c4.Relationship | null => {
     if (isNonNullish(kind) && this.specs.relationships[kind]) {
@@ -194,6 +195,8 @@ export class MergedSpecification {
         ...spec,
         ...model,
         ...(links && { links }),
+        // Relation has no own title -> inherit from specification (if any)
+        title: isEmptyish(title) ? (spec.title ?? title) : title,
         source,
         target,
         kind,
@@ -203,6 +206,7 @@ export class MergedSpecification {
     return {
       ...(links && { links }),
       ...model,
+      title,
       source,
       target,
       id,

--- a/packages/language-server/src/model/parser/SpecificationParser.ts
+++ b/packages/language-server/src/model/parser/SpecificationParser.ts
@@ -1,7 +1,7 @@
 import * as c4 from '@likec4/core'
 import { exact } from '@likec4/core'
 import { nonNullable } from '@likec4/core/utils'
-import { filter, isNonNullish, isNullish, isTruthy, mapToObj, omitBy, pipe } from 'remeda'
+import { filter, isTruthy, mapToObj, pipe } from 'remeda'
 import { ast, parseMarkdownAsString, toRelationshipStyle } from '../../ast'
 import { type Base, removeIndent } from './Base'
 
@@ -35,7 +35,8 @@ export function SpecificationParser<TBase extends Base>(B: TBase) {
       }
 
       const relations_specs = specifications.flatMap(s => s.relationships.filter(this.isValid))
-      for (const { kind, props } of relations_specs) {
+      for (const relSpec of relations_specs) {
+        const { kind, props } = relSpec
         try {
           const kindName = kind.name as c4.RelationshipKind
           if (!isTruthy(kindName)) {
@@ -45,12 +46,15 @@ export function SpecificationParser<TBase extends Base>(B: TBase) {
             this.logError(`Relationship kind "${kindName}" is already defined`, kind, 'specification')
             continue
           }
+          const links = this.parseLinks(relSpec)
           const bodyProps = pipe(
             props.filter(ast.isSpecificationRelationshipStringProperty) ?? [],
-            filter(p => this.isValid(p) && isNonNullish(p.value)),
-            mapToObj(p => [p.key, removeIndent(parseMarkdownAsString(p.value))!] satisfies [string, string]),
-            omitBy(isNullish),
+            filter(p => this.isValid(p)),
+            mapToObj(p => [p.key, p.value as ast.MarkdownOrString | undefined]),
           )
+          // `summary` is not supported on relationship kinds (model relations have no summary)
+          const { summary: _summary, ...baseProps } = this.parseBaseProps(bodyProps)
+          const notation = removeIndent(parseMarkdownAsString(bodyProps.notation))
           const multipleProps = props.filter(ast.isMultipleProperty)
           if (multipleProps.length > 1) {
             this.logError(
@@ -60,11 +64,13 @@ export function SpecificationParser<TBase extends Base>(B: TBase) {
             )
           }
           const multipleProp = multipleProps[0]
-          c4Specification.relationships[kindName] = {
-            ...bodyProps,
+          c4Specification.relationships[kindName] = exact({
+            ...baseProps,
+            notation,
+            ...(links && c4.isNonEmptyArray(links) && { links }),
             ...toRelationshipStyle(props.filter(ast.isRelationshipStyleProperty), this.isValid),
             ...(multipleProp && { multiple: multipleProp.value }),
-          }
+          })
         } catch (e) {
           this.logError(e, kind, 'specification')
         }


### PR DESCRIPTION
Implements #2260.

Relationship kinds in the `specification` can now define `title`, `description` and links — the same way element kinds can (introduced for elements in #2111). These are inherited by every relationship of that kind, and a relationship may override any of them.

```likec4
specification {
  relationship async {
    title 'Asynchronous'
    description 'Communication over a message broker'
    link https://example.com/async
  }
}
model {
  ui .async backend            // inherits title, description and link
  ui .async db 'reads from'    // overrides the title, keeps the rest
}
```

### Notes

- Mirrors the element-kind implementation: the spec parser reuses `parseBaseProps`/`parseLinks`, and `ParsedAstSpecification.relationships` now uses `c4.RelationshipSpecification` (previously a hand-maintained inline duplicate of the type).
- `summary` is intentionally **not** added — model relations have no `summary` field (`RelationStringProperty` is `title | technology | description`), so inheriting it would be inconsistent.
- Inheritance: `description` / `technology` / `links` already flow through the existing `{ ...spec, ...model }` merge; only `title` needs explicit handling in `toModelRelation`, because the relation parser defaults an unset title to `''`. Deployment relations inherit automatically (their parser omits an unset title) — covered by a test.

### Tests

- Grammar validation for `title` / `description` / `link` on relationship kinds.
- Model relations inherit `title` / `description` / `links` from the spec; a relation's own properties override the spec defaults.
- Deployment relations inherit the spec title.

## Checklist

- [x] I've thoroughly read the latest [contribution guidelines](https://github.com/likec4/likec4/blob/main/CONTRIBUTING.md).
- [x] I've rebased my branch onto `main` **before** creating this PR.
- [x] I've added tests to cover my changes (if applicable).
- [x] I've verified `pnpm typecheck` and `pnpm test`.
- [x] I've added [changesets](https://changesets-docs.vercel.app/) (you can use `/changeset-generator` SKILL).
- [x] My change requires documentation updates.
- [x] I've updated the documentation accordingly (or will do in follow-up PR).
