### PR TITLE
feat: configure webapp export formats

### DIFF
--- a/.changeset/webapp-export-formats.md
+++ b/.changeset/webapp-export-formats.md
@@ -1,0 +1,8 @@
+---
+'@likec4/config': patch
+'likec4': patch
+---
+
+Allow generated webapps to limit available export formats from project config.
+
+Omitting `webapp.exportFormats` keeps all current formats enabled; an empty list hides webapp exports.

--- a/apps/docs/src/content/docs/dsl/Config/index.mdx
+++ b/apps/docs/src/content/docs/dsl/Config/index.mdx
@@ -257,6 +257,7 @@ Use an empty array to remove the Export button.
 
 Supported values are `png`, `jpg`, `dot`, `d2`, `mmd`, `puml`, and `drawio`.
 This setting affects the generated webapp only; CLI export commands are unchanged.
+For `png` and `jpg`, this removes the menu entries; direct image export routes used by screenshot automation remain available.
 In multi-project webapps, each project uses its own export format list.
 
 ## Image Aliases

--- a/apps/docs/src/content/docs/dsl/Config/index.mdx
+++ b/apps/docs/src/content/docs/dsl/Config/index.mdx
@@ -239,6 +239,26 @@ Hide specific views from the landing page grid:
 }
 ```
 
+## Webapp export formats
+
+Configure which export formats are available in the generated web application.
+When `webapp.exportFormats` is omitted, all webapp exports remain enabled.
+Use an empty array to remove the Export button.
+
+```jsonc
+{
+  "$schema": "https://likec4.dev/schemas/config.json",
+  "name": "project-name",
+  "webapp": {
+    "exportFormats": ["png", "jpg", "drawio"]
+  }
+}
+```
+
+Supported values are `png`, `jpg`, `dot`, `d2`, `mmd`, `puml`, and `drawio`.
+This setting affects the generated webapp only; CLI export commands are unchanged.
+In multi-project webapps, each project uses its own export format list.
+
 ## Image Aliases
 
 When using local images in your LikeC4 model, you can create aliases for the folder your images are in to make them more readable and the files more transportable.

--- a/e2e/bootstrap.mjs
+++ b/e2e/bootstrap.mjs
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 // @ts-nocheck
 
 import 'zx/globals'
@@ -20,7 +27,7 @@ const likec4 = await LikeC4.fromWorkspace('src', {
   throwIfInvalid: true,
 })
 
-assert.deepEqual(likec4.projects().sort(), ['e2e', 'issue-2282'])
+assert.deepEqual(likec4.projects().sort(), ['e2e', 'export-config', 'export-disabled', 'issue-2282'])
 
 // Check e2e workspace
 const computedModel = likec4.syncComputedModel('e2e')

--- a/e2e/src/export-config/.likec4rc
+++ b/e2e/src/export-config/.likec4rc
@@ -1,0 +1,7 @@
+{
+  name: 'export-config',
+  implicitViews: false,
+  webapp: {
+    exportFormats: ['png'],
+  },
+}

--- a/e2e/src/export-config/source.c4
+++ b/e2e/src/export-config/source.c4
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+specification {
+  element system
+}
+
+model {
+  app = system "Application" {
+    -> api "uses"
+  }
+
+  api = system "API"
+}
+
+views {
+  view index {
+    include *
+  }
+}

--- a/e2e/src/export-disabled/.likec4rc
+++ b/e2e/src/export-disabled/.likec4rc
@@ -1,0 +1,7 @@
+{
+  name: 'export-disabled',
+  implicitViews: false,
+  webapp: {
+    exportFormats: [],
+  },
+}

--- a/e2e/src/export-disabled/source.c4
+++ b/e2e/src/export-disabled/source.c4
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+specification {
+  element system
+}
+
+model {
+  app = system "Application" {
+    -> api "uses"
+  }
+
+  api = system "API"
+}
+
+views {
+  view index {
+    include *
+  }
+}

--- a/e2e/tests/search-params.spec.ts
+++ b/e2e/tests/search-params.spec.ts
@@ -43,6 +43,10 @@ function projectViewUrl(projectId: string, viewId: string, extra?: Record<string
   return `/project/${encodeURIComponent(projectId)}/view/${encodeURIComponent(viewId)}/${qs ? `?${qs}` : ''}`
 }
 
+function projectTextExportUrl(projectId: string, viewId: string, format: 'dot' | 'd2' | 'mmd' | 'puml'): string {
+  return `/project/${encodeURIComponent(projectId)}/view/${encodeURIComponent(viewId)}/${format}`
+}
+
 function viewUrl(viewId: string, extra?: Record<string, string>): string {
   return projectViewUrl(PROJECT, viewId, extra)
 }
@@ -157,6 +161,18 @@ test.describe('webapp.exportFormats configuration', () => {
     }
 
     await gotoAndWaitForCanvas(page, projectExportUrl(EXPORT_CONFIG_PROJECT, STATIC_VIEW))
+  })
+
+  test('blocks direct text export routes for disabled formats', async ({ page }) => {
+    await page.goto(projectTextExportUrl(EXPORT_CONFIG_PROJECT, STATIC_VIEW, 'dot'))
+
+    await expect(page.getByText(/The diagram\s+index\s+does not exist or contains errors/)).toBeVisible()
+  })
+
+  test('keeps direct text export routes available for enabled formats', async ({ page }) => {
+    await page.goto(projectTextExportUrl(PROJECT, STATIC_VIEW, 'dot'))
+
+    await expect(page.getByText('digraph {').first()).toBeVisible()
   })
 
   test('removes export entry points when every webapp export format is disabled', async ({ page }) => {

--- a/e2e/tests/search-params.spec.ts
+++ b/e2e/tests/search-params.spec.ts
@@ -8,7 +8,7 @@
 import type { Page } from '@playwright/test'
 import { expect, test } from '@playwright/test'
 import { canvas } from '../helpers/selectors'
-import { TIMEOUT_CANVAS } from '../helpers/timeouts'
+import { TIMEOUT_CANVAS, TIMEOUT_MENU } from '../helpers/timeouts'
 
 /**
  * E2E tests for URL search parameters (?theme=, ?dynamic=, ?relationships=).
@@ -180,9 +180,6 @@ test.describe('webapp.exportFormats configuration', () => {
     await gotoAndWaitForCanvas(page, projectViewUrl(EXPORT_DISABLED_PROJECT, STATIC_VIEW))
 
     await expect(page.getByRole('button', { name: 'Export', exact: true })).toHaveCount(0)
-
-    await page.goto(projectExportUrl(EXPORT_DISABLED_PROJECT, STATIC_VIEW))
-    await expect(page.getByText(/does not exist or contains errors/)).toBeVisible()
 
     await gotoAndWaitForCanvas(
       page,

--- a/e2e/tests/search-params.spec.ts
+++ b/e2e/tests/search-params.spec.ts
@@ -146,7 +146,7 @@ test.describe('webapp.exportFormats configuration', () => {
     'Export to Draw.io',
   ] as const
 
-  test('limits the view export menu and blocks disabled image export routes', async ({ page }) => {
+  test('limits the view export menu to enabled formats', async ({ page }) => {
     await gotoAndWaitForCanvas(page, projectViewUrl(EXPORT_CONFIG_PROJECT, STATIC_VIEW))
 
     await page.getByRole('button', { name: 'Export', exact: true }).click()
@@ -157,9 +157,6 @@ test.describe('webapp.exportFormats configuration', () => {
     }
 
     await gotoAndWaitForCanvas(page, projectExportUrl(EXPORT_CONFIG_PROJECT, STATIC_VIEW))
-
-    await page.goto(projectExportUrl(EXPORT_CONFIG_PROJECT, STATIC_VIEW, { format: 'jpeg' }))
-    await expect(page.getByRole('alert')).toContainText('does not exist or contains errors')
   })
 
   test('removes export entry points when every webapp export format is disabled', async ({ page }) => {

--- a/e2e/tests/search-params.spec.ts
+++ b/e2e/tests/search-params.spec.ts
@@ -146,7 +146,7 @@ test.describe('webapp.exportFormats configuration', () => {
     'Export to Draw.io',
   ] as const
 
-  test('limits the view export menu and image export route to enabled formats', async ({ page }) => {
+  test('limits the view export menu and blocks disabled image export routes', async ({ page }) => {
     await gotoAndWaitForCanvas(page, projectViewUrl(EXPORT_CONFIG_PROJECT, STATIC_VIEW))
 
     await page.getByRole('button', { name: 'Export', exact: true }).click()
@@ -159,32 +159,12 @@ test.describe('webapp.exportFormats configuration', () => {
     await gotoAndWaitForCanvas(page, projectExportUrl(EXPORT_CONFIG_PROJECT, STATIC_VIEW))
 
     await page.goto(projectExportUrl(EXPORT_CONFIG_PROJECT, STATIC_VIEW, { format: 'jpeg' }))
-    await expect(page.getByText(/does not exist or contains errors/)).toBeVisible()
-  })
-
-  test('uses the same export format list for relationship export menus', async ({ page }) => {
-    await gotoAndWaitForCanvas(
-      page,
-      projectViewUrl(EXPORT_CONFIG_PROJECT, STATIC_VIEW, { relationships: 'app', relationshipScope: 'view' }),
-    )
-
-    await page.getByRole('button', { name: 'Export relationship view' }).click()
-    await expect(page.getByRole('menu')).toBeVisible({ timeout: TIMEOUT_MENU })
-    await expect(page.getByRole('menuitem', { name: 'Export as .png' })).toBeVisible()
-    for (const item of DISABLED_MENU_ITEMS) {
-      await expect(page.getByRole('menuitem', { name: item })).toHaveCount(0)
-    }
+    await expect(page.getByRole('alert')).toContainText('does not exist or contains errors')
   })
 
   test('removes export entry points when every webapp export format is disabled', async ({ page }) => {
     await gotoAndWaitForCanvas(page, projectViewUrl(EXPORT_DISABLED_PROJECT, STATIC_VIEW))
 
     await expect(page.getByRole('button', { name: 'Export', exact: true })).toHaveCount(0)
-
-    await gotoAndWaitForCanvas(
-      page,
-      projectViewUrl(EXPORT_DISABLED_PROJECT, STATIC_VIEW, { relationships: 'app', relationshipScope: 'view' }),
-    )
-    await expect(page.getByRole('button', { name: 'Export relationship view' })).toHaveCount(0)
   })
 })

--- a/e2e/tests/search-params.spec.ts
+++ b/e2e/tests/search-params.spec.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import type { Page } from '@playwright/test'
 import { expect, test } from '@playwright/test'
 import { canvas } from '../helpers/selectors'
@@ -16,18 +23,28 @@ import { TIMEOUT_CANVAS } from '../helpers/timeouts'
  */
 
 const PROJECT = 'e2e'
+const EXPORT_CONFIG_PROJECT = 'export-config'
+const EXPORT_DISABLED_PROJECT = 'export-disabled'
 const STATIC_VIEW = 'index'
 const DYNAMIC_VIEW = 'dynamic-view-1'
 
-function exportUrl(viewId: string, extra?: Record<string, string>): string {
+function projectExportUrl(projectId: string, viewId: string, extra?: Record<string, string>): string {
   const params = new URLSearchParams({ padding: '22', ...extra })
-  return `/project/${encodeURIComponent(PROJECT)}/export/${encodeURIComponent(viewId)}/?${params.toString()}`
+  return `/project/${encodeURIComponent(projectId)}/export/${encodeURIComponent(viewId)}/?${params.toString()}`
+}
+
+function exportUrl(viewId: string, extra?: Record<string, string>): string {
+  return projectExportUrl(PROJECT, viewId, extra)
+}
+
+function projectViewUrl(projectId: string, viewId: string, extra?: Record<string, string>): string {
+  const params = extra ? new URLSearchParams(extra) : undefined
+  const qs = params?.toString()
+  return `/project/${encodeURIComponent(projectId)}/view/${encodeURIComponent(viewId)}/${qs ? `?${qs}` : ''}`
 }
 
 function viewUrl(viewId: string, extra?: Record<string, string>): string {
-  const params = extra ? new URLSearchParams(extra) : undefined
-  const qs = params?.toString()
-  return `/project/${encodeURIComponent(PROJECT)}/view/${encodeURIComponent(viewId)}/${qs ? `?${qs}` : ''}`
+  return projectViewUrl(PROJECT, viewId, extra)
 }
 
 const COLOR_SCHEME_ATTR = 'data-mantine-color-scheme'
@@ -112,5 +129,65 @@ test.describe('?relationships= search parameter', () => {
   test('absent ?relationships= does not open overlay', async ({ page }) => {
     await gotoAndWaitForCanvas(page, viewUrl(STATIC_VIEW))
     await expect(page.locator(RELATIONSHIPS_BROWSER)).toHaveCount(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// webapp.exportFormats
+// ---------------------------------------------------------------------------
+
+test.describe('webapp.exportFormats configuration', () => {
+  const DISABLED_MENU_ITEMS = [
+    'Export as .jpg',
+    'Export as .dot',
+    'Export as .d2',
+    'Export as .mmd',
+    'Export as .puml',
+    'Export to Draw.io',
+  ] as const
+
+  test('limits the view export menu and image export route to enabled formats', async ({ page }) => {
+    await gotoAndWaitForCanvas(page, projectViewUrl(EXPORT_CONFIG_PROJECT, STATIC_VIEW))
+
+    await page.getByRole('button', { name: 'Export', exact: true }).click()
+    await expect(page.getByRole('menu')).toBeVisible({ timeout: TIMEOUT_MENU })
+    await expect(page.getByRole('menuitem', { name: 'Export as .png' })).toBeVisible()
+    for (const item of DISABLED_MENU_ITEMS) {
+      await expect(page.getByRole('menuitem', { name: item })).toHaveCount(0)
+    }
+
+    await gotoAndWaitForCanvas(page, projectExportUrl(EXPORT_CONFIG_PROJECT, STATIC_VIEW))
+
+    await page.goto(projectExportUrl(EXPORT_CONFIG_PROJECT, STATIC_VIEW, { format: 'jpeg' }))
+    await expect(page.getByText(/does not exist or contains errors/)).toBeVisible()
+  })
+
+  test('uses the same export format list for relationship export menus', async ({ page }) => {
+    await gotoAndWaitForCanvas(
+      page,
+      projectViewUrl(EXPORT_CONFIG_PROJECT, STATIC_VIEW, { relationships: 'app', relationshipScope: 'view' }),
+    )
+
+    await page.getByRole('button', { name: 'Export relationship view' }).click()
+    await expect(page.getByRole('menu')).toBeVisible({ timeout: TIMEOUT_MENU })
+    await expect(page.getByRole('menuitem', { name: 'Export as .png' })).toBeVisible()
+    for (const item of DISABLED_MENU_ITEMS) {
+      await expect(page.getByRole('menuitem', { name: item })).toHaveCount(0)
+    }
+  })
+
+  test('removes export entry points when every webapp export format is disabled', async ({ page }) => {
+    await gotoAndWaitForCanvas(page, projectViewUrl(EXPORT_DISABLED_PROJECT, STATIC_VIEW))
+
+    await expect(page.getByRole('button', { name: 'Export', exact: true })).toHaveCount(0)
+
+    await page.goto(projectExportUrl(EXPORT_DISABLED_PROJECT, STATIC_VIEW))
+    await expect(page.getByText(/does not exist or contains errors/)).toBeVisible()
+
+    await gotoAndWaitForCanvas(
+      page,
+      projectViewUrl(EXPORT_DISABLED_PROJECT, STATIC_VIEW, { relationships: 'app', relationshipScope: 'view' }),
+    )
+    await expect(page.getByRole('button', { name: 'Export relationship view' })).toHaveCount(0)
   })
 })

--- a/e2e/tests/webcomponent-overlay.spec.ts
+++ b/e2e/tests/webcomponent-overlay.spec.ts
@@ -60,7 +60,7 @@ test('webcomponent expanded overlay uses the shadow-root theme background (#2965
     hasUnscopedRootHostSelector: false,
   })
 
-  await frame.locator(CANVAS_SELECTOR).first().click()
+  await frame.locator('.react-flow__node').first().click()
 
   const overlayBody = frame.locator('dialog[open] .likec4-overlay-body').first()
   await expect(overlayBody).toBeVisible({ timeout: TIMEOUT_CANVAS })

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -55,6 +55,13 @@
         "default": "./dist/node/index.mjs"
       }
     },
+    "./webapp-export-formats": {
+      "sources": "./src/webapp-export-formats.ts",
+      "default": {
+        "types": "./dist/webapp-export-formats.d.mts",
+        "default": "./dist/webapp-export-formats.mjs"
+      }
+    },
     "./package.json": "./package.json",
     "./schema.json": "./schema.json"
   },

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 export type {
   GeneratorFn,
   GeneratorFnContext,
@@ -6,10 +13,15 @@ export type {
   LikeC4ProjectConfigInput,
   LikeC4ProjectJsonConfig,
   LocateResult,
+  WebappConfig,
+  WebappExportFormat,
 } from './schema'
 
 export {
   LikeC4ProjectConfigOps,
+  WebappConfigSchema,
+  WebappExportFormats,
+  WebappExportFormatSchema,
 } from './schema'
 
 export type {

--- a/packages/config/src/schema.spec.ts
+++ b/packages/config/src/schema.spec.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { describe, it } from 'vitest'
 import { validateProjectConfig as validateConfig } from './schema'
 import { ImageAliasesSchema } from './schema.image-alias'
@@ -80,6 +87,61 @@ describe('ProjectConfig schema', () => {
         const config = { name: 'test', exclude: ['**/node_modules/**', '**/dist/**'] }
         const result = validateConfig(config)
         expect(result.exclude).toEqual(['**/node_modules/**', '**/dist/**'])
+      })
+    })
+
+    describe('webapp field', () => {
+      it('should enable every export format when exportFormats is omitted', ({ expect }) => {
+        const result = validateConfig({
+          name: 'test',
+          webapp: {},
+        })
+
+        expect(result.webapp?.exportFormats).toEqual(['png', 'jpg', 'dot', 'd2', 'mmd', 'puml', 'drawio'])
+      })
+
+      it('should preserve a configured export format allow-list', ({ expect }) => {
+        const result = validateConfig({
+          name: 'test',
+          webapp: {
+            exportFormats: ['jpg', 'drawio', 'dot'],
+          },
+        })
+
+        expect(result.webapp?.exportFormats).toEqual(['jpg', 'drawio', 'dot'])
+      })
+
+      it('should allow disabling every webapp export format', ({ expect }) => {
+        const result = validateConfig({
+          name: 'test',
+          webapp: {
+            exportFormats: [],
+          },
+        })
+
+        expect(result.webapp?.exportFormats).toEqual([])
+      })
+
+      it('should reject duplicate export formats', ({ expect }) => {
+        expect(() =>
+          validateConfig({
+            name: 'test',
+            webapp: {
+              exportFormats: ['png', 'png'],
+            },
+          })
+        ).toThrow('Export formats cannot contain duplicates')
+      })
+
+      it('should reject unknown export formats', ({ expect }) => {
+        expect(() =>
+          validateConfig({
+            name: 'test',
+            webapp: {
+              exportFormats: ['svg'],
+            },
+          })
+        ).toThrow()
       })
     })
 

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -53,6 +53,34 @@ export const ManualLayoutsConfigSchema = z
 
 export type ManualLayoutsConfig = z.infer<typeof ManualLayoutsConfigSchema>
 
+export const WebappExportFormats = ['png', 'jpg', 'dot', 'd2', 'mmd', 'puml', 'drawio'] as const
+
+export const WebappExportFormatSchema = z.enum(WebappExportFormats)
+
+export type WebappExportFormat = z.infer<typeof WebappExportFormatSchema>
+
+export const WebappConfigSchema = z
+  .strictObject({
+    exportFormats: z.array(WebappExportFormatSchema)
+      .refine(
+        (formats) => new Set(formats).size === formats.length,
+        { message: 'Export formats cannot contain duplicates' },
+      )
+      .default([...WebappExportFormats])
+      .meta({
+        description: [
+          'Webapp export formats enabled in the generated application.',
+          'Omit to enable all export formats. Use an empty array to disable webapp exports.',
+        ].join('\n'),
+      }),
+  })
+  .meta({
+    id: 'WebappConfig',
+    description: 'Configuration for the generated web application',
+  })
+
+export type WebappConfig = z.infer<typeof WebappConfigSchema>
+
 export const LandingPageSchema = z
   .union([
     z.strictObject({
@@ -128,6 +156,7 @@ export const LikeC4ProjectJsonConfigSchema = z.object({
       description: 'Auto-generate scoped views for elements without explicit views. Defaults to false.',
     }),
   landingPage: LandingPageSchema.optional(),
+  webapp: WebappConfigSchema.optional(),
 })
   .meta({
     id: 'LikeC4ProjectConfig',

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -22,6 +22,7 @@ import z from 'zod/v4'
 import { ImageAliasesSchema } from './schema.image-alias'
 import { type IncludeConfig, IncludeSchema } from './schema.include'
 import { LikeC4StylesConfigSchema } from './schema.theme'
+import { type WebappExportFormat, WebappExportFormats } from './webapp-export-formats'
 
 export interface VscodeURI {
   readonly scheme: string
@@ -53,11 +54,11 @@ export const ManualLayoutsConfigSchema = z
 
 export type ManualLayoutsConfig = z.infer<typeof ManualLayoutsConfigSchema>
 
-export const WebappExportFormats = ['png', 'jpg', 'dot', 'd2', 'mmd', 'puml', 'drawio'] as const
+export { WebappExportFormats }
 
 export const WebappExportFormatSchema = z.enum(WebappExportFormats)
 
-export type WebappExportFormat = z.infer<typeof WebappExportFormatSchema>
+export type { WebappExportFormat }
 
 export const WebappConfigSchema = z
   .strictObject({

--- a/packages/config/src/webapp-export-formats.ts
+++ b/packages/config/src/webapp-export-formats.ts
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+export const WebappExportFormats = ['png', 'jpg', 'dot', 'd2', 'mmd', 'puml', 'drawio'] as const
+
+export type WebappExportFormat = typeof WebappExportFormats[number]

--- a/packages/config/tsdown.config.mts
+++ b/packages/config/tsdown.config.mts
@@ -5,6 +5,7 @@ export default defineConfig({
   entry: [
     'src/index.ts',
     'src/node/index.ts',
+    'src/webapp-export-formats.ts',
   ],
   platform: 'node',
   hooks: {

--- a/packages/likec4-spa/src/components/view-page/Header.tsx
+++ b/packages/likec4-spa/src/components/view-page/Header.tsx
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { useLikeC4Projects } from '@likec4/diagram'
 import {
   Button,
@@ -17,6 +24,10 @@ import {
 } from '@tanstack/react-router'
 import { AnimatePresence } from 'motion/react'
 import { memo, useCallback, useState } from 'react'
+import {
+  enabledWebappExportFormats,
+  isWebappExportFormatEnabled,
+} from '../../export-formats'
 import { useCurrentProject, useCurrentViewId } from '../../hooks'
 import { ColorSchemeToggle } from '../ColorSchemeToggle'
 import { NavigationPanel } from './NavigationPanel'
@@ -106,6 +117,7 @@ function ExportButton() {
   const [isDrawioLoading, setIsDrawioLoading] = useState(false)
   const project = useCurrentProject()
   const viewId = useCurrentViewId()
+  const enabledFormats = enabledWebappExportFormats(project)
 
   const handleDrawioExport = useCallback(async () => {
     try {
@@ -120,6 +132,10 @@ function ExportButton() {
       setIsDrawioLoading(false)
     }
   }, [project.id, viewId])
+
+  if (enabledFormats.length === 0) {
+    return null
+  }
 
   return (
     <Menu shadow="md" width={200} trigger="click-hover" openDelay={200}>
@@ -137,67 +153,81 @@ function ExportButton() {
 
       <MenuDropdown>
         <MenuLabel>Current view</MenuLabel>
-        <MenuItem
-          renderRoot={(props) => (
-            <Link
-              target="_blank"
-              to={isInsideProject ? '/project/$projectId/export/$viewId/' : '/export/$viewId/'}
-              search={enableDownload}
-              {...props} />
-          )}
-        >
-          Export as .png
-        </MenuItem>
-        <MenuItem
-          renderRoot={(props) => (
-            <Link
-              target="_blank"
-              to={isInsideProject ? '/project/$projectId/export/$viewId/' : '/export/$viewId/'}
-              search={enableJpegDownload}
-              {...props} />
-          )}
-        >
-          Export as .jpg
-        </MenuItem>
-        <MenuItem
-          renderRoot={(props) => (
-            <Link
-              to={isInsideProject ? '/project/$projectId/view/$viewId/dot/' : '/view/$viewId/dot/'}
-              search
-              {...props} />
-          )}
-        >
-          Export as .dot
-        </MenuItem>
-        <MenuItem
-          renderRoot={(props) => (
-            <Link
-              to={isInsideProject ? '/project/$projectId/view/$viewId/d2' : '/view/$viewId/d2'}
-              search
-              {...props} />
-          )}
-        >
-          Export as .d2
-        </MenuItem>
-        <MenuItem
-          renderRoot={(props) => (
-            <Link
-              to={isInsideProject ? '/project/$projectId/view/$viewId/mmd' : '/view/$viewId/mmd'}
-              search
-              {...props} />
-          )}>
-          Export as .mmd
-        </MenuItem>
-        <MenuItem
-          renderRoot={(props) => (
-            <Link
-              to={isInsideProject ? '/project/$projectId/view/$viewId/puml' : '/view/$viewId/puml'}
-              search
-              {...props} />
-          )}>
-          Export as .puml
-        </MenuItem>
-        <MenuItem disabled={isDrawioLoading} onClick={handleDrawioExport}>Export to Draw.io</MenuItem>
+        {isWebappExportFormatEnabled(project, 'png') && (
+          <MenuItem
+            renderRoot={(props) => (
+              <Link
+                target="_blank"
+                to={isInsideProject ? '/project/$projectId/export/$viewId/' : '/export/$viewId/'}
+                search={enableDownload}
+                {...props} />
+            )}
+          >
+            Export as .png
+          </MenuItem>
+        )}
+        {isWebappExportFormatEnabled(project, 'jpg') && (
+          <MenuItem
+            renderRoot={(props) => (
+              <Link
+                target="_blank"
+                to={isInsideProject ? '/project/$projectId/export/$viewId/' : '/export/$viewId/'}
+                search={enableJpegDownload}
+                {...props} />
+            )}
+          >
+            Export as .jpg
+          </MenuItem>
+        )}
+        {isWebappExportFormatEnabled(project, 'dot') && (
+          <MenuItem
+            renderRoot={(props) => (
+              <Link
+                to={isInsideProject ? '/project/$projectId/view/$viewId/dot/' : '/view/$viewId/dot/'}
+                search
+                {...props} />
+            )}
+          >
+            Export as .dot
+          </MenuItem>
+        )}
+        {isWebappExportFormatEnabled(project, 'd2') && (
+          <MenuItem
+            renderRoot={(props) => (
+              <Link
+                to={isInsideProject ? '/project/$projectId/view/$viewId/d2' : '/view/$viewId/d2'}
+                search
+                {...props} />
+            )}
+          >
+            Export as .d2
+          </MenuItem>
+        )}
+        {isWebappExportFormatEnabled(project, 'mmd') && (
+          <MenuItem
+            renderRoot={(props) => (
+              <Link
+                to={isInsideProject ? '/project/$projectId/view/$viewId/mmd' : '/view/$viewId/mmd'}
+                search
+                {...props} />
+            )}>
+            Export as .mmd
+          </MenuItem>
+        )}
+        {isWebappExportFormatEnabled(project, 'puml') && (
+          <MenuItem
+            renderRoot={(props) => (
+              <Link
+                to={isInsideProject ? '/project/$projectId/view/$viewId/puml' : '/view/$viewId/puml'}
+                search
+                {...props} />
+            )}>
+            Export as .puml
+          </MenuItem>
+        )}
+        {isWebappExportFormatEnabled(project, 'drawio') && (
+          <MenuItem disabled={isDrawioLoading} onClick={handleDrawioExport}>Export to Draw.io</MenuItem>
+        )}
         <MenuItem disabled>Export to Miro</MenuItem>
         <MenuItem disabled>Export to Notion</MenuItem>
         {

--- a/packages/likec4-spa/src/components/view-page/Header.tsx
+++ b/packages/likec4-spa/src/components/view-page/Header.tsx
@@ -24,10 +24,7 @@ import {
 } from '@tanstack/react-router'
 import { AnimatePresence } from 'motion/react'
 import { memo, useCallback, useState } from 'react'
-import {
-  enabledWebappExportFormats,
-  isWebappExportFormatEnabled,
-} from '../../export-formats'
+import { enabledWebappExportFormats } from '../../export-formats'
 import { useCurrentProject, useCurrentViewId } from '../../hooks'
 import { ColorSchemeToggle } from '../ColorSchemeToggle'
 import { NavigationPanel } from './NavigationPanel'
@@ -117,7 +114,7 @@ function ExportButton() {
   const [isDrawioLoading, setIsDrawioLoading] = useState(false)
   const project = useCurrentProject()
   const viewId = useCurrentViewId()
-  const enabledFormats = enabledWebappExportFormats(project)
+  const enabledFormats = new Set(enabledWebappExportFormats(project))
 
   const handleDrawioExport = useCallback(async () => {
     try {
@@ -133,7 +130,7 @@ function ExportButton() {
     }
   }, [project.id, viewId])
 
-  if (enabledFormats.length === 0) {
+  if (enabledFormats.size === 0) {
     return null
   }
 
@@ -153,7 +150,7 @@ function ExportButton() {
 
       <MenuDropdown>
         <MenuLabel>Current view</MenuLabel>
-        {isWebappExportFormatEnabled(project, 'png') && (
+        {enabledFormats.has('png') && (
           <MenuItem
             renderRoot={(props) => (
               <Link
@@ -166,7 +163,7 @@ function ExportButton() {
             Export as .png
           </MenuItem>
         )}
-        {isWebappExportFormatEnabled(project, 'jpg') && (
+        {enabledFormats.has('jpg') && (
           <MenuItem
             renderRoot={(props) => (
               <Link
@@ -179,7 +176,7 @@ function ExportButton() {
             Export as .jpg
           </MenuItem>
         )}
-        {isWebappExportFormatEnabled(project, 'dot') && (
+        {enabledFormats.has('dot') && (
           <MenuItem
             renderRoot={(props) => (
               <Link
@@ -191,7 +188,7 @@ function ExportButton() {
             Export as .dot
           </MenuItem>
         )}
-        {isWebappExportFormatEnabled(project, 'd2') && (
+        {enabledFormats.has('d2') && (
           <MenuItem
             renderRoot={(props) => (
               <Link
@@ -203,7 +200,7 @@ function ExportButton() {
             Export as .d2
           </MenuItem>
         )}
-        {isWebappExportFormatEnabled(project, 'mmd') && (
+        {enabledFormats.has('mmd') && (
           <MenuItem
             renderRoot={(props) => (
               <Link
@@ -214,7 +211,7 @@ function ExportButton() {
             Export as .mmd
           </MenuItem>
         )}
-        {isWebappExportFormatEnabled(project, 'puml') && (
+        {enabledFormats.has('puml') && (
           <MenuItem
             renderRoot={(props) => (
               <Link
@@ -225,7 +222,7 @@ function ExportButton() {
             Export as .puml
           </MenuItem>
         )}
-        {isWebappExportFormatEnabled(project, 'drawio') && (
+        {enabledFormats.has('drawio') && (
           <MenuItem disabled={isDrawioLoading} onClick={handleDrawioExport}>Export to Draw.io</MenuItem>
         )}
         <MenuItem disabled>Export to Miro</MenuItem>

--- a/packages/likec4-spa/src/export-formats.spec.ts
+++ b/packages/likec4-spa/src/export-formats.spec.ts
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import type { WebappExportFormat } from '@likec4/config'
+import { describe, it } from 'vitest'
+import {
+  enabledWebappExportFormats,
+  hasAnyWebappExportFormatEnabled,
+  isImageExportFormatEnabled,
+  isWebappExportFormatEnabled,
+} from './export-formats'
+
+describe('SPA webapp export format helpers', () => {
+  it('defaults to every export format for older project metadata', ({ expect }) => {
+    expect(enabledWebappExportFormats({})).toEqual(['png', 'jpg', 'dot', 'd2', 'mmd', 'puml', 'drawio'])
+    expect(hasAnyWebappExportFormatEnabled({})).toBe(true)
+  })
+
+  it('keeps an empty export format list disabled', ({ expect }) => {
+    expect(enabledWebappExportFormats({ exportFormats: [] })).toEqual([])
+    expect(hasAnyWebappExportFormatEnabled({ exportFormats: [] })).toBe(false)
+  })
+
+  it('normalizes enabled formats to the fixed LikeC4 menu order', ({ expect }) => {
+    expect(enabledWebappExportFormats({ exportFormats: ['drawio', 'jpg', 'dot'] })).toEqual([
+      'jpg',
+      'dot',
+      'drawio',
+    ])
+  })
+
+  it('checks text and image export formats against project capabilities', ({ expect }) => {
+    const project: { exportFormats: WebappExportFormat[] } = { exportFormats: ['png', 'drawio'] }
+
+    expect(isWebappExportFormatEnabled(project, 'drawio')).toBe(true)
+    expect(isWebappExportFormatEnabled(project, 'dot')).toBe(false)
+    expect(isImageExportFormatEnabled(project, 'png')).toBe(true)
+    expect(isImageExportFormatEnabled(project, 'jpeg')).toBe(false)
+  })
+})

--- a/packages/likec4-spa/src/export-formats.spec.ts
+++ b/packages/likec4-spa/src/export-formats.spec.ts
@@ -2,24 +2,16 @@
 //
 // Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
-import type { WebappExportFormat } from '@likec4/config'
 import { describe, it } from 'vitest'
-import {
-  enabledWebappExportFormats,
-  hasAnyWebappExportFormatEnabled,
-  isImageExportFormatEnabled,
-  isWebappExportFormatEnabled,
-} from './export-formats'
+import { enabledWebappExportFormats } from './export-formats'
 
 describe('SPA webapp export format helpers', () => {
   it('defaults to every export format for older project metadata', ({ expect }) => {
     expect(enabledWebappExportFormats({})).toEqual(['png', 'jpg', 'dot', 'd2', 'mmd', 'puml', 'drawio'])
-    expect(hasAnyWebappExportFormatEnabled({})).toBe(true)
   })
 
   it('keeps an empty export format list disabled', ({ expect }) => {
     expect(enabledWebappExportFormats({ exportFormats: [] })).toEqual([])
-    expect(hasAnyWebappExportFormatEnabled({ exportFormats: [] })).toBe(false)
   })
 
   it('normalizes enabled formats to the fixed LikeC4 menu order', ({ expect }) => {
@@ -28,14 +20,5 @@ describe('SPA webapp export format helpers', () => {
       'dot',
       'drawio',
     ])
-  })
-
-  it('checks text and image export formats against project capabilities', ({ expect }) => {
-    const project: { exportFormats: WebappExportFormat[] } = { exportFormats: ['png', 'drawio'] }
-
-    expect(isWebappExportFormatEnabled(project, 'drawio')).toBe(true)
-    expect(isWebappExportFormatEnabled(project, 'dot')).toBe(false)
-    expect(isImageExportFormatEnabled(project, 'png')).toBe(true)
-    expect(isImageExportFormatEnabled(project, 'jpeg')).toBe(false)
   })
 })

--- a/packages/likec4-spa/src/export-formats.ts
+++ b/packages/likec4-spa/src/export-formats.ts
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import type { WebappExportFormat } from '@likec4/config'
+
+const WEBAPP_EXPORT_FORMATS = [
+  'png',
+  'jpg',
+  'dot',
+  'd2',
+  'mmd',
+  'puml',
+  'drawio',
+] as const satisfies readonly WebappExportFormat[]
+
+type ProjectExportCapabilities = {
+  exportFormats?: readonly WebappExportFormat[] | undefined
+}
+
+type ImageExportSearchFormat = 'png' | 'jpeg'
+
+export function enabledWebappExportFormats(project: ProjectExportCapabilities): WebappExportFormat[] {
+  const configured = project.exportFormats
+  if (!configured) {
+    return [...WEBAPP_EXPORT_FORMATS]
+  }
+  const enabledFormats = new Set(configured)
+  return WEBAPP_EXPORT_FORMATS.filter(format => enabledFormats.has(format))
+}
+
+export function hasAnyWebappExportFormatEnabled(project: ProjectExportCapabilities): boolean {
+  return enabledWebappExportFormats(project).length > 0
+}
+
+export function isWebappExportFormatEnabled(
+  project: ProjectExportCapabilities,
+  format: WebappExportFormat,
+): boolean {
+  return enabledWebappExportFormats(project).includes(format)
+}
+
+export function isImageExportFormatEnabled(
+  project: ProjectExportCapabilities,
+  format: ImageExportSearchFormat,
+): boolean {
+  return isWebappExportFormatEnabled(project, format === 'jpeg' ? 'jpg' : format)
+}

--- a/packages/likec4-spa/src/export-formats.ts
+++ b/packages/likec4-spa/src/export-formats.ts
@@ -2,14 +2,25 @@
 //
 // Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
-import { type WebappExportFormat, WebappExportFormats } from '@likec4/config'
+import type { WebappExportFormat } from '@likec4/config'
+
+const WebappExportFormats = [
+  'png',
+  'jpg',
+  'dot',
+  'd2',
+  'mmd',
+  'puml',
+  'drawio',
+] as const satisfies readonly WebappExportFormat[]
 
 type ProjectExportCapabilities = {
   exportFormats?: readonly WebappExportFormat[] | undefined
 }
 
-type ImageExportSearchFormat = 'png' | 'jpeg'
-
+/**
+ * Returns enabled webapp export formats in canonical menu order.
+ */
 export function enabledWebappExportFormats(project: ProjectExportCapabilities): WebappExportFormat[] {
   const configured = project.exportFormats
   if (!configured) {
@@ -17,22 +28,4 @@ export function enabledWebappExportFormats(project: ProjectExportCapabilities): 
   }
   const enabledFormats = new Set(configured)
   return WebappExportFormats.filter(format => enabledFormats.has(format))
-}
-
-export function hasAnyWebappExportFormatEnabled(project: ProjectExportCapabilities): boolean {
-  return enabledWebappExportFormats(project).length > 0
-}
-
-export function isWebappExportFormatEnabled(
-  project: ProjectExportCapabilities,
-  format: WebappExportFormat,
-): boolean {
-  return enabledWebappExportFormats(project).includes(format)
-}
-
-export function isImageExportFormatEnabled(
-  project: ProjectExportCapabilities,
-  format: ImageExportSearchFormat,
-): boolean {
-  return isWebappExportFormatEnabled(project, format === 'jpeg' ? 'jpg' : format)
 }

--- a/packages/likec4-spa/src/export-formats.ts
+++ b/packages/likec4-spa/src/export-formats.ts
@@ -2,17 +2,7 @@
 //
 // Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
-import type { WebappExportFormat } from '@likec4/config'
-
-const WEBAPP_EXPORT_FORMATS = [
-  'png',
-  'jpg',
-  'dot',
-  'd2',
-  'mmd',
-  'puml',
-  'drawio',
-] as const satisfies readonly WebappExportFormat[]
+import { type WebappExportFormat, WebappExportFormats } from '@likec4/config'
 
 type ProjectExportCapabilities = {
   exportFormats?: readonly WebappExportFormat[] | undefined
@@ -23,10 +13,10 @@ type ImageExportSearchFormat = 'png' | 'jpeg'
 export function enabledWebappExportFormats(project: ProjectExportCapabilities): WebappExportFormat[] {
   const configured = project.exportFormats
   if (!configured) {
-    return [...WEBAPP_EXPORT_FORMATS]
+    return [...WebappExportFormats]
   }
   const enabledFormats = new Set(configured)
-  return WEBAPP_EXPORT_FORMATS.filter(format => enabledFormats.has(format))
+  return WebappExportFormats.filter(format => enabledFormats.has(format))
 }
 
 export function hasAnyWebappExportFormatEnabled(project: ProjectExportCapabilities): boolean {

--- a/packages/likec4-spa/src/export-formats.ts
+++ b/packages/likec4-spa/src/export-formats.ts
@@ -2,17 +2,7 @@
 //
 // Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
-import type { WebappExportFormat } from '@likec4/config'
-
-const WebappExportFormats = [
-  'png',
-  'jpg',
-  'dot',
-  'd2',
-  'mmd',
-  'puml',
-  'drawio',
-] as const satisfies readonly WebappExportFormat[]
+import { type WebappExportFormat, WebappExportFormats } from '@likec4/config/webapp-export-formats'
 
 type ProjectExportCapabilities = {
   exportFormats?: readonly WebappExportFormat[] | undefined

--- a/packages/likec4-spa/src/pages/ExportPage.spec.ts
+++ b/packages/likec4-spa/src/pages/ExportPage.spec.ts
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ExportPage } from './ExportPage'
+
+const testState = vi.hoisted(() => ({
+  diagram: {
+    id: 'index',
+    bounds: { x: 0, y: 0, width: 640, height: 480 },
+    description: null,
+    notation: null,
+  },
+  project: {
+    exportFormats: ['drawio'],
+  },
+  search: {
+    format: 'png',
+  },
+}))
+
+vi.mock('@likec4/diagram', () => ({
+  LikeC4Diagram: () => React.createElement('div', { 'data-testid': 'diagram' }),
+  pickViewBounds: () => testState.diagram.bounds,
+  useLikeC4Styles: () => ({
+    colors: () => ({
+      elements: {
+        fill: '#fff',
+        stroke: '#000',
+        hiContrast: '#000',
+        loContrast: '#fff',
+      },
+    }),
+  }),
+}))
+
+vi.mock('@likec4/diagram/custom', () => ({
+  ElementShape: () => React.createElement('div'),
+  Markdown: ({ children }: { children: React.ReactNode }) => React.createElement('div', null, children),
+}))
+
+vi.mock('@likec4/styles/jsx', () => ({
+  Box: ({ children, css: _css, ...props }: React.PropsWithChildren<Record<string, unknown>>) =>
+    React.createElement('div', props, children),
+}))
+
+vi.mock('@mantine/core', () => ({
+  LoadingOverlay: React.forwardRef<HTMLDivElement>((props, ref) => React.createElement('div', { ...props, ref })),
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  useSearch: () => testState.search,
+}))
+
+vi.mock('../components/NotFound', () => ({
+  NotFound: () => React.createElement('div', { 'data-testid': 'not-found' }, 'not found'),
+}))
+
+vi.mock('../hooks', () => ({
+  useCurrentProject: () => testState.project,
+  useCurrentView: () => [testState.diagram],
+  useTransparentBackground: vi.fn(),
+}))
+
+describe('ExportPage', () => {
+  beforeEach(() => {
+    testState.project.exportFormats = ['drawio']
+    testState.search.format = 'png'
+  })
+
+  it('keeps the image export route available when webapp image downloads are disabled', () => {
+    const markup = renderToStaticMarkup(React.createElement(ExportPage))
+
+    expect(markup).toContain('data-testid="export-page"')
+    expect(markup).not.toContain('data-testid="not-found"')
+  })
+})

--- a/packages/likec4-spa/src/pages/ExportPage.spec.ts
+++ b/packages/likec4-spa/src/pages/ExportPage.spec.ts
@@ -14,9 +14,6 @@ const testState = vi.hoisted(() => ({
     description: null,
     notation: null,
   },
-  project: {
-    exportFormats: ['drawio'],
-  },
   search: {
     format: 'png',
   },
@@ -60,18 +57,16 @@ vi.mock('../components/NotFound', () => ({
 }))
 
 vi.mock('../hooks', () => ({
-  useCurrentProject: () => testState.project,
   useCurrentView: () => [testState.diagram],
-  useTransparentBackground: vi.fn(),
+  useTransparentBackground: vi.fn<(transparent: boolean) => void>(),
 }))
 
 describe('ExportPage', () => {
   beforeEach(() => {
-    testState.project.exportFormats = ['drawio']
     testState.search.format = 'png'
   })
 
-  it('keeps the image export route available when webapp image downloads are disabled', () => {
+  it('renders image export routes independently from webapp menu capabilities', () => {
     const markup = renderToStaticMarkup(React.createElement(ExportPage))
 
     expect(markup).toContain('data-testid="export-page"')

--- a/packages/likec4-spa/src/pages/ExportPage.tsx
+++ b/packages/likec4-spa/src/pages/ExportPage.tsx
@@ -13,9 +13,7 @@ import { LoadingOverlay } from '@mantine/core'
 import { useSearch } from '@tanstack/react-router'
 import type { CSSProperties } from 'react'
 import { useRef } from 'react'
-import { NotFound } from '../components/NotFound'
-import { isImageExportFormatEnabled } from '../export-formats'
-import { useCurrentProject, useCurrentView, useTransparentBackground } from '../hooks'
+import { useCurrentView, useTransparentBackground } from '../hooks'
 import {
   computeExportPageLayout,
   EXPORT_DESCRIPTION_BODY_TOP_GAP,
@@ -118,15 +116,10 @@ async function downloadAsJpeg({
 export function ExportPage() {
   const [diagram] = useCurrentView()
   const { format } = useSearch({ strict: false })
-  const project = useCurrentProject()
   const imageFormat = format ?? 'png'
   const isJpeg = imageFormat === 'jpeg'
 
   useTransparentBackground(!isJpeg)
-
-  if (!isImageExportFormatEnabled(project, imageFormat)) {
-    return <NotFound />
-  }
 
   if (!diagram) {
     return <div>Loading...</div>

--- a/packages/likec4-spa/src/pages/ExportPage.tsx
+++ b/packages/likec4-spa/src/pages/ExportPage.tsx
@@ -13,7 +13,9 @@ import { LoadingOverlay } from '@mantine/core'
 import { useSearch } from '@tanstack/react-router'
 import type { CSSProperties } from 'react'
 import { useRef } from 'react'
-import { useCurrentView, useTransparentBackground } from '../hooks'
+import { NotFound } from '../components/NotFound'
+import { isImageExportFormatEnabled } from '../export-formats'
+import { useCurrentProject, useCurrentView, useTransparentBackground } from '../hooks'
 import {
   computeExportPageLayout,
   EXPORT_DESCRIPTION_BODY_TOP_GAP,
@@ -116,9 +118,15 @@ async function downloadAsJpeg({
 export function ExportPage() {
   const [diagram] = useCurrentView()
   const { format } = useSearch({ strict: false })
-  const isJpeg = format === 'jpeg'
+  const project = useCurrentProject()
+  const imageFormat = format ?? 'png'
+  const isJpeg = imageFormat === 'jpeg'
 
   useTransparentBackground(!isJpeg)
+
+  if (!isImageExportFormatEnabled(project, imageFormat)) {
+    return <NotFound />
+  }
 
   if (!diagram) {
     return <div>Loading...</div>

--- a/packages/likec4/src/config/index.ts
+++ b/packages/likec4/src/config/index.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 export {
   defineConfig,
   defineGenerators,
@@ -16,4 +23,5 @@ export {
   type LikeC4ProjectJsonConfig,
   type LikeC4StylesConfig,
   type LikeC4StylesConfigInput,
+  type WebappExportFormat,
 } from '@likec4/config'

--- a/packages/vite-plugin/src/modules.d.ts
+++ b/packages/vite-plugin/src/modules.d.ts
@@ -6,7 +6,7 @@
 // Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
 
 declare module 'likec4:projects' {
-  import type { WebappExportFormat } from '@likec4/config'
+  import type { WebappExportFormat } from 'likec4/config'
   import type { ProjectId } from 'likec4/model'
   type LandingPageConfig =
     | { redirect: true }

--- a/packages/vite-plugin/src/modules.d.ts
+++ b/packages/vite-plugin/src/modules.d.ts
@@ -1,4 +1,12 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 declare module 'likec4:projects' {
+  import type { WebappExportFormat } from '@likec4/config'
   import type { ProjectId } from 'likec4/model'
   type LandingPageConfig =
     | { redirect: true }
@@ -8,6 +16,7 @@ declare module 'likec4:projects' {
     id: ProjectId
     title?: string
     landingPage?: LandingPageConfig
+    exportFormats: readonly WebappExportFormat[]
   }
   export const isSingleProject: boolean
   export const projects: readonly [Project, ...Project[]]

--- a/packages/vite-plugin/src/plugin.ts
+++ b/packages/vite-plugin/src/plugin.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import type { ProjectId } from '@likec4/core/types'
 import type { LikeC4LanguageServices } from '@likec4/language-services'
 import { fromWorkspace } from '@likec4/language-services/node'
@@ -19,6 +26,7 @@ import { type AppConfig, createAppConfigModule } from './virtuals/app-config'
 import { d2Module, projectD2Module } from './virtuals/d2'
 import { dotModule, projectDotSourcesModule } from './virtuals/dot'
 import { drawioModule, projectDrawioModule } from './virtuals/drawio'
+import { effectiveWebappExportFormats } from './virtuals/export-formats'
 import { iconsModule, projectIconsModule } from './virtuals/icons'
 import { mmdModule, projectMmdSourcesModule } from './virtuals/mmd'
 import { modelModule, projectModelModule } from './virtuals/model'
@@ -245,6 +253,7 @@ export function LikeC4VitePlugin({
       title: p.title,
       folder: p.folder.toString(),
       landingPage: p.config.landingPage,
+      exportFormats: effectiveWebappExportFormats(p.config),
     })) satisfies (data: ProjectsData) => any
     let _last: any
     return <T extends ProjectsData>(update: T): boolean => {

--- a/packages/vite-plugin/src/plugin.ts
+++ b/packages/vite-plugin/src/plugin.ts
@@ -168,6 +168,18 @@ const hmrProjectVirtuals = [
   projectPumlModule,
   projectDrawioModule,
 ]
+
+/**
+ * Root virtual modules that cache project-level export capability maps.
+ */
+const hmrProjectListVirtuals = [
+  d2Module,
+  dotModule,
+  mmdModule,
+  pumlModule,
+  drawioModule,
+]
+
 /**
  * All virtual modules per LikeC4 project ()
  */
@@ -182,11 +194,7 @@ const _virtuals = [
   projectsOverviewModule,
   singleProjectModule,
   singleProjectReactModule,
-  d2Module,
-  dotModule,
-  mmdModule,
-  pumlModule,
-  drawioModule,
+  ...hmrProjectListVirtuals,
   iconsModule,
   rpcModule,
 ]
@@ -435,6 +443,9 @@ export function LikeC4VitePlugin({
             await reloadModule(projectsModule.virtualId)
             await reloadModule(iconsModule.virtualId)
             await reloadModule(modelModule.virtualId)
+            for (const module of hmrProjectListVirtuals) {
+              await reloadModule(module.virtualId)
+            }
             if (projects.length > 1) {
               await reloadModule(projectsOverviewModule.virtualId)
             }

--- a/packages/vite-plugin/src/virtuals/_shared.ts
+++ b/packages/vite-plugin/src/virtuals/_shared.ts
@@ -1,4 +1,11 @@
-import type { LikeC4ProjectConfig } from '@likec4/config'
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
+import type { LikeC4ProjectConfig, WebappExportFormat } from '@likec4/config'
 import type { LikeC4Project, NonEmptyArray, ProjectId } from '@likec4/core'
 import type { LikeC4LanguageServices } from '@likec4/language-services'
 import type { URI } from 'langium'
@@ -7,6 +14,7 @@ import { joinURL } from 'ufo'
 import type { Rolldown } from 'vite'
 import { type ViteLogger, logGenerating } from '../logger'
 import type { AIOptions } from '../plugin'
+import { isWebappExportFormatEnabled } from './export-formats'
 import { hardenJsonStringLiteralForEmbeddedScript } from './hardenJsonStringLiteralForEmbeddedScript'
 
 export { k }
@@ -51,6 +59,7 @@ export interface VirtualModule {
  * Project scoped virtual module
  */
 export interface ProjectVirtualModule {
+  exportFormat?: WebappExportFormat
   matches: (id: string) => ProjectId | null
   virtualId: (projectId: ProjectId) => string
   load(
@@ -81,14 +90,22 @@ export function generateMatches(moduleId: string, extension = '.js') {
   }
 }
 
-export function generateCombinedProjects(moduleId: string, fnName: string): VirtualModule {
+export function generateCombinedProjects(
+  moduleId: string,
+  fnName: string,
+  exportFormat?: WebappExportFormat,
+): VirtualModule {
   return {
     id: `likec4:${moduleId}`,
     virtualId: 'likec4:plugin/' + moduleId + '.js',
     async load({ projects }) {
       logGenerating(moduleId)
 
-      const cases = projects.map(({ id }) => {
+      const enabledProjects = exportFormat
+        ? projects.filter(({ config }) => isWebappExportFormatEnabled(config, exportFormat))
+        : projects
+
+      const cases = enabledProjects.map(({ id }) => {
         const idLiteral = hardenJsonStringLiteralForEmbeddedScript(JSON.stringify(id))
         const pkgLiteral = hardenJsonStringLiteralForEmbeddedScript(
           JSON.stringify(joinURL(`likec4:${moduleId}`, id)),
@@ -106,12 +123,18 @@ export async function ${fnName}(projectId) {
   if (!fn) {
     const projects = Object.keys(${fnName}Fn)
     console.error('Unknown projectId: ' + projectId + ' (available: ' + projects + ')')
+    ${
+        exportFormat
+          ? `throw new Error('Project does not enable ${exportFormat} export: ' + projectId)`
+          : `
     if (projects.length === 0) {
       throw new Error('No projects found, invalid state')
     }
     projectId = projects[0]
     console.warn('Falling back to project: ' + projectId)
     fn = ${fnName}Fn[projectId]
+    `
+      }
   }
   return await fn()
 }

--- a/packages/vite-plugin/src/virtuals/_shared.ts
+++ b/packages/vite-plugin/src/virtuals/_shared.ts
@@ -112,6 +112,9 @@ export function generateCombinedProjects(
         )
         return `${idLiteral}: async () => await import(${pkgLiteral})`
       })
+      const disabledExportMessageLiteral = exportFormat
+        ? hardenJsonStringLiteralForEmbeddedScript(JSON.stringify(`Project does not enable ${exportFormat} export: `))
+        : null
 
       const code = `
 export let ${fnName}Fn = {
@@ -125,7 +128,7 @@ export async function ${fnName}(projectId) {
     console.error('Unknown projectId: ' + projectId + ' (available: ' + projects + ')')
     ${
         exportFormat
-          ? `throw new Error('Project does not enable ${exportFormat} export: ' + projectId)`
+          ? `throw new Error(${disabledExportMessageLiteral} + projectId)`
           : `
     if (projects.length === 0) {
       throw new Error('No projects found, invalid state')

--- a/packages/vite-plugin/src/virtuals/_shared.ts
+++ b/packages/vite-plugin/src/virtuals/_shared.ts
@@ -144,14 +144,9 @@ export async function ${fnName}(projectId) {
 
 if (import.meta.hot) {
   import.meta.hot.accept(md => {
-    if (!import.meta.hot.data.$update) {
-      import.meta.hot.data.$update = ${fnName}Fn
-    }
     const update = md.${fnName}Fn
     if (update) {
-      for (const [id, fn] of Object.entries(update)) {
-        import.meta.hot.data.$update[id] ??= fn
-      }
+      ${fnName}Fn = update
     } else {
       import.meta.hot.invalidate()
     }

--- a/packages/vite-plugin/src/virtuals/d2.ts
+++ b/packages/vite-plugin/src/virtuals/d2.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import type { LikeC4Model } from '@likec4/core/model'
 import { generateD2 } from '@likec4/generators'
 import { CompositeGeneratorNode, expandToNode, joinToNode, NL, toString } from 'langium/generate'
@@ -47,6 +54,7 @@ function code(model: LikeC4Model.Computed) {
 }
 
 export const projectD2Module: ProjectVirtualModule = {
+  exportFormat: 'd2',
   ...generateMatches('d2'),
   async load({ likec4, project }) {
     logGenerating('d2', project.id)
@@ -58,4 +66,4 @@ export const projectD2Module: ProjectVirtualModule = {
   },
 }
 
-export const d2Module = generateCombinedProjects('d2', 'loadD2Sources')
+export const d2Module = generateCombinedProjects('d2', 'loadD2Sources', 'd2')

--- a/packages/vite-plugin/src/virtuals/dot.ts
+++ b/packages/vite-plugin/src/virtuals/dot.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { CompositeGeneratorNode, expandToNode, joinToNode, NL, toString } from 'langium/generate'
 import { mapToObj } from 'remeda'
 import { logGenerating } from '../logger'
@@ -84,6 +91,7 @@ function code(
 }
 
 export const projectDotSourcesModule: ProjectVirtualModule = {
+  exportFormat: 'dot',
   ...generateMatches('dot'),
   async load({ likec4, project }) {
     logGenerating('dot', project.id)
@@ -96,4 +104,4 @@ export const projectDotSourcesModule: ProjectVirtualModule = {
   },
 }
 
-export const dotModule = generateCombinedProjects('dot', 'loadDotSources')
+export const dotModule = generateCombinedProjects('dot', 'loadDotSources', 'dot')

--- a/packages/vite-plugin/src/virtuals/drawio.ts
+++ b/packages/vite-plugin/src/virtuals/drawio.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import type { LikeC4Model } from '@likec4/core/model'
 import { generateDrawio, generateDrawioEditUrl } from '@likec4/generators'
 import { CompositeGeneratorNode, expandToNode, joinToNode, NL, toString } from 'langium/generate'
@@ -47,6 +54,7 @@ function code(model: LikeC4Model.Layouted) {
 }
 
 export const projectDrawioModule: ProjectVirtualModule = {
+  exportFormat: 'drawio',
   ...generateMatches('drawio'),
   async load({ likec4, project }) {
     logGenerating('drawio', project.id)
@@ -58,4 +66,4 @@ export const projectDrawioModule: ProjectVirtualModule = {
   },
 }
 
-export const drawioModule = generateCombinedProjects('drawio', 'loadDrawioSources')
+export const drawioModule = generateCombinedProjects('drawio', 'loadDrawioSources', 'drawio')

--- a/packages/vite-plugin/src/virtuals/export-formats.spec.ts
+++ b/packages/vite-plugin/src/virtuals/export-formats.spec.ts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import type { LikeC4ProjectConfig } from '@likec4/config'
+import { describe, it } from 'vitest'
+import {
+  effectiveWebappExportFormats,
+  isWebappExportFormatEnabled,
+} from './export-formats'
+
+describe('webapp export format capabilities', () => {
+  it('enables every export format when webapp config is omitted', ({ expect }) => {
+    expect(effectiveWebappExportFormats({})).toEqual(['png', 'jpg', 'dot', 'd2', 'mmd', 'puml', 'drawio'])
+  })
+
+  it('keeps disabled exports disabled', ({ expect }) => {
+    expect(effectiveWebappExportFormats({ webapp: { exportFormats: [] } })).toEqual([])
+  })
+
+  it('normalizes configured formats to the fixed LikeC4 menu order', ({ expect }) => {
+    expect(effectiveWebappExportFormats({ webapp: { exportFormats: ['drawio', 'jpg', 'dot'] } })).toEqual([
+      'jpg',
+      'dot',
+      'drawio',
+    ])
+  })
+
+  it('checks whether a project has an export format enabled', ({ expect }) => {
+    const config: Pick<LikeC4ProjectConfig, 'webapp'> = { webapp: { exportFormats: ['png', 'drawio'] } }
+
+    expect(isWebappExportFormatEnabled(config, 'png')).toBe(true)
+    expect(isWebappExportFormatEnabled(config, 'dot')).toBe(false)
+  })
+})

--- a/packages/vite-plugin/src/virtuals/export-formats.ts
+++ b/packages/vite-plugin/src/virtuals/export-formats.ts
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import type { LikeC4ProjectConfig, WebappExportFormat } from '@likec4/config'
+import { WebappExportFormats } from '@likec4/config'
+
+type WebappExportConfig = Pick<LikeC4ProjectConfig, 'webapp'>
+
+export function effectiveWebappExportFormats(config: WebappExportConfig): WebappExportFormat[] {
+  const configured = config.webapp?.exportFormats
+  if (!configured) {
+    return [...WebappExportFormats]
+  }
+  const enabledFormats = new Set(configured)
+  return WebappExportFormats.filter(format => enabledFormats.has(format))
+}
+
+export function isWebappExportFormatEnabled(config: WebappExportConfig, format: WebappExportFormat): boolean {
+  return effectiveWebappExportFormats(config).includes(format)
+}

--- a/packages/vite-plugin/src/virtuals/export-formats.ts
+++ b/packages/vite-plugin/src/virtuals/export-formats.ts
@@ -2,8 +2,8 @@
 //
 // Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
-import type { LikeC4ProjectConfig, WebappExportFormat } from '@likec4/config'
-import { WebappExportFormats } from '@likec4/config'
+import type { LikeC4ProjectConfig } from '@likec4/config'
+import { type WebappExportFormat, WebappExportFormats } from '@likec4/config/webapp-export-formats'
 
 type WebappExportConfig = Pick<LikeC4ProjectConfig, 'webapp'>
 

--- a/packages/vite-plugin/src/virtuals/mmd.ts
+++ b/packages/vite-plugin/src/virtuals/mmd.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import type { LikeC4Model } from '@likec4/core/model'
 import { generateMermaid } from '@likec4/generators'
 import { CompositeGeneratorNode, expandToNode, joinToNode, NL, toString } from 'langium/generate'
@@ -49,6 +56,7 @@ function code(model: LikeC4Model.Computed) {
 }
 
 export const projectMmdSourcesModule: ProjectVirtualModule = {
+  exportFormat: 'mmd',
   ...generateMatches('mmd'),
   async load({ likec4, project }) {
     logGenerating('mmd', project.id)
@@ -60,4 +68,4 @@ export const projectMmdSourcesModule: ProjectVirtualModule = {
   },
 }
 
-export const mmdModule = generateCombinedProjects('mmd', 'loadMmdSources')
+export const mmdModule = generateCombinedProjects('mmd', 'loadMmdSources', 'mmd')

--- a/packages/vite-plugin/src/virtuals/projects.spec.ts
+++ b/packages/vite-plugin/src/virtuals/projects.spec.ts
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import { describe, it } from 'vitest'
+import { generateCombinedProjects } from './_shared'
+import { projectsModule } from './projects'
+
+describe('projects virtual module export capabilities', () => {
+  it('publishes effective export formats for every project', async ({ expect }) => {
+    const result = await projectsModule.load.call({} as any, {
+      projects: [
+        {
+          id: 'all',
+          title: undefined,
+          config: {},
+        },
+        {
+          id: 'configured',
+          title: 'Configured',
+          config: {
+            webapp: {
+              exportFormats: ['drawio', 'jpg', 'dot'],
+            },
+          },
+        },
+      ],
+    } as any)
+
+    expect(result).toMatchObject({
+      moduleType: 'js',
+    })
+    const code = typeof result === 'string' ? result : result.code
+    expect(code).toContain('exportFormats: [\n      \'png\',')
+    expect(code).toContain('id: \'configured\'')
+    expect(code).toContain('exportFormats: [\n      \'jpg\',\n      \'dot\',\n      \'drawio\'')
+  })
+
+  it('generates combined export modules only for projects that enable the format', async ({ expect }) => {
+    const mod = generateCombinedProjects('dot', 'loadDotSources', 'dot')
+    const result = await mod.load.call({} as any, {
+      projects: [
+        {
+          id: 'exports-dot',
+          config: {
+            webapp: {
+              exportFormats: ['dot'],
+            },
+          },
+        },
+        {
+          id: 'without-dot',
+          config: {
+            webapp: {
+              exportFormats: ['png'],
+            },
+          },
+        },
+      ],
+    } as any)
+
+    const code = typeof result === 'string' ? result : result.code
+    expect(code).toContain('exports-dot')
+    expect(code).not.toContain('without-dot')
+    expect(code).toContain('throw new Error(\'Project does not enable dot export: \' + projectId)')
+    expect(code).not.toContain('Falling back to project')
+  })
+})

--- a/packages/vite-plugin/src/virtuals/projects.spec.ts
+++ b/packages/vite-plugin/src/virtuals/projects.spec.ts
@@ -64,5 +64,7 @@ describe('projects virtual module export capabilities', () => {
     expect(code).not.toContain('without-dot')
     expect(code).toContain('throw new Error("Project does not enable dot export: " + projectId)')
     expect(code).not.toContain('Falling back to project')
+    expect(code).toContain('loadDotSourcesFn = update')
+    expect(code).not.toContain('??=')
   })
 })

--- a/packages/vite-plugin/src/virtuals/projects.spec.ts
+++ b/packages/vite-plugin/src/virtuals/projects.spec.ts
@@ -67,4 +67,27 @@ describe('projects virtual module export capabilities', () => {
     expect(code).toContain('loadDotSourcesFn = update')
     expect(code).not.toContain('??=')
   })
+
+  it('generates parseable combined export modules for escaped project ids', async ({ expect }) => {
+    const mod = generateCombinedProjects('dot', 'loadDotSources', 'dot')
+    const result = await mod.load.call({} as any, {
+      projects: [
+        {
+          id: 'weird-project</script>\u2028with-slash',
+          config: {
+            webapp: {
+              exportFormats: ['dot'],
+            },
+          },
+        },
+      ],
+    } as any)
+
+    const code = typeof result === 'string' ? result : result.code
+    expect(code).not.toContain('</script>')
+    await expect(import(`data:text/javascript,${encodeURIComponent(code)}`)).resolves.toMatchObject({
+      loadDotSources: expect.any(Function),
+      loadDotSourcesFn: expect.any(Object),
+    })
+  })
 })

--- a/packages/vite-plugin/src/virtuals/projects.spec.ts
+++ b/packages/vite-plugin/src/virtuals/projects.spec.ts
@@ -62,7 +62,7 @@ describe('projects virtual module export capabilities', () => {
     const code = typeof result === 'string' ? result : result.code
     expect(code).toContain('exports-dot')
     expect(code).not.toContain('without-dot')
-    expect(code).toContain('throw new Error(\'Project does not enable dot export: \' + projectId)')
+    expect(code).toContain('throw new Error("Project does not enable dot export: " + projectId)')
     expect(code).not.toContain('Falling back to project')
   })
 })

--- a/packages/vite-plugin/src/virtuals/projects.ts
+++ b/packages/vite-plugin/src/virtuals/projects.ts
@@ -1,14 +1,23 @@
-import type { LikeC4ProjectConfig } from '@likec4/config'
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
+import type { LikeC4ProjectConfig, WebappExportFormat } from '@likec4/config'
 import type { NonEmptyArray } from '@likec4/core'
 import JSON5 from 'json5'
 import { map } from 'remeda'
 import { logGenerating } from '../logger'
 import type { VirtualModule } from './_shared'
+import { effectiveWebappExportFormats } from './export-formats'
 
 type ProjectData = {
   id: string
   title: string | undefined
   landingPage: LikeC4ProjectConfig['landingPage']
+  exportFormats: WebappExportFormat[]
 }
 
 const code = (projects: NonEmptyArray<ProjectData>) => `
@@ -53,6 +62,7 @@ export const projectsModule = {
         id: p.id,
         title: p.title,
         landingPage: p.config.landingPage,
+        exportFormats: effectiveWebappExportFormats(p.config),
       }))),
       moduleType: 'js',
     }

--- a/packages/vite-plugin/src/virtuals/puml.ts
+++ b/packages/vite-plugin/src/virtuals/puml.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import type { LikeC4Model } from '@likec4/core/model'
 import { generatePuml } from '@likec4/generators'
 import { CompositeGeneratorNode, expandToNode, joinToNode, NL, toString } from 'langium/generate'
@@ -48,6 +55,7 @@ function code(model: LikeC4Model.Computed) {
 }
 
 export const projectPumlModule: ProjectVirtualModule = {
+  exportFormat: 'puml',
   ...generateMatches('puml'),
   async load({ likec4, project }) {
     logGenerating('puml', project.id)
@@ -59,4 +67,4 @@ export const projectPumlModule: ProjectVirtualModule = {
   },
 }
 
-export const pumlModule = generateCombinedProjects('puml', 'loadPumlSources')
+export const pumlModule = generateCombinedProjects('puml', 'loadPumlSources', 'puml')


### PR DESCRIPTION
## Summary
- Adds `webapp.exportFormats` project config to control which webapp export formats are available.
- Hides disabled export menu items and blocks disabled export routes.
- Adds e2e fixtures for PNG-only and all-disabled export configurations.

## Screenshots
Public LikeC4 e2e examples only.

Before: default project exposes the full export menu.
![Default export menu](https://raw.githubusercontent.com/likec4/likec4/cgk/pr-assets-export-screenshots-20260629/.github/pr-screenshots/export-formats-20260629/likec4-pr1-before-default-export-menu.png)

After: PNG-only config exposes only PNG export.
![PNG-only export menu](https://raw.githubusercontent.com/likec4/likec4/cgk/pr-assets-export-screenshots-20260629/.github/pr-screenshots/export-formats-20260629/likec4-pr1-after-png-only-export-menu.png)

After: empty config removes the Export entry point.
![Export disabled](https://raw.githubusercontent.com/likec4/likec4/cgk/pr-assets-export-screenshots-20260629/.github/pr-screenshots/export-formats-20260629/likec4-pr1-after-all-disabled.png)

## Validation
- `pnpm pretest:e2e`
- e2e search-params Playwright suite, 17 tests against locally built preview
- `pnpm exec vitest run packages/config/src/schema.spec.ts`
- `pnpm --filter @likec4/vite-plugin test -- src/virtuals/export-formats.spec.ts src/virtuals/projects.spec.ts`
- `pnpm --filter @likec4/spa test -- src/export-formats.spec.ts`
- `python3 /home/ckeller/src/agent-skills/skills/likec4-license-headers/scripts/apply_likec4_headers.py --check --base origin/main`
