### PR TITLE
fix(language-server): file watcher honors project `exclude` (fixes EMFILE on large repos)

### DIFF
--- a/.changeset/watcher-honor-exclude.md
+++ b/.changeset/watcher-honor-exclude.md
@@ -1,0 +1,7 @@
+---
+"@likec4/language-server": patch
+---
+
+Fix `EMFILE: too many open files, watch` crash in `likec4 serve`/`dev` on large repositories.
+
+The file watcher now honors the project's `exclude` patterns from `likec4.config.json`, consistent with how the source scan already filters files. Previously the watcher descended into every directory regardless of `exclude` (it only skipped `node_modules`/`.git` and non-`.c4` files), so on repositories where `.c4` files are a small fraction of a large tree it could exhaust the OS file-watch limit and crash on startup.

--- a/packages/language-server/src/filesystem/ChokidarWatcher.ts
+++ b/packages/language-server/src/filesystem/ChokidarWatcher.ts
@@ -64,11 +64,7 @@ export class ChokidarFileSystemWatcher implements FileSystemWatcher {
     let watcher = chokidar.watch(folder, {
       ignored: [
         path => insideNodeModulesOrRepo(path),
-        // Honor the project's `exclude` patterns (likec4.config.json) so the
-        // watcher does not descend into large excluded subtrees. Without this,
-        // the watcher walks the entire workspace regardless of `exclude` and
-        // can crash with `EMFILE: too many open files, watch` on big repos,
-        // where the .c4 sources are a small fraction of the tree.
+        // Honor the project's `exclude` so the watcher skips excluded subtrees.
         path => projectsManager.isExcluded(URI.file(path)),
         (path, stats) => !!stats && stats.isFile() && !isAnyLikeC4File(path),
       ],

--- a/packages/language-server/src/filesystem/ChokidarWatcher.ts
+++ b/packages/language-server/src/filesystem/ChokidarWatcher.ts
@@ -59,9 +59,17 @@ export class ChokidarFileSystemWatcher implements FileSystemWatcher {
   private createWatcher(folder: string): FSWatcher {
     logger.debug`create watcher for folder: ${folder}`
 
+    const projectsManager = this.services.workspace.ProjectsManager
+
     let watcher = chokidar.watch(folder, {
       ignored: [
         path => insideNodeModulesOrRepo(path),
+        // Honor the project's `exclude` patterns (likec4.config.json) so the
+        // watcher does not descend into large excluded subtrees. Without this,
+        // the watcher walks the entire workspace regardless of `exclude` and
+        // can crash with `EMFILE: too many open files, watch` on big repos,
+        // where the .c4 sources are a small fraction of the tree.
+        path => projectsManager.isExcluded(URI.file(path)),
         (path, stats) => !!stats && stats.isFile() && !isAnyLikeC4File(path),
       ],
       followSymlinks: true,


### PR DESCRIPTION
## Problem

On a large repository where `.c4` files are a small fraction of the tree, `likec4 serve` / `dev` crashes on startup with:

```
Unhandled rejection: EMFILE: too many open files, watch
  at FSWatcher._handle.onchange (node:internal/fs/watchers:267:21)
```

The crash happens right after `likec4.server.projects register '<project>'`, before `found N source files`.

The `exclude` option in `likec4.config.json` correctly filters the **scanned** sources, but it is **not applied to the file watcher**. `ChokidarFileSystemWatcher` walks the whole workspace and opens a `fs.watch` handle per directory. On macOS this exceeds `fs.watch` scaling limits and throws `EMFILE` — independent of `ulimit -n` (the limit is internal to macOS `fs.watch`, not `RLIMIT_NOFILE`; verified up to 1048576).

Repro context: a workspace with ~7,600 directories / ~20,000 files of which only 82 are `.c4` (the rest generated OpenAPI/JSON/MD), and a config:

```json
{ "name": "x", "exclude": ["**/node_modules/**", "**/services/**"] }
```

## Cause

`packages/language-server/src/filesystem/ChokidarWatcher.ts` builds the watcher with an `ignored` list that only skips `node_modules`/`.git` directories and non-`.c4` **files**:

```ts
ignored: [
  path => insideNodeModulesOrRepo(path),
  (path, stats) => !!stats && stats.isFile() && !isAnyLikeC4File(path),
]
```

It never consults the project's `exclude` patterns. Because the second predicate matches only **files**, excluded **directories** are still descended into and watched.

Contributing factor: chokidar 4+ dropped `fsevents`, so on macOS it falls back to per-directory `fs.watch` (one handle per dir) instead of a single recursive native watcher — which is why the *directory* count is what triggers `EMFILE`.

## Fix

Honor the project's `exclude` in the watcher, reusing the matcher `ProjectsManager` already compiles (`isExcluded()`), so excluded directories are pruned during traversal — consistent with the source scan.

## Validation

- Built from source with this change and ran the patched CLI against the failing repo (`likec4 serve domains/` from the repo root):
  ```
  likec4.lang  workspace: found 82 source files
  likec4.vite  Enabling HMR: localhost:24678 (auto-discovered)
  Local:   http://localhost:5173/
  ```
  No more `EMFILE`; the dev server starts normally. Watched directory count dropped 7,589 → 414.
- `pnpm typecheck` for `@likec4/language-server` ✅
- `@likec4/language-server` test suite ✅ (721 passed, 2 skipped, 2 todo)

## Note

Honoring `exclude` resolves it in practice. For workspaces that remain very large *after* exclusion, a follow-up could watch only directories that contain (or lead to) `.c4`/config/layout files, or re-introduce a single recursive native watcher on macOS — happy to explore in a separate PR if desired.

## Checklist

- [x] I've thoroughly read the latest [contribution guidelines](https://github.com/likec4/likec4/blob/main/CONTRIBUTING.md).
- [x] I've rebased my branch onto `main` **before** creating this PR.
- [ ] I've added tests to cover my changes (if applicable). <!-- The watcher's `ignored` predicates are not currently unit-tested; validated manually against a large real-world workspace (see Validation). Happy to add a test if you can point me at the preferred harness. -->
- [x] I've verified `pnpm typecheck` and `pnpm test` (typecheck across deps + the `@likec4/language-server` suite, 721 passing).
- [x] I've added [changesets](https://changesets-docs.vercel.app/) (`@likec4/language-server`, patch).
- [ ] My change requires documentation updates.
- [ ] I've updated the documentation accordingly (or will do in follow-up PR).
