### PR TITLE
fix: add keyboard diagram zoom shortcuts

### DIFF
--- a/.changeset/fix-keyboard-diagram-zoom.md
+++ b/.changeset/fix-keyboard-diagram-zoom.md
@@ -1,0 +1,7 @@
+---
+'@likec4/diagram': patch
+---
+
+Add keyboard zoom shortcuts for focused diagrams and make zoomable diagrams keyboard-focusable.
+
+Fixes [#2915](https://github.com/likec4/likec4/issues/2915)

--- a/apps/docs/src/content/docs/tooling/react.mdx
+++ b/apps/docs/src/content/docs/tooling/react.mdx
@@ -38,6 +38,17 @@ Add [`@likec4/core`](https://www.npmjs.com/package/%40likec4%2Fcore) and [`@like
   />
 <br />
 
+## Keyboard shortcuts
+
+Focused diagrams support keyboard zoom shortcuts. Click a diagram or tab into it first; while the diagram is focused,
+these shortcuts control diagram zoom instead of browser page zoom. Tab out of the diagram to use browser page zoom.
+
+| Shortcut | Action |
+| --- | --- |
+| `Ctrl`/`Cmd` + `+` or `=` | Zoom in |
+| `Ctrl`/`Cmd` + `-` or `_` | Zoom out |
+| `Ctrl`/`Cmd` + `0` | Reset the viewport |
+
 LikeC4 React library can be used in two ways.
 
 

--- a/e2e/tests/accessible-zoom.spec.ts
+++ b/e2e/tests/accessible-zoom.spec.ts
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import { expect, test } from '@playwright/test'
+import type { Page } from '@playwright/test'
+import { canvas } from '../helpers/selectors'
+import { TIMEOUT_CANVAS } from '../helpers/timeouts'
+
+type ViewportTransform = {
+  raw: string
+  scale: number
+  x: number
+  y: number
+}
+
+async function viewportTransform(page: Page): Promise<ViewportTransform> {
+  return page.locator('.react-flow__viewport').first().evaluate((element) => {
+    const raw = window.getComputedStyle(element).transform
+    const matrix = new DOMMatrixReadOnly(raw)
+    return {
+      raw,
+      scale: matrix.a,
+      x: matrix.e,
+      y: matrix.f,
+    }
+  })
+}
+
+function isSameViewportTransform(actual: ViewportTransform, expected: ViewportTransform): boolean {
+  return Math.abs(actual.scale - expected.scale) <= 0.001
+    && Math.abs(actual.x - expected.x) <= 1
+    && Math.abs(actual.y - expected.y) <= 1
+}
+
+test('diagram supports keyboard zoom shortcuts (#2915)', async ({ page }) => {
+  await page.goto('/project/e2e/view/index/')
+  await expect(canvas(page)).toBeVisible({ timeout: TIMEOUT_CANVAS })
+
+  const diagram = page.locator('.react-flow').first()
+  await diagram.focus()
+  await expect(diagram).toBeFocused()
+
+  const before = await viewportTransform(page)
+  await page.keyboard.press('Control+Equal')
+  await expect.poll(async () => (await viewportTransform(page)).raw).not.toBe(before.raw)
+
+  const afterZoomIn = await viewportTransform(page)
+  await page.keyboard.press('Control+-')
+  await expect.poll(async () => (await viewportTransform(page)).raw).not.toBe(afterZoomIn.raw)
+
+  await page.keyboard.press('Control+-')
+  await expect.poll(async () => (await viewportTransform(page)).raw).not.toBe(before.raw)
+
+  const afterZoomOut = await viewportTransform(page)
+  await page.keyboard.press('Control+0')
+  await expect.poll(async () => (await viewportTransform(page)).raw).not.toBe(afterZoomOut.raw)
+  await expect.poll(async () => isSameViewportTransform(await viewportTransform(page), before)).toBe(true)
+})

--- a/packages/diagram/src/base/BaseXYFlow.tsx
+++ b/packages/diagram/src/base/BaseXYFlow.tsx
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { cx } from '@likec4/styles/css'
 import { useMantineColorScheme } from '@mantine/core'
 import {
@@ -6,17 +13,18 @@ import {
   ReactFlow,
   useStore,
 } from '@xyflow/react'
-import { useMemo } from 'react'
+import { type KeyboardEvent, useMemo } from 'react'
 import type { SetRequired, Simplify } from 'type-fest'
 import { useCallbackRef } from '../hooks/useCallbackRef'
 import { useUpdateEffect } from '../hooks/useUpdateEffect'
-import { useIsZoomTooSmall, useXYStoreApi } from '../hooks/useXYFlow'
+import { useIsZoomTooSmall, useXYFlow, useXYStoreApi } from '../hooks/useXYFlow'
 import type { ViewPadding } from '../LikeC4Diagram.props'
 import { roundDpr } from '../utils/roundDpr'
 import { stopPropagation } from '../utils/xyflow'
 import { type XYBackground, Background } from './Background'
 import { Base } from './Base'
 import { MaxZoom, MinZoom } from './const'
+import { getKeyboardZoomAction } from './keyboardZoom'
 import type { BaseEdge, BaseNode } from './types'
 
 export type BaseXYFlowProps<NodeType extends BaseNode, EdgeType extends BaseEdge> = Simplify<
@@ -85,11 +93,39 @@ export function BaseXYFlow<
 
   const isBgWithPattern = background !== 'transparent' && background !== 'solid'
   const isZoomTooSmall = useIsZoomTooSmall()
+  const xyflow = useXYFlow()
   const xystore = useXYStoreApi()
   const { colorScheme } = useMantineColorScheme()
   if (!colorMode) {
     colorMode = colorScheme === 'auto' ? 'system' : colorScheme
   }
+
+  const tabIndex = props.tabIndex ?? (zoomable ? 0 : undefined)
+  const hasAccessibleName = props['aria-label'] !== undefined || props['aria-labelledby'] !== undefined
+  const ariaLabel = hasAccessibleName || tabIndex === undefined ? props['aria-label'] : 'Interactive diagram'
+
+  const onKeyDown = useCallbackRef((event: KeyboardEvent<HTMLDivElement>) => {
+    props.onKeyDown?.(event)
+    if (event.defaultPrevented || !zoomable) {
+      return
+    }
+    const action = getKeyboardZoomAction(event.nativeEvent)
+    if (!action) {
+      return
+    }
+    event.preventDefault()
+    switch (action) {
+      case 'zoom-in':
+        void xyflow.zoomIn()
+        return
+      case 'zoom-out':
+        void xyflow.zoomOut()
+        return
+      case 'reset':
+        void xyflow.fitView(fitViewOptions)
+        return
+    }
+  })
 
   return (
     <ReactFlow<NodeType, EdgeType>
@@ -195,6 +231,9 @@ export function BaseXYFlow<
       onNodeDoubleClick={stopPropagation}
       onEdgeDoubleClick={stopPropagation}
       {...props}
+      aria-label={ariaLabel}
+      tabIndex={tabIndex}
+      onKeyDown={onKeyDown}
     >
       {isBgWithPattern && <Background background={background} />}
       {onViewportResize && <ViewportResizeHanlder onViewportResize={onViewportResize} />}

--- a/packages/diagram/src/base/keyboardZoom.spec.ts
+++ b/packages/diagram/src/base/keyboardZoom.spec.ts
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { getKeyboardZoomAction, isEditableKeyboardTarget } from './keyboardZoom'
+
+const hadHTMLElement = 'HTMLElement' in globalThis
+const hadDocument = 'document' in globalThis
+const originalHTMLElement = globalThis.HTMLElement
+const originalDocument = globalThis.document
+
+class TestHTMLElement extends EventTarget {
+  public isContentEditable = false
+
+  constructor(public readonly tagName: string) {
+    super()
+  }
+
+  public set contentEditable(value: string) {
+    this.isContentEditable = value === 'true'
+  }
+}
+
+beforeAll(() => {
+  Object.assign(globalThis, {
+    HTMLElement: TestHTMLElement,
+    document: {
+      body: new TestHTMLElement('body'),
+      createElement: (tagName: string) => new TestHTMLElement(tagName),
+    },
+  })
+})
+
+afterAll(() => {
+  if (hadHTMLElement) {
+    globalThis.HTMLElement = originalHTMLElement
+  } else {
+    Reflect.deleteProperty(globalThis, 'HTMLElement')
+  }
+
+  if (hadDocument) {
+    globalThis.document = originalDocument
+  } else {
+    Reflect.deleteProperty(globalThis, 'document')
+  }
+})
+
+function event(key: string, target: EventTarget | null = document.body): Pick<
+  KeyboardEvent,
+  'key' | 'ctrlKey' | 'metaKey' | 'target'
+> {
+  return {
+    key,
+    ctrlKey: true,
+    metaKey: false,
+    target,
+  }
+}
+
+describe('keyboard zoom helpers', () => {
+  it('maps ctrl/meta zoom shortcuts to actions', () => {
+    expect(getKeyboardZoomAction(event('+'))).toBe('zoom-in')
+    expect(getKeyboardZoomAction(event('='))).toBe('zoom-in')
+    expect(getKeyboardZoomAction(event('-'))).toBe('zoom-out')
+    expect(getKeyboardZoomAction(event('_'))).toBe('zoom-out')
+    expect(getKeyboardZoomAction(event('0'))).toBe('reset')
+    expect(getKeyboardZoomAction({
+      key: '+',
+      ctrlKey: false,
+      metaKey: true,
+      target: document.body,
+    })).toBe('zoom-in')
+  })
+
+  it('ignores non-modified and unrelated keys', () => {
+    expect(getKeyboardZoomAction({
+      key: '+',
+      ctrlKey: false,
+      metaKey: false,
+      target: document.body,
+    })).toBeNull()
+    expect(getKeyboardZoomAction(event('k'))).toBeNull()
+  })
+
+  it('detects editable keyboard targets', () => {
+    const input = document.createElement('input')
+    const select = document.createElement('select')
+    const textarea = document.createElement('textarea')
+    const editable = document.createElement('div')
+    editable.contentEditable = 'true'
+
+    expect(isEditableKeyboardTarget(input)).toBe(true)
+    expect(isEditableKeyboardTarget(select)).toBe(true)
+    expect(isEditableKeyboardTarget(textarea)).toBe(true)
+    expect(isEditableKeyboardTarget(editable)).toBe(true)
+    expect(isEditableKeyboardTarget(document.createElement('button'))).toBe(false)
+  })
+
+  it('does not map shortcuts from editable targets', () => {
+    const input = document.createElement('input')
+
+    expect(getKeyboardZoomAction(event('+', input))).toBeNull()
+  })
+})

--- a/packages/diagram/src/base/keyboardZoom.ts
+++ b/packages/diagram/src/base/keyboardZoom.ts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+export type KeyboardZoomAction = 'zoom-in' | 'zoom-out' | 'reset'
+
+export function isEditableKeyboardTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) {
+    return false
+  }
+  const tagName = target.tagName.toLowerCase()
+  return tagName === 'input' || tagName === 'textarea' || tagName === 'select' || target.isContentEditable
+}
+
+export function getKeyboardZoomAction(event: Pick<KeyboardEvent, 'key' | 'ctrlKey' | 'metaKey' | 'target'>):
+  | KeyboardZoomAction
+  | null
+{
+  if ((!event.ctrlKey && !event.metaKey) || isEditableKeyboardTarget(event.target)) {
+    return null
+  }
+  switch (event.key) {
+    case '+':
+    case '=':
+      return 'zoom-in'
+    case '-':
+    case '_':
+      return 'zoom-out'
+    case '0':
+      return 'reset'
+    default:
+      return null
+  }
+}


### PR DESCRIPTION
Fixes #2915

## Summary
- Add keyboard zoom shortcuts for focused diagrams: `Ctrl`/`Cmd` + `+`/`=`, `-`/`_`, and `0`.
- Make zoomable diagrams keyboard-focusable by default while preserving caller-provided focus and key handlers.
- Document focus behavior and add unit plus Playwright coverage for keyboard zoom.

## Validation
- Red before fix: shortcut helper returned no action and the Playwright viewport transform did not change.
- `pnpm --filter @likec4/diagram test -- src/base/keyboardZoom.spec.ts`
- `pnpm --dir e2e exec playwright test tests/accessible-zoom.spec.ts`
- LikeC4 license header check: passed.
- Cursor: no blocking findings after fixes.
- Claude: no blocking findings; select editable-target coverage and docs note added.
- CodeRabbit: minor docs key-variant finding fixed; rerun reported 0 issues.

## Screenshots
Not applicable: this is a keyboard interaction change with no static visual before/after state.