### PR TITLE
fix: inherit dynamic relationship kind styles

### DIFF
--- a/.changeset/fix-dynamic-relationship-kind-styles.md
+++ b/.changeset/fix-dynamic-relationship-kind-styles.md
@@ -1,0 +1,7 @@
+---
+'@likec4/core': patch
+---
+
+Inherit relationship kind styles in dynamic views.
+
+Fixes [#2916](https://github.com/likec4/likec4/issues/2916)

--- a/packages/core/src/compute-view/dynamic-view/__test__/step-fields.spec.ts
+++ b/packages/core/src/compute-view/dynamic-view/__test__/step-fields.spec.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { describe, expect, it } from 'vitest'
 import { Builder } from '../../../builder/Builder'
 import type { LikeC4Model } from '../../../model'
@@ -330,6 +337,40 @@ describe('Dynamic view step fields', () => {
       })
     })
 
+    it('should inherit styles from model relationship kind specification', () => {
+      const model = Builder
+        .specification({
+          elements: ['el'],
+          relationships: {
+            action: {
+              color: 'green',
+              line: 'solid',
+              head: 'open',
+              tail: 'diamond',
+            },
+          },
+        })
+        .model(({ el, rel }, _) =>
+          _(
+            el('shopify'),
+            el('webhook'),
+            rel('shopify', 'webhook', {
+              kind: 'action',
+            }),
+          )
+        )
+        .toLikeC4Model()
+
+      const edge = computeEdgeFromStep(model)
+
+      expect(edge).toMatchObject({
+        color: 'green',
+        line: 'solid',
+        head: 'open',
+        tail: 'diamond',
+      })
+    })
+
     it('should combine technology and styles from specification', () => {
       const model = Builder
         .specification({
@@ -362,6 +403,39 @@ describe('Dynamic view step fields', () => {
         line: 'solid',
         head: 'open',
         tail: 'diamond',
+      })
+    })
+
+    it('should inherit specification styles from model relationship kind', () => {
+      const model = Builder
+        .specification({
+          elements: ['el'],
+          relationships: {
+            requests: {
+              technology: 'HTTP Request',
+              color: 'blue',
+              line: 'solid',
+            },
+          },
+        })
+        .model(({ el, rel }, _) =>
+          _(
+            el('shopify'),
+            el('webhook'),
+            rel('shopify', 'webhook', {
+              kind: 'requests',
+            }),
+          )
+        )
+        .toLikeC4Model()
+
+      const edge = computeEdgeFromStep(model)
+
+      expect(edge).toMatchObject({
+        kind: 'requests',
+        technology: 'HTTP Request',
+        color: 'blue',
+        line: 'solid',
       })
     })
   })

--- a/packages/core/src/compute-view/dynamic-view/utils.spec.ts
+++ b/packages/core/src/compute-view/dynamic-view/utils.spec.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { describe, expect, it } from 'vitest'
 import { Builder } from '../../builder/Builder'
 import type { LikeC4Model } from '../../model'
@@ -15,6 +22,17 @@ describe('findRelations', () => {
       relationships: {
         requests: {
           technology: 'HTTP Request',
+          color: 'blue',
+          line: 'solid',
+          head: 'open',
+          tail: 'diamond',
+        },
+        responds: {
+          technology: 'Webhook Response',
+          color: 'red',
+          line: 'dashed',
+          head: 'normal',
+          tail: 'odot',
         },
       },
       tags: {},
@@ -101,6 +119,57 @@ describe('findRelations', () => {
 
     expect(result).toMatchObject({
       technology: 'HTTP Request',
+    })
+  })
+
+  it('should return style from single relationship kind specification', () => {
+    const model = baseModel
+      .model(({ rel }, _) =>
+        _(
+          rel('shopify', 'webhook', {
+            kind: 'requests',
+          }),
+        )
+      )
+      .toLikeC4Model()
+    const shopify = model.element('shopify')
+    const webhook = model.element('webhook')
+
+    const result = findRelations(shopify, webhook, viewId)
+
+    expect(result).toMatchObject({
+      kind: 'requests',
+      technology: 'HTTP Request',
+      color: 'blue',
+      line: 'solid',
+      head: 'open',
+      tail: 'diamond',
+    })
+  })
+
+  it('should prefer explicit relationship arrow styles over kind specification', () => {
+    const model = baseModel
+      .model(({ rel }, _) =>
+        _(
+          rel('shopify', 'webhook', {
+            kind: 'requests',
+            head: 'normal',
+            tail: 'odot',
+          }),
+        )
+      )
+      .toLikeC4Model()
+    const shopify = model.element('shopify')
+    const webhook = model.element('webhook')
+
+    const result = findRelations(shopify, webhook, viewId)
+
+    expect(result).toMatchObject({
+      kind: 'requests',
+      color: 'blue',
+      line: 'solid',
+      head: 'normal',
+      tail: 'odot',
     })
   })
 
@@ -227,6 +296,58 @@ describe('findRelations', () => {
       technology: 'HTTP Request',
       kind: 'requests',
     })
+    expect(result.relations).toHaveLength(2)
+  })
+
+  it('should return style when multiple relationships share the same kind specification', () => {
+    const model = baseModel
+      .model(({ rel }, _) =>
+        _(
+          rel('a.child1', 'b.child1', {
+            kind: 'requests',
+          }),
+          rel('a.child2', 'b.child2', {
+            kind: 'requests',
+          }),
+        )
+      )
+      .toLikeC4Model()
+
+    const result = testFindRelationsOnModel(model)
+
+    expect(result).toMatchObject({
+      kind: 'requests',
+      technology: 'HTTP Request',
+      color: 'blue',
+      line: 'solid',
+      head: 'open',
+      tail: 'diamond',
+    })
+    expect(result.relations).toHaveLength(2)
+  })
+
+  it('should not return style when multiple relationships have different kind specifications', () => {
+    const model = baseModel
+      .model(({ rel }, _) =>
+        _(
+          rel('a.child1', 'b.child1', {
+            kind: 'requests',
+          }),
+          rel('a.child2', 'b.child2', {
+            kind: 'responds',
+          }),
+        )
+      )
+      .toLikeC4Model()
+
+    const result = testFindRelationsOnModel(model)
+
+    expect(result).not.toHaveProperty('kind')
+    expect(result).not.toHaveProperty('technology')
+    expect(result).not.toHaveProperty('color')
+    expect(result).not.toHaveProperty('line')
+    expect(result).not.toHaveProperty('head')
+    expect(result).not.toHaveProperty('tail')
     expect(result.relations).toHaveLength(2)
   })
 })

--- a/packages/core/src/compute-view/dynamic-view/utils.ts
+++ b/packages/core/src/compute-view/dynamic-view/utils.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { first, flatMap, hasAtLeast, isDeepEqual, isTruthy, map, only, pipe, reduce, unique } from 'remeda'
 import type { ElementModel } from '../../model'
 import { findConnection } from '../../model/connection/model'
@@ -11,6 +18,7 @@ import {
   type DynamicViewStep,
   type MarkdownOrString,
   type NonEmptyArray,
+  type RelationshipArrowType,
   type RelationshipLineType,
   type ViewRuleGlobalStyle,
   exact,
@@ -119,6 +127,8 @@ export function findRelations<A extends Any>(
   navigateTo?: aux.StrictViewId<A>
   color?: Color
   line?: RelationshipLineType
+  head?: RelationshipArrowType
+  tail?: RelationshipArrowType
   technology?: string
   description?: MarkdownOrString
 } {
@@ -128,16 +138,21 @@ export function findRelations<A extends Any>(
   if (!isNonEmptyArray(relationships)) {
     return {}
   }
+  const specificationOf = (kind: aux.RelationKind<A> | null | undefined) =>
+    kind ? source.$model.specification.relationships[kind] : undefined
   if (relationships.length === 1) {
     const relation = relationships[0]
+    const spec = specificationOf(relation.kind)
     return exact({
       title: relation.title ?? undefined,
       kind: relation.kind ?? undefined,
       tags: relation.tags,
       relations: [relation.id],
       navigateTo: relation.$relationship.navigateTo,
-      color: relation.$relationship.color,
-      line: relation.$relationship.line,
+      color: relation.$relationship.color ?? spec?.color,
+      line: relation.$relationship.line ?? spec?.line,
+      head: relation.$relationship.head ?? spec?.head,
+      tail: relation.$relationship.tail ?? spec?.tail,
       technology: relation.technology ?? undefined,
       description: relation.$relationship.description ?? undefined,
     })
@@ -169,11 +184,18 @@ export function findRelations<A extends Any>(
 
   const commonProperties = pipe(
     relationships,
-    reduce((acc, { title, technology, $relationship: r }) => {
+    reduce((acc, { title, technology, kind, $relationship: r }) => {
+      const spec = specificationOf(kind)
+      const color = r.color ?? spec?.color
+      const line = r.line ?? spec?.line
+      const head = r.head ?? spec?.head
+      const tail = r.tail ?? spec?.tail
       isTruthy(title) && acc.title.add(title)
-      isTruthy(r.color) && acc.color.add(r.color)
-      isTruthy(r.line) && acc.line.add(r.line)
-      isTruthy(r.kind) && acc.kind.add(r.kind)
+      isTruthy(color) && acc.color.add(color)
+      isTruthy(line) && acc.line.add(line)
+      isTruthy(head) && acc.head.add(head)
+      isTruthy(tail) && acc.tail.add(tail)
+      isTruthy(kind) && acc.kind.add(kind)
       isTruthy(technology) && acc.technology.add(technology)
       if (isTruthy(r.description) && !acc.description.some(isDeepEqual(r.description))) {
         acc.description.push(r.description)
@@ -183,6 +205,8 @@ export function findRelations<A extends Any>(
       kind: new Set<aux.RelationKind<A>>(),
       color: new Set<Color>(),
       line: new Set<RelationshipLineType>(),
+      head: new Set<RelationshipArrowType>(),
+      tail: new Set<RelationshipArrowType>(),
       title: new Set<string>(),
       technology: new Set<string>(),
       description: [] as MarkdownOrString[],
@@ -197,6 +221,8 @@ export function findRelations<A extends Any>(
     title: only([...commonProperties.title]),
     color: only([...commonProperties.color]),
     line: only([...commonProperties.line]),
+    head: only([...commonProperties.head]),
+    tail: only([...commonProperties.tail]),
     technology: only([...commonProperties.technology]),
     description: only(commonProperties.description),
   })


### PR DESCRIPTION
Fixes #2916

## Summary
- Inherit relationship-kind styles for dynamic view relationships when the model relationship omits explicit style fields.
- Covers color, line, head, tail, and the existing technology inheritance path.
- Add tests for single relationships, shared kind specs, conflicting kind specs, and explicit arrow overrides.

## Validation
- Red before fix: dynamic relationship kind styles missed `head`/`tail` and fell back to default arrows.
- `pnpm --filter @likec4/core test -- src/compute-view/dynamic-view`
- LikeC4 license header check: passed.
- Cursor: no blocking findings after fixes.
- Claude: requested override/conflict coverage; added.
- CodeRabbit: 0 issues.

## Screenshots
Not applicable: this fixes dynamic-view relationship style data and has no static visual UI delta.