### PR TITLE
feat(diagram): show full view description in tooltip in navigation panel

### DIFF
--- a/.changeset/view-description-tooltip.md
+++ b/.changeset/view-description-tooltip.md
@@ -1,0 +1,9 @@
+---
+'@likec4/diagram': patch
+---
+
+Navigation panel: show the full view description in a tooltip on hover.
+
+View descriptions in the navigation menu are truncated to fit the item, so long descriptions were not fully readable without opening the view. Hovering a view now reveals its complete description in a tooltip.
+
+Closes [#2933](https://github.com/likec4/likec4/issues/2933)

--- a/packages/diagram/src/navigationpanel/NavigationPanelDropdown.tsx
+++ b/packages/diagram/src/navigationpanel/NavigationPanelDropdown.tsx
@@ -47,6 +47,7 @@ import { isArray, isEmpty, pipe, sort } from 'remeda'
 import { type NavigationLinkProps, NavigationLink } from '../components/NavigationLink'
 import { useOnDiagramEvent } from '../hooks/useDiagram'
 import { useLikeC4Model } from '../hooks/useLikeC4Model'
+import { Tooltip } from './_common'
 import type { NavigationPanelActorContext, NavigationPanelActorSnapshot } from './actor'
 import { ProjectsMenu } from './dropdown/ProjectsMenu'
 import {
@@ -521,17 +522,26 @@ function FolderColumnItem({ columnItem, ...props }: { columnItem: ColumnItem } &
       )
     case 'view':
       return (
-        <NavigationLink
-          key={columnItem.viewId}
-          variant="filled"
-          active={columnItem.selected}
-          label={columnItem.title}
-          description={columnItem.description}
-          leftSection={ViewTypeIcon[columnItem.viewType]}
-          maw="300px"
-          miw="200px"
-          {...props}
-        />
+        <Tooltip
+          label={columnItem.description}
+          disabled={!columnItem.description}
+          multiline
+          w={260}
+          withinPortal
+          position="left"
+        >
+          <NavigationLink
+            key={columnItem.viewId}
+            variant="filled"
+            active={columnItem.selected}
+            label={columnItem.title}
+            description={columnItem.description}
+            leftSection={ViewTypeIcon[columnItem.viewType]}
+            maw="300px"
+            miw="200px"
+            {...props}
+          />
+        </Tooltip>
       )
     default:
       nonexhaustive(columnItem)


### PR DESCRIPTION
Closes #2933.

View descriptions in the navigation panel are truncated to fit the menu item (single line + ellipsis), so long descriptions were not fully readable without opening the view. Hovering a view item now reveals its **complete** description in a tooltip — mirroring the truncated-text + tooltip pattern already used for element metadata values (`overlays/element-details/MetadataValue.tsx`).

The tooltip is disabled when a view has no description, so empty tooltips never appear.

### Verified locally

Ran the playground (`@likec4/playground`, dev server uses the diagram source) with a model whose views are grouped in a folder and have long descriptions:

- Hovering a view **with** a description → tooltip shows the full description text. ✅
- Hovering a view **without** a description → no tooltip. ✅

## Checklist

- [x] I've thoroughly read the latest [contribution guidelines](https://github.com/likec4/likec4/blob/main/CONTRIBUTING.md).
- [x] I've rebased my branch onto `main` **before** creating this PR.
- [ ] I've added tests to cover my changes (if applicable).
- [x] I've verified `pnpm typecheck` and `pnpm test`.
- [x] I've added [changesets](https://changesets-docs.vercel.app/) (you can use `/changeset-generator` SKILL).
- [ ] My change requires documentation updates.
- [ ] I've updated the documentation accordingly (or will do in follow-up PR).
