### PR TITLE
Fix link with label showing both label and url

### DIFF
--- a/packages/diagram/src/components/Link.tsx
+++ b/packages/diagram/src/components/Link.tsx
@@ -22,7 +22,7 @@ export const Link = forwardRef<HTMLDivElement, Omit<BadgeProps, 'children' | 'cl
         radius="sm"
         size="sm"
         tt="none"
-        leftSection={value.title ? <>{value.title}</> : null}
+        leftSection={null}
         rightSection={
           <CopyButton value={url} timeout={1500}>
             {({ copy, copied }) => (
@@ -98,13 +98,13 @@ export const Link = forwardRef<HTMLDivElement, Omit<BadgeProps, 'children' | 'cl
               _hover: 'underline',
             },
           }}>
-          {isGithub && (
+          {!value.title && isGithub && (
             <GithubIcon
               height="12"
               width="12"
               style={{ verticalAlign: 'middle', marginRight: '4px' }} />
           )}
-          {isGithub ? url.replace(GITHUB_PREFIX, '') : url}
+          {value.title ? value.title : isGithub ? url.replace(GITHUB_PREFIX, '') : url}
         </styled.a>
       </Badge>
     )

--- a/packages/diagram/src/components/Link.tsx
+++ b/packages/diagram/src/components/Link.tsx
@@ -104,7 +104,7 @@ export const Link = forwardRef<HTMLDivElement, Omit<BadgeProps, 'children' | 'cl
               width="12"
               style={{ verticalAlign: 'middle', marginRight: '4px' }} />
           )}
-          {value.title ? value.title : isGithub ? url.replace(GITHUB_PREFIX, '') : url}
+          {value.title ?? (isGithub ? url.replace(GITHUB_PREFIX, '') : url)}
         </styled.a>
       </Badge>
     )


### PR DESCRIPTION
This fixes issue #3076 where a link with a label was showing both the label and the URL. Now, if a label is provided, only the label will be displayed, and the URL will be hidden.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask, and propose improvements. We're here to help. -->

- [x] I've thoroughly read the latest [contribution guidelines](https://github.com/likec4/likec4/blob/main/CONTRIBUTING.md).
- [x] I've rebased my branch onto `main` **before** creating this PR.
- [ ] I've added tests to cover my changes (if applicable).
- [x] I've verified `pnpm typecheck` and `pnpm test`. **(found 12 errors but none related to my update)**
- [ ] I've added [changesets](https://changesets-docs.vercel.app/) (you can use `/changeset-generator` SKILL).
- [ ] My change requires documentation updates.
- [ ] I've updated the documentation accordingly (or will do in follow-up PR).
