### PR TITLE
chore: add pre-push typecheck hook

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,1 @@
+pnpm git:pre-push

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "clean": "pnpm -r run clean && rimraf -v -g \"**/.turbo\" \"**/node_modules/.cache\" \"**/node_modules/.vite\"",
     "clean:lib": "rimraf -v -g \"packages/*/lib\" \"styled-system/*/lib\" \"**/.tsbuildinfo\"",
     "git:pre-commit": "nano-staged",
+    "git:pre-push": "pnpm typecheck",
     "test": "vitest run --no-isolate",
     "test:affected": "turbo run test --affected --filter=\"!./apps/*\"",
     "test:watch": "vitest --no-isolate",


### PR DESCRIPTION
## Summary

Adds a Husky pre-push hook that runs the existing `pnpm typecheck` command before local branches are pushed. This catches TypeScript failures earlier without slowing down every commit.

## Validation

- `pnpm git:pre-push`
- `git diff --check origin/main..HEAD`
- `dprint check package.json`
- LikeC4 NVIDIA header checker: skipped `.husky/pre-push` and `package.json` as non-stampable files

No changeset is included because this is contributor tooling only and does not affect published package behavior.