### PR TITLE
fix: preserve manual layouts in layouted model

### DIFF
--- a/.changeset/fix-layouted-model-manual-layouts.md
+++ b/.changeset/fix-layouted-model-manual-layouts.md
@@ -1,0 +1,7 @@
+---
+'@likec4/language-server': patch
+---
+
+Preserve manual layout positions when generating layouted models.
+
+Fixes [#2553](https://github.com/likec4/likec4/issues/2553)

--- a/packages/language-server/src/LikeC4LanguageServices.ts
+++ b/packages/language-server/src/LikeC4LanguageServices.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import type { LikeC4ProjectConfig } from '@likec4/config'
 import {
   type LayoutedView,
@@ -257,13 +264,23 @@ export class DefaultLikeC4LanguageServices implements LikeC4LanguageServices {
     if (!model) {
       throw new Error('Failed to compute model, empty project?')
     }
-    const layouted = await this.views.layoutAllViews(projectId, cancelToken)
+    const diagrams = await this.views.diagrams(projectId, cancelToken)
+    const layoutedViews = diagrams.map(diagram => {
+      if (diagram._layout === 'manual' && model.findManualLayout(diagram.id) && diagram.drifts === undefined) {
+        return {
+          ...diagram,
+          // `undefined` means the view model should calculate drifts.
+          // `null` marks an applied manual layout with no drifts to calculate.
+          drifts: null,
+        }
+      }
+      return diagram
+    })
     return LikeC4Model.create({
       ...model.$data,
       _stage: 'layouted' as const,
       views: pipe(
-        layouted,
-        map(prop('diagram')),
+        layoutedViews,
         indexBy(prop('id')),
       ),
     })

--- a/packages/language-server/src/views/LikeC4Views.spec.ts
+++ b/packages/language-server/src/views/LikeC4Views.spec.ts
@@ -1,9 +1,21 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
+import type { LayoutedView, NodeId, ViewId } from '@likec4/core'
 import { deepEqual } from 'fast-equals'
 import { indexBy } from 'remeda'
-import { describe } from 'vitest'
+import { afterEach, describe, vi } from 'vitest'
 import { testFileScope as it } from '../test'
 
 describe('LikeC4Views', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   it('diagrams returns cached result', async ({ expect, t }) => {
     await t.validate(`
       specification {
@@ -69,5 +81,182 @@ describe('LikeC4Views', () => {
     expect(diagrams1.index).not.toStrictEqual(diagrams2.index)
     // expect that sys2 view is the same
     expect(diagrams1.sys2).toStrictEqual(diagrams2.sys2)
+  })
+
+  it('layoutedModel preserves manual layout snapshots', async ({ expect, t }) => {
+    await t.validate(`
+      specification {
+        element component
+      }
+      model {
+        component sys1
+        component sys2
+        sys1 -> sys2
+      }
+      views {
+        view index {
+          include *
+        }
+      }
+    `)
+
+    const autoDiagram = await t.services.likec4.Views.diagrams().then(diagrams => diagrams[0])
+    expect(autoDiagram).toBeDefined()
+
+    const manualDiagram: LayoutedView = {
+      ...autoDiagram!,
+      _layout: 'manual',
+      nodes: autoDiagram!.nodes.map(node =>
+        node.id === 'sys1'
+          ? {
+            ...node,
+            x: 1000,
+            y: 2000,
+          }
+          : node
+      ),
+    }
+    const viewId = manualDiagram.id as ViewId
+
+    const manualLayouts = t.services.shared.workspace.ManualLayouts
+    vi.spyOn(manualLayouts, 'read').mockResolvedValue({
+      hash: 'manual-layout-hash',
+      views: {
+        [viewId]: manualDiagram,
+      },
+    })
+    t.services.shared.workspace.WorkspaceManager.forceCleanCaches()
+
+    const layoutedModel = await t.services.likec4.LanguageServices.layoutedModel()
+    const viewData = layoutedModel.$data.views[viewId]
+    if (!viewData) {
+      throw new Error(`Expected view data for ${viewId}`)
+    }
+    const view = layoutedModel.view('index').$view
+    const firstNode = view.nodes.find(node => node.id === 'sys1' as NodeId)
+
+    expect(layoutedModel.findManualLayout('index')).toEqual(manualDiagram)
+    expect(layoutedModel.$data.manualLayouts?.[viewId]).toEqual(manualDiagram)
+    expect(Object.hasOwn(viewData, 'drifts')).toBe(true)
+    expect(viewData.drifts).toBeNull()
+    expect(view._layout).toBe('manual')
+    expect(firstNode).toMatchObject({
+      x: 1000,
+      y: 2000,
+    })
+  })
+
+  it('layoutedModel preserves applied manual layout drift reasons', async ({ expect, t }) => {
+    await t.validate(`
+      specification {
+        element component
+      }
+      model {
+        component sys1
+        component sys2
+        sys1 -> sys2
+      }
+      views {
+        view index {
+          include *
+        }
+      }
+    `)
+
+    const autoDiagram = await t.services.likec4.Views.diagrams().then(diagrams => diagrams[0])
+    expect(autoDiagram).toBeDefined()
+
+    const manualDiagram: LayoutedView = {
+      ...autoDiagram!,
+      _layout: 'manual',
+      drifts: ['nodes-drift'],
+    }
+    const viewId = manualDiagram.id as ViewId
+
+    const manualLayouts = t.services.shared.workspace.ManualLayouts
+    vi.spyOn(manualLayouts, 'read').mockResolvedValue({
+      hash: 'manual-layout-hash',
+      views: {
+        [viewId]: manualDiagram,
+      },
+    })
+    t.services.shared.workspace.WorkspaceManager.forceCleanCaches()
+    vi.spyOn(t.services.likec4.Views, 'diagrams').mockResolvedValue([manualDiagram])
+
+    const layoutedModel = await t.services.likec4.LanguageServices.layoutedModel()
+    const viewData = layoutedModel.$data.views[viewId]
+
+    expect(viewData).toEqual(manualDiagram)
+  })
+
+  it('layoutedModel keeps auto views when another view has manual layout', async ({ expect, t }) => {
+    await t.validate(`
+      specification {
+        element component
+      }
+      model {
+        component sys1
+        component sys2 {
+          component sys21
+        }
+        sys1 -> sys2.sys21
+      }
+      views {
+        view index {
+          include *
+        }
+        view sys2 of sys2 {
+          include *
+        }
+      }
+    `)
+
+    const diagrams = await t.services.likec4.Views.diagrams().then(d => indexBy(d, v => v.id as 'index' | 'sys2'))
+    const indexDiagram = diagrams.index
+    if (!indexDiagram) {
+      throw new Error('Expected index diagram')
+    }
+    const manualDiagram: LayoutedView = {
+      ...indexDiagram,
+      _layout: 'manual',
+      nodes: indexDiagram.nodes.map(node =>
+        node.id === 'sys1'
+          ? {
+            ...node,
+            x: 1000,
+            y: 2000,
+          }
+          : node
+      ),
+    }
+    const viewId = manualDiagram.id as ViewId
+
+    const manualLayouts = t.services.shared.workspace.ManualLayouts
+    vi.spyOn(manualLayouts, 'read').mockResolvedValue({
+      hash: 'manual-layout-hash',
+      views: {
+        [viewId]: manualDiagram,
+      },
+    })
+    t.services.shared.workspace.WorkspaceManager.forceCleanCaches()
+
+    const layoutedModel = await t.services.likec4.LanguageServices.layoutedModel()
+    const views = layoutedModel.$data.views
+    const manualView = views['index']
+    const autoView = views['sys2']
+    if (!manualView) {
+      throw new Error('Expected manual index view')
+    }
+    if (!autoView) {
+      throw new Error('Expected auto sys2 view')
+    }
+
+    expect(Object.keys(views)).toEqual(expect.arrayContaining(['index', 'sys2']))
+    expect(manualView._layout).toBe('manual')
+    expect(manualView.nodes.find(node => node.id === 'sys1')).toMatchObject({
+      x: 1000,
+      y: 2000,
+    })
+    expect(autoView._layout).not.toBe('manual')
   })
 })


### PR DESCRIPTION
Fixes #2553

## Summary
- Preserve manual layout positions when `layoutedModel()` is used for generated model data.
- Keep real manual-layout drift reasons, and mark applied no-drift manual views as resolved.
- Add regression coverage for manual-only and mixed manual/auto view models.

## Validation
- Red before fix: manual layout was returned as auto layout in `layoutedModel()`.
- `pnpm --filter @likec4/language-server test -- src/views/LikeC4Views.spec.ts -t "layoutedModel"`
- LikeC4 license header check: passed.
- Cursor: no blocking findings after fixes.
- Claude: requested mixed-view regression coverage; added.
- CodeRabbit: 0 issues.

## Screenshots
Not applicable: this fixes generated layouted model data and has no static visual UI delta.