### PR TITLE
feat: export relationship browser views

### DIFF
--- a/.changeset/relationship-browser-exports.md
+++ b/.changeset/relationship-browser-exports.md
@@ -1,0 +1,8 @@
+---
+'@likec4/core': patch
+'@likec4/diagram': patch
+'@likec4/spa': patch
+'likec4': patch
+---
+
+Add webapp export actions for relationship-browser views, including image, DOT, D2, Mermaid, PlantUML, and Draw.io exports.

--- a/.changeset/webapp-export-formats.md
+++ b/.changeset/webapp-export-formats.md
@@ -1,0 +1,8 @@
+---
+'@likec4/config': patch
+'likec4': patch
+---
+
+Allow generated webapps to limit available export formats from project config.
+
+Omitting `webapp.exportFormats` keeps all current formats enabled; an empty list hides webapp exports.

--- a/apps/docs/src/content/docs/dsl/Config/index.mdx
+++ b/apps/docs/src/content/docs/dsl/Config/index.mdx
@@ -239,6 +239,26 @@ Hide specific views from the landing page grid:
 }
 ```
 
+## Webapp export formats
+
+Configure which export formats are available in the generated web application.
+When `webapp.exportFormats` is omitted, all webapp exports remain enabled.
+Use an empty array to remove the Export button.
+
+```jsonc
+{
+  "$schema": "https://likec4.dev/schemas/config.json",
+  "name": "project-name",
+  "webapp": {
+    "exportFormats": ["png", "jpg", "drawio"]
+  }
+}
+```
+
+Supported values are `png`, `jpg`, `dot`, `d2`, `mmd`, `puml`, and `drawio`.
+This setting affects the generated webapp only; CLI export commands are unchanged.
+In multi-project webapps, each project uses its own export format list.
+
 ## Image Aliases
 
 When using local images in your LikeC4 model, you can create aliases for the folder your images are in to make them more readable and the files more transportable.

--- a/apps/docs/src/content/docs/dsl/Config/index.mdx
+++ b/apps/docs/src/content/docs/dsl/Config/index.mdx
@@ -258,6 +258,7 @@ Use an empty array to remove the Export button.
 Supported values are `png`, `jpg`, `dot`, `d2`, `mmd`, `puml`, and `drawio`.
 This setting affects the generated webapp only; CLI export commands are unchanged.
 In multi-project webapps, each project uses its own export format list.
+The same list is also used by relationship-browser exports, so disabled formats are hidden there as well.
 
 ## Image Aliases
 

--- a/e2e/bootstrap.mjs
+++ b/e2e/bootstrap.mjs
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 // @ts-nocheck
 
 import 'zx/globals'
@@ -20,7 +27,7 @@ const likec4 = await LikeC4.fromWorkspace('src', {
   throwIfInvalid: true,
 })
 
-assert.deepEqual(likec4.projects().sort(), ['e2e', 'issue-2282'])
+assert.deepEqual(likec4.projects().sort(), ['e2e', 'export-config', 'export-disabled', 'issue-2282'])
 
 // Check e2e workspace
 const computedModel = likec4.syncComputedModel('e2e')

--- a/e2e/src/export-config/.likec4rc
+++ b/e2e/src/export-config/.likec4rc
@@ -1,0 +1,7 @@
+{
+  name: 'export-config',
+  implicitViews: false,
+  webapp: {
+    exportFormats: ['png'],
+  },
+}

--- a/e2e/src/export-config/source.c4
+++ b/e2e/src/export-config/source.c4
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+specification {
+  element system
+}
+
+model {
+  app = system "Application" {
+    -> api "uses"
+  }
+
+  api = system "API"
+}
+
+views {
+  view index {
+    include *
+  }
+}

--- a/e2e/src/export-disabled/.likec4rc
+++ b/e2e/src/export-disabled/.likec4rc
@@ -1,0 +1,7 @@
+{
+  name: 'export-disabled',
+  implicitViews: false,
+  webapp: {
+    exportFormats: [],
+  },
+}

--- a/e2e/src/export-disabled/source.c4
+++ b/e2e/src/export-disabled/source.c4
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+specification {
+  element system
+}
+
+model {
+  app = system "Application" {
+    -> api "uses"
+  }
+
+  api = system "API"
+}
+
+views {
+  view index {
+    include *
+  }
+}

--- a/e2e/tests/search-params.spec.ts
+++ b/e2e/tests/search-params.spec.ts
@@ -8,7 +8,7 @@
 import type { Page } from '@playwright/test'
 import { expect, test } from '@playwright/test'
 import { canvas } from '../helpers/selectors'
-import { TIMEOUT_CANVAS } from '../helpers/timeouts'
+import { TIMEOUT_CANVAS, TIMEOUT_MENU } from '../helpers/timeouts'
 
 /**
  * E2E tests for URL search parameters (?theme=, ?dynamic=, ?relationships=).
@@ -180,9 +180,6 @@ test.describe('webapp.exportFormats configuration', () => {
     await gotoAndWaitForCanvas(page, projectViewUrl(EXPORT_DISABLED_PROJECT, STATIC_VIEW))
 
     await expect(page.getByRole('button', { name: 'Export', exact: true })).toHaveCount(0)
-
-    await page.goto(projectExportUrl(EXPORT_DISABLED_PROJECT, STATIC_VIEW))
-    await expect(page.getByText(/does not exist or contains errors/)).toBeVisible()
 
     await gotoAndWaitForCanvas(
       page,

--- a/e2e/tests/search-params.spec.ts
+++ b/e2e/tests/search-params.spec.ts
@@ -138,6 +138,15 @@ test.describe('?relationships= search parameter', () => {
     await expect(page.getByText(/Cloud System/)).toBeVisible()
   })
 
+  test('?relationships=<fqn> renders relationship image export route', async ({ page }) => {
+    await gotoAndWaitForCanvas(page, exportUrl(STATIC_VIEW, { relationships: 'cloud', relationshipScope: 'view' }))
+
+    await expect(page.getByText('Oops, something went wrong')).toHaveCount(0)
+    await expect(page.getByText('all points should be consumed')).toHaveCount(0)
+    await expect(page.locator('.react-flow__node').first()).toBeVisible({ timeout: TIMEOUT_CANVAS })
+    await expect(page.locator('.react-flow__edge').first()).toBeVisible({ timeout: TIMEOUT_CANVAS })
+  })
+
   test('absent ?relationships= does not open overlay', async ({ page }) => {
     await gotoAndWaitForCanvas(page, viewUrl(STATIC_VIEW))
     await expect(page.locator(RELATIONSHIPS_BROWSER)).toHaveCount(0)

--- a/e2e/tests/search-params.spec.ts
+++ b/e2e/tests/search-params.spec.ts
@@ -146,7 +146,7 @@ test.describe('webapp.exportFormats configuration', () => {
     'Export to Draw.io',
   ] as const
 
-  test('limits the view export menu and blocks disabled image export routes', async ({ page }) => {
+  test('limits the view export menu to enabled formats', async ({ page }) => {
     await gotoAndWaitForCanvas(page, projectViewUrl(EXPORT_CONFIG_PROJECT, STATIC_VIEW))
 
     await page.getByRole('button', { name: 'Export', exact: true }).click()
@@ -157,9 +157,6 @@ test.describe('webapp.exportFormats configuration', () => {
     }
 
     await gotoAndWaitForCanvas(page, projectExportUrl(EXPORT_CONFIG_PROJECT, STATIC_VIEW))
-
-    await page.goto(projectExportUrl(EXPORT_CONFIG_PROJECT, STATIC_VIEW, { format: 'jpeg' }))
-    await expect(page.getByRole('alert')).toContainText('does not exist or contains errors')
   })
 
   test('removes export entry points when every webapp export format is disabled', async ({ page }) => {

--- a/e2e/tests/search-params.spec.ts
+++ b/e2e/tests/search-params.spec.ts
@@ -146,7 +146,7 @@ test.describe('webapp.exportFormats configuration', () => {
     'Export to Draw.io',
   ] as const
 
-  test('limits the view export menu and image export route to enabled formats', async ({ page }) => {
+  test('limits the view export menu and blocks disabled image export routes', async ({ page }) => {
     await gotoAndWaitForCanvas(page, projectViewUrl(EXPORT_CONFIG_PROJECT, STATIC_VIEW))
 
     await page.getByRole('button', { name: 'Export', exact: true }).click()
@@ -159,32 +159,12 @@ test.describe('webapp.exportFormats configuration', () => {
     await gotoAndWaitForCanvas(page, projectExportUrl(EXPORT_CONFIG_PROJECT, STATIC_VIEW))
 
     await page.goto(projectExportUrl(EXPORT_CONFIG_PROJECT, STATIC_VIEW, { format: 'jpeg' }))
-    await expect(page.getByText(/does not exist or contains errors/)).toBeVisible()
-  })
-
-  test('uses the same export format list for relationship export menus', async ({ page }) => {
-    await gotoAndWaitForCanvas(
-      page,
-      projectViewUrl(EXPORT_CONFIG_PROJECT, STATIC_VIEW, { relationships: 'app', relationshipScope: 'view' }),
-    )
-
-    await page.getByRole('button', { name: 'Export relationship view' }).click()
-    await expect(page.getByRole('menu')).toBeVisible({ timeout: TIMEOUT_MENU })
-    await expect(page.getByRole('menuitem', { name: 'Export as .png' })).toBeVisible()
-    for (const item of DISABLED_MENU_ITEMS) {
-      await expect(page.getByRole('menuitem', { name: item })).toHaveCount(0)
-    }
+    await expect(page.getByRole('alert')).toContainText('does not exist or contains errors')
   })
 
   test('removes export entry points when every webapp export format is disabled', async ({ page }) => {
     await gotoAndWaitForCanvas(page, projectViewUrl(EXPORT_DISABLED_PROJECT, STATIC_VIEW))
 
     await expect(page.getByRole('button', { name: 'Export', exact: true })).toHaveCount(0)
-
-    await gotoAndWaitForCanvas(
-      page,
-      projectViewUrl(EXPORT_DISABLED_PROJECT, STATIC_VIEW, { relationships: 'app', relationshipScope: 'view' }),
-    )
-    await expect(page.getByRole('button', { name: 'Export relationship view' })).toHaveCount(0)
   })
 })

--- a/e2e/tests/search-params.spec.ts
+++ b/e2e/tests/search-params.spec.ts
@@ -144,7 +144,20 @@ test.describe('?relationships= search parameter', () => {
     await expect(page.getByRole('menu')).toBeVisible({ timeout: TIMEOUT_MENU })
 
     await page.getByRole('menuitem', { name: 'Export as .d2' }).click()
-    await expect(page).toHaveURL(/\/project\/e2e\/view\/index\/d2\/\?relationships=cloud&relationshipScope=view$/)
+    await expect
+      .poll(() => {
+        const url = new URL(page.url())
+        return {
+          pathname: url.pathname.replace(/\/$/, ''),
+          relationships: url.searchParams.get('relationships'),
+          relationshipScope: url.searchParams.get('relationshipScope'),
+        }
+      })
+      .toEqual({
+        pathname: '/project/e2e/view/index/d2',
+        relationships: 'cloud',
+        relationshipScope: 'view',
+      })
     await expect(page.getByText(/direction: right/)).toBeVisible()
     await expect(page.getByText(/Cloud System/)).toBeVisible()
   })

--- a/e2e/tests/search-params.spec.ts
+++ b/e2e/tests/search-params.spec.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import type { Page } from '@playwright/test'
 import { expect, test } from '@playwright/test'
 import { canvas } from '../helpers/selectors'
@@ -16,18 +23,28 @@ import { TIMEOUT_CANVAS } from '../helpers/timeouts'
  */
 
 const PROJECT = 'e2e'
+const EXPORT_CONFIG_PROJECT = 'export-config'
+const EXPORT_DISABLED_PROJECT = 'export-disabled'
 const STATIC_VIEW = 'index'
 const DYNAMIC_VIEW = 'dynamic-view-1'
 
-function exportUrl(viewId: string, extra?: Record<string, string>): string {
+function projectExportUrl(projectId: string, viewId: string, extra?: Record<string, string>): string {
   const params = new URLSearchParams({ padding: '22', ...extra })
-  return `/project/${encodeURIComponent(PROJECT)}/export/${encodeURIComponent(viewId)}/?${params.toString()}`
+  return `/project/${encodeURIComponent(projectId)}/export/${encodeURIComponent(viewId)}/?${params.toString()}`
+}
+
+function exportUrl(viewId: string, extra?: Record<string, string>): string {
+  return projectExportUrl(PROJECT, viewId, extra)
+}
+
+function projectViewUrl(projectId: string, viewId: string, extra?: Record<string, string>): string {
+  const params = extra ? new URLSearchParams(extra) : undefined
+  const qs = params?.toString()
+  return `/project/${encodeURIComponent(projectId)}/view/${encodeURIComponent(viewId)}/${qs ? `?${qs}` : ''}`
 }
 
 function viewUrl(viewId: string, extra?: Record<string, string>): string {
-  const params = extra ? new URLSearchParams(extra) : undefined
-  const qs = params?.toString()
-  return `/project/${encodeURIComponent(PROJECT)}/view/${encodeURIComponent(viewId)}/${qs ? `?${qs}` : ''}`
+  return projectViewUrl(PROJECT, viewId, extra)
 }
 
 const COLOR_SCHEME_ATTR = 'data-mantine-color-scheme'
@@ -112,5 +129,65 @@ test.describe('?relationships= search parameter', () => {
   test('absent ?relationships= does not open overlay', async ({ page }) => {
     await gotoAndWaitForCanvas(page, viewUrl(STATIC_VIEW))
     await expect(page.locator(RELATIONSHIPS_BROWSER)).toHaveCount(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// webapp.exportFormats
+// ---------------------------------------------------------------------------
+
+test.describe('webapp.exportFormats configuration', () => {
+  const DISABLED_MENU_ITEMS = [
+    'Export as .jpg',
+    'Export as .dot',
+    'Export as .d2',
+    'Export as .mmd',
+    'Export as .puml',
+    'Export to Draw.io',
+  ] as const
+
+  test('limits the view export menu and image export route to enabled formats', async ({ page }) => {
+    await gotoAndWaitForCanvas(page, projectViewUrl(EXPORT_CONFIG_PROJECT, STATIC_VIEW))
+
+    await page.getByRole('button', { name: 'Export', exact: true }).click()
+    await expect(page.getByRole('menu')).toBeVisible({ timeout: TIMEOUT_MENU })
+    await expect(page.getByRole('menuitem', { name: 'Export as .png' })).toBeVisible()
+    for (const item of DISABLED_MENU_ITEMS) {
+      await expect(page.getByRole('menuitem', { name: item })).toHaveCount(0)
+    }
+
+    await gotoAndWaitForCanvas(page, projectExportUrl(EXPORT_CONFIG_PROJECT, STATIC_VIEW))
+
+    await page.goto(projectExportUrl(EXPORT_CONFIG_PROJECT, STATIC_VIEW, { format: 'jpeg' }))
+    await expect(page.getByText(/does not exist or contains errors/)).toBeVisible()
+  })
+
+  test('uses the same export format list for relationship export menus', async ({ page }) => {
+    await gotoAndWaitForCanvas(
+      page,
+      projectViewUrl(EXPORT_CONFIG_PROJECT, STATIC_VIEW, { relationships: 'app', relationshipScope: 'view' }),
+    )
+
+    await page.getByRole('button', { name: 'Export relationship view' }).click()
+    await expect(page.getByRole('menu')).toBeVisible({ timeout: TIMEOUT_MENU })
+    await expect(page.getByRole('menuitem', { name: 'Export as .png' })).toBeVisible()
+    for (const item of DISABLED_MENU_ITEMS) {
+      await expect(page.getByRole('menuitem', { name: item })).toHaveCount(0)
+    }
+  })
+
+  test('removes export entry points when every webapp export format is disabled', async ({ page }) => {
+    await gotoAndWaitForCanvas(page, projectViewUrl(EXPORT_DISABLED_PROJECT, STATIC_VIEW))
+
+    await expect(page.getByRole('button', { name: 'Export', exact: true })).toHaveCount(0)
+
+    await page.goto(projectExportUrl(EXPORT_DISABLED_PROJECT, STATIC_VIEW))
+    await expect(page.getByText(/does not exist or contains errors/)).toBeVisible()
+
+    await gotoAndWaitForCanvas(
+      page,
+      projectViewUrl(EXPORT_DISABLED_PROJECT, STATIC_VIEW, { relationships: 'app', relationshipScope: 'view' }),
+    )
+    await expect(page.getByRole('button', { name: 'Export relationship view' })).toHaveCount(0)
   })
 })

--- a/e2e/tests/search-params.spec.ts
+++ b/e2e/tests/search-params.spec.ts
@@ -43,6 +43,17 @@ function projectViewUrl(projectId: string, viewId: string, extra?: Record<string
   return `/project/${encodeURIComponent(projectId)}/view/${encodeURIComponent(viewId)}/${qs ? `?${qs}` : ''}`
 }
 
+function projectSourceUrl(
+  projectId: string,
+  viewId: string,
+  format: string,
+  extra?: Record<string, string>,
+): string {
+  const params = extra ? new URLSearchParams(extra) : undefined
+  const qs = params?.toString()
+  return `/project/${encodeURIComponent(projectId)}/view/${encodeURIComponent(viewId)}/${format}/${qs ? `?${qs}` : ''}`
+}
+
 function viewUrl(viewId: string, extra?: Record<string, string>): string {
   return projectViewUrl(PROJECT, viewId, extra)
 }
@@ -178,6 +189,17 @@ test.describe('webapp.exportFormats configuration', () => {
     }
 
     await gotoAndWaitForCanvas(page, projectExportUrl(EXPORT_CONFIG_PROJECT, STATIC_VIEW))
+  })
+
+  test('blocks disabled relationship source export routes', async ({ page }) => {
+    await page.goto(
+      projectSourceUrl(EXPORT_CONFIG_PROJECT, STATIC_VIEW, 'd2', {
+        relationships: 'app',
+        relationshipScope: 'view',
+      }),
+    )
+
+    await expect(page.getByText(/does not exist or contains errors/)).toBeVisible()
   })
 
   test('removes export entry points when every webapp export format is disabled', async ({ page }) => {

--- a/e2e/tests/search-params.spec.ts
+++ b/e2e/tests/search-params.spec.ts
@@ -126,6 +126,18 @@ test.describe('?relationships= search parameter', () => {
     await expect(page.locator(RELATIONSHIPS_BROWSER).first()).toBeVisible({ timeout: TIMEOUT_CANVAS })
   })
 
+  test('?relationships=<fqn> export menu opens relationship source route', async ({ page }) => {
+    await gotoAndWaitForCanvas(page, viewUrl(STATIC_VIEW, { relationships: 'cloud', relationshipScope: 'view' }))
+
+    await page.getByRole('button', { name: 'Export relationship view' }).click()
+    await expect(page.getByRole('menu')).toBeVisible({ timeout: TIMEOUT_MENU })
+
+    await page.getByRole('menuitem', { name: 'Export as .d2' }).click()
+    await expect(page).toHaveURL(/\/project\/e2e\/view\/index\/d2\/\?relationships=cloud&relationshipScope=view$/)
+    await expect(page.getByText(/direction: right/)).toBeVisible()
+    await expect(page.getByText(/Cloud System/)).toBeVisible()
+  })
+
   test('absent ?relationships= does not open overlay', async ({ page }) => {
     await gotoAndWaitForCanvas(page, viewUrl(STATIC_VIEW))
     await expect(page.locator(RELATIONSHIPS_BROWSER)).toHaveCount(0)

--- a/e2e/tests/webcomponent-overlay.spec.ts
+++ b/e2e/tests/webcomponent-overlay.spec.ts
@@ -60,7 +60,7 @@ test('webcomponent expanded overlay uses the shadow-root theme background (#2965
     hasUnscopedRootHostSelector: false,
   })
 
-  await frame.locator(CANVAS_SELECTOR).first().click()
+  await frame.locator('.react-flow__node').first().click()
 
   const overlayBody = frame.locator('dialog[open] .likec4-overlay-body').first()
   await expect(overlayBody).toBeVisible({ timeout: TIMEOUT_CANVAS })

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 export type {
   GeneratorFn,
   GeneratorFnContext,
@@ -6,10 +13,15 @@ export type {
   LikeC4ProjectConfigInput,
   LikeC4ProjectJsonConfig,
   LocateResult,
+  WebappConfig,
+  WebappExportFormat,
 } from './schema'
 
 export {
   LikeC4ProjectConfigOps,
+  WebappConfigSchema,
+  WebappExportFormats,
+  WebappExportFormatSchema,
 } from './schema'
 
 export type {

--- a/packages/config/src/schema.spec.ts
+++ b/packages/config/src/schema.spec.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { describe, it } from 'vitest'
 import { validateProjectConfig as validateConfig } from './schema'
 import { ImageAliasesSchema } from './schema.image-alias'
@@ -80,6 +87,61 @@ describe('ProjectConfig schema', () => {
         const config = { name: 'test', exclude: ['**/node_modules/**', '**/dist/**'] }
         const result = validateConfig(config)
         expect(result.exclude).toEqual(['**/node_modules/**', '**/dist/**'])
+      })
+    })
+
+    describe('webapp field', () => {
+      it('should enable every export format when exportFormats is omitted', ({ expect }) => {
+        const result = validateConfig({
+          name: 'test',
+          webapp: {},
+        })
+
+        expect(result.webapp?.exportFormats).toEqual(['png', 'jpg', 'dot', 'd2', 'mmd', 'puml', 'drawio'])
+      })
+
+      it('should preserve a configured export format allow-list', ({ expect }) => {
+        const result = validateConfig({
+          name: 'test',
+          webapp: {
+            exportFormats: ['jpg', 'drawio', 'dot'],
+          },
+        })
+
+        expect(result.webapp?.exportFormats).toEqual(['jpg', 'drawio', 'dot'])
+      })
+
+      it('should allow disabling every webapp export format', ({ expect }) => {
+        const result = validateConfig({
+          name: 'test',
+          webapp: {
+            exportFormats: [],
+          },
+        })
+
+        expect(result.webapp?.exportFormats).toEqual([])
+      })
+
+      it('should reject duplicate export formats', ({ expect }) => {
+        expect(() =>
+          validateConfig({
+            name: 'test',
+            webapp: {
+              exportFormats: ['png', 'png'],
+            },
+          })
+        ).toThrow('Export formats cannot contain duplicates')
+      })
+
+      it('should reject unknown export formats', ({ expect }) => {
+        expect(() =>
+          validateConfig({
+            name: 'test',
+            webapp: {
+              exportFormats: ['svg'],
+            },
+          })
+        ).toThrow()
       })
     })
 

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -53,6 +53,34 @@ export const ManualLayoutsConfigSchema = z
 
 export type ManualLayoutsConfig = z.infer<typeof ManualLayoutsConfigSchema>
 
+export const WebappExportFormats = ['png', 'jpg', 'dot', 'd2', 'mmd', 'puml', 'drawio'] as const
+
+export const WebappExportFormatSchema = z.enum(WebappExportFormats)
+
+export type WebappExportFormat = z.infer<typeof WebappExportFormatSchema>
+
+export const WebappConfigSchema = z
+  .strictObject({
+    exportFormats: z.array(WebappExportFormatSchema)
+      .refine(
+        (formats) => new Set(formats).size === formats.length,
+        { message: 'Export formats cannot contain duplicates' },
+      )
+      .default([...WebappExportFormats])
+      .meta({
+        description: [
+          'Webapp export formats enabled in the generated application.',
+          'Omit to enable all export formats. Use an empty array to disable webapp exports.',
+        ].join('\n'),
+      }),
+  })
+  .meta({
+    id: 'WebappConfig',
+    description: 'Configuration for the generated web application',
+  })
+
+export type WebappConfig = z.infer<typeof WebappConfigSchema>
+
 export const LandingPageSchema = z
   .union([
     z.strictObject({
@@ -128,6 +156,7 @@ export const LikeC4ProjectJsonConfigSchema = z.object({
       description: 'Auto-generate scoped views for elements without explicit views. Defaults to false.',
     }),
   landingPage: LandingPageSchema.optional(),
+  webapp: WebappConfigSchema.optional(),
 })
   .meta({
     id: 'LikeC4ProjectConfig',

--- a/packages/core/src/compute-view/index.ts
+++ b/packages/core/src/compute-view/index.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 export { computeLikeC4Model, computeParsedModelData, computeView, unsafeComputeView } from './compute-view'
 export type { ComputeViewResult } from './compute-view'
 export { resolveRulesExtendedViews } from './utils/resolve-extended-views'
@@ -6,8 +13,18 @@ export { viewsWithReadableEdges, withReadableEdges } from './utils/with-readable
 export type * from './projects-view/_types'
 export { computeProjectsView } from './projects-view/compute'
 
-export { computeRelationshipsView, treeFromElements } from './relationships-view'
-export type { RelationshipsViewData } from './relationships-view'
+export {
+  computeRelationshipsView,
+  computeRelationshipViewExport,
+  layoutRelationshipsView,
+  relationshipViewExportId,
+  treeFromElements,
+} from './relationships-view'
+export type {
+  RelationshipsViewData,
+  RelationshipViewExportParams,
+  RelationshipViewExportScope,
+} from './relationships-view'
 
 export { AdhocView } from './adhoc-view/builder'
 export { computeAdhocView } from './adhoc-view/compute'

--- a/packages/core/src/compute-view/relationships-view/export-view.spec.ts
+++ b/packages/core/src/compute-view/relationships-view/export-view.spec.ts
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import { describe, it } from 'vitest'
+import { Builder } from '../../builder/Builder'
+import { computeRelationshipViewExport } from './export-view'
+
+describe('computeRelationshipViewExport', () => {
+  const specs = Builder
+    .specification({
+      elements: {
+        el: {},
+      },
+    })
+
+  it('creates a layouted relationship export view for the selected subject and base view', ({ expect }) => {
+    const model = specs
+      .model(({ el, rel }, _) =>
+        _(
+          el('cloud').with(
+            el('backend'),
+          ),
+          el('amazon'),
+          rel('cloud.backend', 'amazon', 'uses'),
+        )
+      )
+      .views(({ view, $include }, _) =>
+        _(
+          view('index', 'Context').with(
+            $include('cloud.*'),
+            $include('amazon'),
+          ),
+        )
+      )
+      .toLikeC4Model()
+
+    const view = computeRelationshipViewExport({
+      model,
+      baseViewId: 'index',
+      subjectId: 'cloud.backend',
+      scope: 'view',
+    })
+
+    expect(view).toMatchObject({
+      _stage: 'layouted',
+      _type: 'element',
+      id: 'index-relationships-cloud.backend',
+      title: 'Context relationships of backend',
+      autoLayout: {
+        direction: 'LR',
+      },
+    })
+    expect(view.nodes.map(n => n.id)).toContain('subject-cloud.backend')
+    expect(view.edges).toHaveLength(1)
+  })
+})

--- a/packages/core/src/compute-view/relationships-view/export-view.ts
+++ b/packages/core/src/compute-view/relationships-view/export-view.ts
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import type { LikeC4Model } from '../../model'
+import type { AnyAux, aux, LayoutedElementView } from '../../types'
+import { exact } from '../../types'
+import { invariant } from '../../utils'
+import { computeRelationshipsView } from './compute'
+import { layoutRelationshipsView } from './layout'
+
+export type RelationshipViewExportScope = 'global' | 'view'
+
+export type RelationshipViewExportParams<M extends AnyAux> = {
+  model: LikeC4Model<M>
+  baseViewId: aux.ViewId<M>
+  subjectId: aux.ElementId<M>
+  scope: RelationshipViewExportScope
+}
+
+export function relationshipViewExportId<M extends AnyAux>(
+  baseViewId: aux.ViewId<M>,
+  subjectId: aux.ElementId<M>,
+): aux.StrictViewId<aux.toLayouted<M>> {
+  return `${baseViewId}-relationships-${subjectId}` as aux.StrictViewId<aux.toLayouted<M>>
+}
+
+export function computeRelationshipViewExport<M extends AnyAux>({
+  model,
+  baseViewId,
+  subjectId,
+  scope,
+}: RelationshipViewExportParams<M>): LayoutedElementView<aux.toLayouted<M>> {
+  const baseView = model.findView(baseViewId)
+  invariant(baseView, `Base view ${baseViewId} not found`)
+
+  const subject = model.element(subjectId)
+  const relationships = computeRelationshipsView(subjectId, model, baseViewId, scope)
+  const layouted = layoutRelationshipsView(relationships)
+
+  return exact({
+    _stage: 'layouted',
+    _type: 'element',
+    id: relationshipViewExportId(baseViewId, subjectId),
+    title: `${baseView.titleOrId} relationships of ${subject.title}`,
+    description: null,
+    tags: [],
+    links: null,
+    hash: `${baseView.$view.hash}:relationships:${scope}:${subjectId}`,
+    autoLayout: {
+      direction: 'LR',
+    },
+    nodes: layouted.nodes,
+    edges: layouted.edges,
+    bounds: layouted.bounds,
+  })
+}

--- a/packages/core/src/compute-view/relationships-view/index.ts
+++ b/packages/core/src/compute-view/relationships-view/index.ts
@@ -1,3 +1,17 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 export type { RelationshipsViewData } from './_types'
 export { computeRelationshipsView } from './compute'
+export {
+  computeRelationshipViewExport,
+  relationshipViewExportId,
+  type RelationshipViewExportParams,
+  type RelationshipViewExportScope,
+} from './export-view'
+export { layoutRelationshipsView } from './layout'
 export { treeFromElements } from './utils'

--- a/packages/core/src/compute-view/relationships-view/layout.spec.ts
+++ b/packages/core/src/compute-view/relationships-view/layout.spec.ts
@@ -41,5 +41,6 @@ describe('layoutRelationshipsView', () => {
     })
     expect(edge.relations).toHaveLength(2)
     expect(edge.points.length).toBeGreaterThan(0)
+    expect((edge.points.length - 1) % 3).toBe(0)
   })
 })

--- a/packages/core/src/compute-view/relationships-view/layout.spec.ts
+++ b/packages/core/src/compute-view/relationships-view/layout.spec.ts
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import { describe, it } from 'vitest'
+import { Builder } from '../../builder/Builder'
+import { computeRelationshipsView } from './compute'
+import { layoutRelationshipsView } from './layout'
+
+describe('layoutRelationshipsView', () => {
+  const specs = Builder
+    .specification({
+      elements: {
+        el: {},
+      },
+    })
+
+  it('emits one aggregated edge for multiple displayed relationships between the same nodes', ({ expect }) => {
+    const model = specs
+      .model(({ el, rel }, _) =>
+        _(
+          el('cloud').with(
+            el('backend'),
+          ),
+          el('amazon'),
+          rel('cloud.backend', 'amazon', 'uses'),
+          rel('cloud.backend', 'amazon', 'publishes'),
+        )
+      )
+      .toLikeC4Model()
+
+    const relationshipData = computeRelationshipsView('cloud.backend', model, null)
+    const layouted = layoutRelationshipsView(relationshipData)
+
+    expect(layouted.edges).toHaveLength(1)
+    const edge = layouted.edges[0]!
+    expect(edge).toMatchObject({
+      source: 'subject-cloud.backend',
+      target: 'out-amazon',
+      label: '2 relationships',
+    })
+    expect(edge.relations).toHaveLength(2)
+    expect(edge.points.length).toBeGreaterThan(0)
+  })
+})

--- a/packages/core/src/compute-view/relationships-view/layout.ts
+++ b/packages/core/src/compute-view/relationships-view/layout.ts
@@ -6,7 +6,7 @@
 // Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
 
 import dagre, { type EdgeConfig, type GraphLabel } from '@dagrejs/dagre'
-import { concat, filter, find, forEachObj, groupBy, map, mapToObj, pipe, prop, reduce, tap } from 'remeda'
+import { concat, filter, find, forEachObj, groupBy, hasAtLeast, map, mapToObj, pipe, prop, reduce, tap } from 'remeda'
 import type { ElementModel } from '../../model/ElementModel'
 import type { RelationshipModel } from '../../model/RelationModel'
 import {
@@ -172,6 +172,26 @@ function applyDagreLayout(g: G) {
       height,
     }
   }
+}
+
+function toStraightBezierSpline(points: Point[]): NonEmptyArray<Point> {
+  invariant(hasAtLeast(points, 2), 'relationship edge should have at least two points')
+  const [start, ...rest] = points
+  const spline: NonEmptyArray<Point> = [start]
+
+  for (const end of rest) {
+    const previous = spline[spline.length - 1]
+    invariant(previous, 'relationship edge spline should have a previous point')
+    const dx = end[0] - previous[0]
+    const dy = end[1] - previous[1]
+    spline.push(
+      [previous[0] + dx / 3, previous[1] + dy / 3],
+      [previous[0] + dx * 2 / 3, previous[1] + dy * 2 / 3],
+      end,
+    )
+  }
+
+  return spline
 }
 
 export function layoutRelationshipsView(
@@ -390,7 +410,7 @@ export function layoutRelationshipsView(
       head: onlyRelation?.head,
       tail: onlyRelation?.tail,
       navigateTo: onlyRelation?.navigateTo?.id ?? null,
-      points: edge.points.map(p => [p.x, p.y] as Point) as unknown as NonEmptyArray<Point>,
+      points: toStraightBezierSpline(edge.points.map(p => [p.x, p.y])),
       labelBBox: null,
     }))
     return acc

--- a/packages/core/src/compute-view/relationships-view/layout.ts
+++ b/packages/core/src/compute-view/relationships-view/layout.ts
@@ -1,8 +1,25 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import dagre, { type EdgeConfig, type GraphLabel } from '@dagrejs/dagre'
-import { concat, filter, forEachObj, groupBy, map, mapToObj, pipe, prop, reduce, tap } from 'remeda'
+import { concat, filter, find, forEachObj, groupBy, map, mapToObj, pipe, prop, reduce, tap } from 'remeda'
 import type { ElementModel } from '../../model/ElementModel'
 import type { RelationshipModel } from '../../model/RelationModel'
-import { type DiagramNode, type DiagramView, type Fqn, type NodeId, exact } from '../../types'
+import {
+  type DiagramEdge,
+  type DiagramNode,
+  type DiagramView,
+  type EdgeId,
+  type Fqn,
+  type NodeId,
+  type NonEmptyArray,
+  type Point,
+  exact,
+} from '../../types'
 import { invariant, sortParentsFirst } from '../../utils'
 import { toArray } from '../../utils/iterable'
 import { DefaultMap } from '../../utils/mnemonist'
@@ -157,7 +174,9 @@ function applyDagreLayout(g: G) {
   }
 }
 
-export function layoutRelationshipsView(data: RelationshipsViewData): Pick<DiagramView, 'nodes' | 'edges' | 'bounds'> {
+export function layoutRelationshipsView(
+  data: RelationshipsViewData<any>,
+): Pick<DiagramView, 'nodes' | 'edges' | 'bounds'> {
   const g = createGraph()
 
   const incomers = createNodes('in', data.incomers, g),
@@ -319,7 +338,7 @@ export function layoutRelationshipsView(data: RelationshipsViewData): Pick<Diagr
       title: element.title,
       x: position.x,
       y: position.y,
-      description: element.$element.summary ?? element.$element.description ?? null,
+      description: element.summary.$source ?? null,
       technology: element.technology,
       tags: [],
       links: null,
@@ -345,6 +364,52 @@ export function layoutRelationshipsView(data: RelationshipsViewData): Pick<Diagr
     })
   })
 
+  const diagramEdges = g.edges().reduce((acc, e) => {
+    const edge = g.edge(e)
+    const ename = e.name
+    if (!ename) {
+      return acc
+    }
+    const edgeData = find(edges, edge => edge.name === ename)
+    invariant(edgeData, `Edge ${ename} has no relationship data`)
+    const onlyRelation = edgeData.relations.length === 1 ? edgeData.relations[0] : null
+    const edgeId = edgeData.name as EdgeId
+
+    acc.push(exact({
+      id: edgeId,
+      parent: null,
+      source: edgeData.source as NodeId,
+      target: edgeData.target as NodeId,
+      label: onlyRelation ? onlyRelation.title ?? 'untitled' : `${edgeData.relations.length} relationships`,
+      description: onlyRelation?.description.$source ?? null,
+      technology: onlyRelation?.technology ?? null,
+      relations: edgeData.relations.map(r => r.id),
+      kind: onlyRelation?.kind ?? undefined,
+      color: onlyRelation?.color ?? 'gray',
+      line: onlyRelation?.line ?? 'dashed',
+      head: onlyRelation?.head,
+      tail: onlyRelation?.tail,
+      navigateTo: onlyRelation?.navigateTo?.id ?? null,
+      points: edge.points.map(p => [p.x, p.y] as Point) as unknown as NonEmptyArray<Point>,
+      labelBBox: null,
+    }))
+    return acc
+  }, [] as DiagramEdge[])
+
+  const nodeEdges = new Map<NodeId, { inEdges: EdgeId[]; outEdges: EdgeId[] }>()
+  const edgesOf = (nodeId: NodeId) => {
+    let edges = nodeEdges.get(nodeId)
+    if (!edges) {
+      edges = { inEdges: [], outEdges: [] }
+      nodeEdges.set(nodeId, edges)
+    }
+    return edges
+  }
+  for (const edge of diagramEdges) {
+    edgesOf(edge.source).outEdges.push(edge.id)
+    edgesOf(edge.target).inEdges.push(edge.id)
+  }
+
   return {
     bounds: {
       x: 0,
@@ -352,7 +417,11 @@ export function layoutRelationshipsView(data: RelationshipsViewData): Pick<Diagr
       width: g.graph().width ?? 100,
       height: g.graph().height ?? 100,
     },
-    nodes,
-    edges: [],
+    nodes: nodes.map(node => ({
+      ...node,
+      inEdges: nodeEdges.get(node.id)?.inEdges ?? [],
+      outEdges: nodeEdges.get(node.id)?.outEdges ?? [],
+    })),
+    edges: diagramEdges,
   }
 }

--- a/packages/diagram/src/LikeC4Diagram.props.ts
+++ b/packages/diagram/src/LikeC4Diagram.props.ts
@@ -46,6 +46,12 @@ export type ElementIconRendererProps = {
 
 export type ElementIconRenderer = (props: ElementIconRendererProps) => ReactNode
 
+export type RelationshipBrowserActionProps<A extends Any = Unknown> = {
+  subjectId: Fqn<A>
+  viewId: ViewId<A>
+  scope: 'view' | 'global'
+}
+
 export type LikeC4ColorScheme = 'light' | 'dark'
 
 export type OverrideReactFlowProps = Pick<
@@ -258,6 +264,11 @@ export interface LikeC4DiagramProperties<A extends Any = Unknown> {
    * @default true
    */
   enableNotes?: boolean | undefined
+
+  /**
+   * Render host-specific actions in the relationship browser toolbar.
+   */
+  renderRelationshipBrowserActions?: ((props: RelationshipBrowserActionProps<A>) => ReactNode) | undefined
 
   /**
    * Improve performance by hiding certain elements and reducing visual effects (disable mix-blend, shadows, animations)

--- a/packages/diagram/src/LikeC4Diagram.tsx
+++ b/packages/diagram/src/LikeC4Diagram.tsx
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import type { Any } from '@likec4/core/types'
 import { useCustomCompareMemo } from '@react-hookz/web'
 import { type FitViewOptions, ReactFlowProvider as XYFlowProvider } from '@xyflow/react'
@@ -87,6 +94,7 @@ export function LikeC4Diagram<A extends Any = Any>({
   where,
   reactFlowProps,
   renderNodes,
+  renderRelationshipBrowserActions,
   children,
 }: LikeC4DiagramProps<A>): JSX.Element {
   const id = useId()
@@ -209,7 +217,7 @@ export function LikeC4Diagram<A extends Any = Any>({
                           >
                             {children}
                           </LikeC4DiagramXYFlow>
-                          <LikeC4DiagramUI />
+                          <LikeC4DiagramUI renderRelationshipBrowserActions={renderRelationshipBrowserActions} />
                         </CurrentViewModelProvider>
                       </DiagramActorProvider>
                     </XYFlowProvider>

--- a/packages/diagram/src/index.ts
+++ b/packages/diagram/src/index.ts
@@ -24,6 +24,7 @@ export type {
   OnNodeClick,
   OnOpenSource,
   PaddingWithUnit,
+  RelationshipBrowserActionProps,
   ViewPadding,
   ViewPaddings,
   WhereOperator,

--- a/packages/diagram/src/likec4diagram/DiagramUI.tsx
+++ b/packages/diagram/src/likec4diagram/DiagramUI.tsx
@@ -1,8 +1,16 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { useRerender } from '@react-hookz/web'
-import { memo, useCallback } from 'react'
+import { type ReactNode, memo, useCallback } from 'react'
 import { ErrorBoundary } from '../components/ErrorFallback'
 import { useEnabledFeatures } from '../context/DiagramFeatures'
 import { selectDiagramActor, useDiagramSnapshot } from '../hooks/useDiagram'
+import type { RelationshipBrowserActionProps } from '../LikeC4Diagram.props'
 import { NavigationPanel } from '../navigationpanel'
 import { Overlays } from '../overlays/Overlays'
 import { Search } from '../search/Search'
@@ -14,7 +22,11 @@ const selectChildren = selectDiagramActor(s => ({
   search: s.children.search ?? null,
 }))
 
-export const LikeC4DiagramUI = memo(() => {
+export const LikeC4DiagramUI = memo(({
+  renderRelationshipBrowserActions,
+}: {
+  renderRelationshipBrowserActions?: ((props: RelationshipBrowserActionProps) => ReactNode) | undefined
+}) => {
   const {
     enableControls,
     enableNotations,
@@ -34,7 +46,11 @@ export const LikeC4DiagramUI = memo(() => {
   return (
     <ErrorBoundary onReset={handleReset}>
       {enableControls && <NavigationPanel />}
-      {actors.overlays && <Overlays overlaysActorRef={actors.overlays} />}
+      {actors.overlays && (
+        <Overlays
+          overlaysActorRef={actors.overlays}
+          renderRelationshipBrowserActions={renderRelationshipBrowserActions} />
+      )}
       {enableNotations && <NotationPanel />}
       {enableSearch && actors.search && <Search searchActorRef={actors.search} />}
       {enableRelationshipDetails && enableReadOnly && <RelationshipPopover />}

--- a/packages/diagram/src/likec4diagram/state/diagram-api.ts
+++ b/packages/diagram/src/likec4diagram/state/diagram-api.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import type * as t from '@likec4/core/types'
 import type {
   DynamicViewDisplayVariant,
@@ -82,7 +89,7 @@ export interface DiagramApi<A extends Any = Unknown> {
   /**
    * Open relationships browser
    */
-  openRelationshipsBrowser(fqn: Fqn<A>): void
+  openRelationshipsBrowser(fqn: Fqn<A>, scope?: 'view' | 'global'): void
   /**
    * If running in editor, trigger opening source file
    */
@@ -201,8 +208,8 @@ export function makeDiagramApi<A extends Any = Unknown>(actorRef: RefObject<Diag
     fitDiagram: (duration = 350) => {
       actorRef.current.send({ type: 'xyflow.fitDiagram', duration })
     },
-    openRelationshipsBrowser: (fqn) => {
-      actorRef.current.send({ type: 'open.relationshipsBrowser', fqn })
+    openRelationshipsBrowser: (fqn, scope) => {
+      actorRef.current.send({ type: 'open.relationshipsBrowser', fqn, scope })
     },
     openSource: (params: OpenSourceParams<Unknown>) => {
       actorRef.current.send({ type: 'open.source', ...params })

--- a/packages/diagram/src/likec4diagram/state/machine.actions.ts
+++ b/packages/diagram/src/likec4diagram/state/machine.actions.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 // oxlint-disable triple-slash-reference
 // oxlint-disable no-floating-promises
 import {
@@ -742,7 +749,7 @@ export const openOverlay = () =>
             type: 'open.relationshipsBrowser',
             subject: event.fqn,
             viewId: context.view.id,
-            scope: 'view' as const,
+            scope: event.scope ?? 'view',
             closeable: true,
             enableChangeScope: true,
             enableSelectSubject: true,

--- a/packages/diagram/src/likec4diagram/state/machine.setup.ts
+++ b/packages/diagram/src/likec4diagram/state/machine.setup.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import {
   nonexhaustive,
 } from '@likec4/core'
@@ -174,7 +181,7 @@ export type Events =
   | ({ type: 'open.source' } & OpenSourceParams)
   | { type: 'open.elementDetails'; fqn: Fqn; fromNode?: NodeId | undefined }
   | { type: 'open.relationshipDetails'; params: { edgeId: EdgeId } | { source: Fqn; target: Fqn } }
-  | { type: 'open.relationshipsBrowser'; fqn: Fqn }
+  | { type: 'open.relationshipsBrowser'; fqn: Fqn; scope?: 'view' | 'global' | undefined }
   | { type: 'open.search'; search?: string }
   // | { type: 'close.overlay' }
   | { type: 'navigate.to'; viewId: ViewId; fromNode?: NodeId | undefined; focusOnElement?: Fqn | undefined }

--- a/packages/diagram/src/overlays/Overlays.tsx
+++ b/packages/diagram/src/overlays/Overlays.tsx
@@ -1,13 +1,21 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { nonexhaustive } from '@likec4/core'
 import { useSelector } from '@xstate/react'
 import { animate } from 'motion'
 import { AnimatePresence, LayoutGroup, useReducedMotionConfig } from 'motion/react'
-import { useEffect } from 'react'
+import { type ReactNode, useEffect } from 'react'
 import { isNonNullish } from 'remeda'
 import type { AnyActorRef } from 'xstate'
 import { ErrorBoundary } from '../components/ErrorFallback'
 import { DiagramFeatures } from '../context'
 import { useDiagram } from '../hooks'
+import type { RelationshipBrowserActionProps } from '../LikeC4Diagram.props'
 import { ElementDetails } from './element-details/ElementDetails'
 import { Overlay } from './overlay/Overlay'
 import type { OverlaysActorRef, OverlaysActorSnapshot } from './overlaysActor'
@@ -49,7 +57,13 @@ const compareSelectOverlays = <T extends ReturnType<typeof selectOverlays>>(a: T
   })
 }
 
-export function Overlays({ overlaysActorRef }: { overlaysActorRef: OverlaysActorRef }) {
+export function Overlays({
+  overlaysActorRef,
+  renderRelationshipBrowserActions,
+}: {
+  overlaysActorRef: OverlaysActorRef
+  renderRelationshipBrowserActions?: ((props: RelationshipBrowserActionProps) => ReactNode) | undefined
+}) {
   const diagram = useDiagram()
 
   const overlays = useSelector(overlaysActorRef, selectOverlays, compareSelectOverlays)
@@ -100,7 +114,9 @@ export function Overlays({ overlaysActorRef }: { overlaysActorRef: OverlaysActor
             key={overlay.actorRef.sessionId}
             overlayLevel={index}
             onClose={() => close(overlay.actorRef)}>
-            <RelationshipsBrowser actorRef={overlay.actorRef} />
+            <RelationshipsBrowser
+              actorRef={overlay.actorRef}
+              renderActions={renderRelationshipBrowserActions} />
           </Overlay>
         )
       case 'relationshipDetails':

--- a/packages/diagram/src/overlays/relationships-browser/RelationshipsBrowser.spec.ts
+++ b/packages/diagram/src/overlays/relationships-browser/RelationshipsBrowser.spec.ts
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import { describe, it } from 'vitest'
+import { buildRelationshipUrlFromHref } from './RelationshipsBrowser'
+
+describe('buildRelationshipUrlFromHref', () => {
+  it('adds relationship subject and scope to browser-history URLs', ({ expect }) => {
+    expect(buildRelationshipUrlFromHref('https://example.com/view/index/', 'cloud.backend', 'global')).toBe(
+      'https://example.com/view/index/?relationships=cloud.backend&relationshipScope=global',
+    )
+  })
+
+  it('adds relationship subject and scope to hash-router URLs', ({ expect }) => {
+    expect(buildRelationshipUrlFromHref('https://example.com/app/#/view/index/', 'cloud.backend', 'view')).toBe(
+      'https://example.com/app/#/view/index?relationships=cloud.backend&relationshipScope=view',
+    )
+  })
+})

--- a/packages/diagram/src/overlays/relationships-browser/RelationshipsBrowser.tsx
+++ b/packages/diagram/src/overlays/relationships-browser/RelationshipsBrowser.tsx
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { cx } from '@likec4/styles/css'
 import { ActionIcon, Group, Tooltip as MantineTooltip } from '@mantine/core'
 import { useClipboard, useStateHistory } from '@mantine/hooks'
@@ -5,10 +12,11 @@ import { IconAlertTriangle, IconCheck, IconChevronLeft, IconChevronRight, IconLi
 import { Panel, ReactFlowProvider, useReactFlow, useStoreApi } from '@xyflow/react'
 import { shallowEqual } from 'fast-equals'
 import { AnimatePresence, LayoutGroup, m } from 'motion/react'
-import { memo, useEffect, useRef, useState } from 'react'
+import { type ReactNode, memo, useEffect, useRef, useState } from 'react'
 import type { SnapshotFrom } from 'xstate'
 import { BaseXYFlow } from '../../base/BaseXYFlow'
 import { useCallbackRef } from '../../hooks/useCallbackRef'
+import type { RelationshipBrowserActionProps } from '../../LikeC4Diagram.props'
 import type { RelationshipsBrowserTypes } from './_types'
 import type { RelationshipsBrowserActorRef } from './actor'
 import { CompoundNode, ElementNode, EmptyNode, RelationshipEdge } from './custom'
@@ -31,9 +39,10 @@ const edgeTypes = {
 }
 export type RelationshipsBrowserProps = {
   actorRef: RelationshipsBrowserActorRef
+  renderActions?: ((props: RelationshipBrowserActionProps) => ReactNode) | undefined
 }
 
-export function RelationshipsBrowser({ actorRef }: RelationshipsBrowserProps) {
+export function RelationshipsBrowser({ actorRef, renderActions }: RelationshipsBrowserProps) {
   // const actorRef = useDiagramActorState(s => s.children.relationshipsBrowser)
   // if (actorRef == null) {
   //   return null
@@ -55,7 +64,7 @@ export function RelationshipsBrowser({ actorRef }: RelationshipsBrowserProps) {
       <ReactFlowProvider {...initialRef.current}>
         <LayoutGroup id={actorRef.sessionId} inherit={false}>
           <AnimatePresence>
-            <RelationshipsBrowserXYFlow />
+            <RelationshipsBrowserXYFlow renderActions={renderActions} />
           </AnimatePresence>
         </LayoutGroup>
       </ReactFlowProvider>
@@ -73,7 +82,11 @@ const selectorEq = (a: ReturnType<typeof selector>, b: ReturnType<typeof selecto
   shallowEqual(a.nodes, b.nodes) &&
   shallowEqual(a.edges, b.edges)
 
-const RelationshipsBrowserXYFlow = memo(() => {
+const RelationshipsBrowserXYFlow = memo(({
+  renderActions,
+}: {
+  renderActions?: ((props: RelationshipBrowserActionProps) => ReactNode) | undefined
+}) => {
   const browser = useRelationshipsBrowser()
   const {
     isActive,
@@ -138,7 +151,7 @@ const RelationshipsBrowserXYFlow = memo(() => {
       pannable
       zoomable
     >
-      <RelationshipsBrowserInner />
+      <RelationshipsBrowserInner renderActions={renderActions} />
     </BaseXYFlow>
   )
 })
@@ -150,7 +163,11 @@ const selector2 = (state: SnapshotFrom<RelationshipsBrowserActorRef>) => ({
   closeable: state.context.closeable,
 })
 
-const RelationshipsBrowserInner = memo(() => {
+const RelationshipsBrowserInner = memo(({
+  renderActions,
+}: {
+  renderActions?: ((props: RelationshipBrowserActionProps) => ReactNode) | undefined
+}) => {
   const browser = useRelationshipsBrowser()
   const {
     subjectId,
@@ -201,7 +218,12 @@ const RelationshipsBrowserInner = memo(() => {
       {closeable && (
         <Panel position="top-right">
           <Group gap={4} wrap={'nowrap'}>
-            <CopyLinkButton subjectId={subjectId} />
+            {renderActions?.({
+              subjectId: subjectId as never,
+              viewId: viewId as never,
+              scope,
+            })}
+            <CopyLinkButton subjectId={subjectId} scope={scope} />
             <ActionIcon
               variant="default"
               color="gray"
@@ -289,6 +311,7 @@ const TopLeftPanel = ({
  */
 type CopyLinkButtonProps = {
   subjectId: string
+  scope: 'view' | 'global'
 }
 
 const Tooltip = MantineTooltip.withProps({
@@ -307,13 +330,18 @@ const Tooltip = MantineTooltip.withProps({
  * Handles both browser history routing and hash-based routing.
  * Preserves base paths when app is hosted under a sub-path.
  */
-function buildRelationshipUrl(subjectId: string): string {
-  const currentUrl = new URL(window.location.href)
+export function buildRelationshipUrlFromHref(
+  href: string,
+  subjectId: string,
+  scope: 'view' | 'global',
+): string {
+  const currentUrl = new URL(href)
 
   // Hash-based routing: /#/view/name or /base/path/index.html#/view/name
   if (currentUrl.hash.startsWith('#/')) {
     const hashUrl = new URL(currentUrl.hash.substring(1), currentUrl.origin)
     hashUrl.searchParams.set('relationships', subjectId)
+    hashUrl.searchParams.set('relationshipScope', scope)
 
     const cleanPath = hashUrl.pathname.replace(/\/$/, '')
 
@@ -322,7 +350,12 @@ function buildRelationshipUrl(subjectId: string): string {
 
   // Standard browser history routing
   currentUrl.searchParams.set('relationships', subjectId)
+  currentUrl.searchParams.set('relationshipScope', scope)
   return currentUrl.href
+}
+
+function buildRelationshipUrl(subjectId: string, scope: 'view' | 'global'): string {
+  return buildRelationshipUrlFromHref(window.location.href, subjectId, scope)
 }
 
 /**
@@ -330,7 +363,7 @@ function buildRelationshipUrl(subjectId: string): string {
  * Shows visual feedback for both success and failure states.
  * Note: Clipboard API requires HTTPS or localhost. This is a browser security restriction, not a code issue.
  */
-const CopyLinkButton = ({ subjectId }: CopyLinkButtonProps) => {
+const CopyLinkButton = ({ subjectId, scope }: CopyLinkButtonProps) => {
   const clipboard = useClipboard({ timeout: 2000 })
   const [copyError, setCopyError] = useState(false)
   const errorTimeoutRef = useRef<number | null>(null)
@@ -345,7 +378,7 @@ const CopyLinkButton = ({ subjectId }: CopyLinkButtonProps) => {
       errorTimeoutRef.current = null
     }
 
-    const url = buildRelationshipUrl(subjectId)
+    const url = buildRelationshipUrl(subjectId, scope)
 
     // Check if we're NOT in a secure context (HTTP on non-localhost)
     // Clipboard API requires HTTPS or localhost

--- a/packages/likec4-spa/package.json
+++ b/packages/likec4-spa/package.json
@@ -31,7 +31,9 @@
     "vitest:ui": "vitest --no-isolate --ui"
   },
   "dependencies": {
+    "@hpcc-js/wasm-graphviz": "catalog:externals",
     "@likec4/core": "workspace:*",
+    "@likec4/generators": "workspace:*",
     "immer": "catalog:utils",
     "react": "catalog:react",
     "react-dom": "catalog:react",

--- a/packages/likec4-spa/src/components/view-page/Header.tsx
+++ b/packages/likec4-spa/src/components/view-page/Header.tsx
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { useLikeC4Projects } from '@likec4/diagram'
 import {
   Button,
@@ -16,6 +23,10 @@ import {
   useMatches,
 } from '@tanstack/react-router'
 import { memo, useCallback, useState } from 'react'
+import {
+  enabledWebappExportFormats,
+  isWebappExportFormatEnabled,
+} from '../../export-formats'
 import { useCurrentProject, useCurrentViewId } from '../../hooks'
 import { ColorSchemeToggle } from '../ColorSchemeToggle'
 import { NavigationPanel } from './NavigationPanel'
@@ -93,6 +104,7 @@ function ExportButton() {
   const [isDrawioLoading, setIsDrawioLoading] = useState(false)
   const project = useCurrentProject()
   const viewId = useCurrentViewId()
+  const enabledFormats = enabledWebappExportFormats(project)
 
   const handleDrawioExport = useCallback(async () => {
     try {
@@ -107,6 +119,10 @@ function ExportButton() {
       setIsDrawioLoading(false)
     }
   }, [project.id, viewId])
+
+  if (enabledFormats.length === 0) {
+    return null
+  }
 
   return (
     <Menu shadow="md" width={200} trigger="click-hover" openDelay={200}>
@@ -124,67 +140,81 @@ function ExportButton() {
 
       <MenuDropdown>
         <MenuLabel>Current view</MenuLabel>
-        <MenuItem
-          renderRoot={(props) => (
-            <Link
-              target="_blank"
-              to={isInsideProject ? '/project/$projectId/export/$viewId/' : '/export/$viewId/'}
-              search={enableDownload}
-              {...props} />
-          )}
-        >
-          Export as .png
-        </MenuItem>
-        <MenuItem
-          renderRoot={(props) => (
-            <Link
-              target="_blank"
-              to={isInsideProject ? '/project/$projectId/export/$viewId/' : '/export/$viewId/'}
-              search={enableJpegDownload}
-              {...props} />
-          )}
-        >
-          Export as .jpg
-        </MenuItem>
-        <MenuItem
-          renderRoot={(props) => (
-            <Link
-              to={isInsideProject ? '/project/$projectId/view/$viewId/dot/' : '/view/$viewId/dot/'}
-              search
-              {...props} />
-          )}
-        >
-          Export as .dot
-        </MenuItem>
-        <MenuItem
-          renderRoot={(props) => (
-            <Link
-              to={isInsideProject ? '/project/$projectId/view/$viewId/d2' : '/view/$viewId/d2'}
-              search
-              {...props} />
-          )}
-        >
-          Export as .d2
-        </MenuItem>
-        <MenuItem
-          renderRoot={(props) => (
-            <Link
-              to={isInsideProject ? '/project/$projectId/view/$viewId/mmd' : '/view/$viewId/mmd'}
-              search
-              {...props} />
-          )}>
-          Export as .mmd
-        </MenuItem>
-        <MenuItem
-          renderRoot={(props) => (
-            <Link
-              to={isInsideProject ? '/project/$projectId/view/$viewId/puml' : '/view/$viewId/puml'}
-              search
-              {...props} />
-          )}>
-          Export as .puml
-        </MenuItem>
-        <MenuItem disabled={isDrawioLoading} onClick={handleDrawioExport}>Export to Draw.io</MenuItem>
+        {isWebappExportFormatEnabled(project, 'png') && (
+          <MenuItem
+            renderRoot={(props) => (
+              <Link
+                target="_blank"
+                to={isInsideProject ? '/project/$projectId/export/$viewId/' : '/export/$viewId/'}
+                search={enableDownload}
+                {...props} />
+            )}
+          >
+            Export as .png
+          </MenuItem>
+        )}
+        {isWebappExportFormatEnabled(project, 'jpg') && (
+          <MenuItem
+            renderRoot={(props) => (
+              <Link
+                target="_blank"
+                to={isInsideProject ? '/project/$projectId/export/$viewId/' : '/export/$viewId/'}
+                search={enableJpegDownload}
+                {...props} />
+            )}
+          >
+            Export as .jpg
+          </MenuItem>
+        )}
+        {isWebappExportFormatEnabled(project, 'dot') && (
+          <MenuItem
+            renderRoot={(props) => (
+              <Link
+                to={isInsideProject ? '/project/$projectId/view/$viewId/dot/' : '/view/$viewId/dot/'}
+                search
+                {...props} />
+            )}
+          >
+            Export as .dot
+          </MenuItem>
+        )}
+        {isWebappExportFormatEnabled(project, 'd2') && (
+          <MenuItem
+            renderRoot={(props) => (
+              <Link
+                to={isInsideProject ? '/project/$projectId/view/$viewId/d2' : '/view/$viewId/d2'}
+                search
+                {...props} />
+            )}
+          >
+            Export as .d2
+          </MenuItem>
+        )}
+        {isWebappExportFormatEnabled(project, 'mmd') && (
+          <MenuItem
+            renderRoot={(props) => (
+              <Link
+                to={isInsideProject ? '/project/$projectId/view/$viewId/mmd' : '/view/$viewId/mmd'}
+                search
+                {...props} />
+            )}>
+            Export as .mmd
+          </MenuItem>
+        )}
+        {isWebappExportFormatEnabled(project, 'puml') && (
+          <MenuItem
+            renderRoot={(props) => (
+              <Link
+                to={isInsideProject ? '/project/$projectId/view/$viewId/puml' : '/view/$viewId/puml'}
+                search
+                {...props} />
+            )}>
+            Export as .puml
+          </MenuItem>
+        )}
+        {isWebappExportFormatEnabled(project, 'drawio') && (
+          <MenuItem disabled={isDrawioLoading} onClick={handleDrawioExport}>Export to Draw.io</MenuItem>
+        )}
         <MenuItem disabled>Export to Miro</MenuItem>
         <MenuItem disabled>Export to Notion</MenuItem>
         {

--- a/packages/likec4-spa/src/components/view-page/Header.tsx
+++ b/packages/likec4-spa/src/components/view-page/Header.tsx
@@ -23,10 +23,7 @@ import {
   useMatches,
 } from '@tanstack/react-router'
 import { memo, useCallback, useState } from 'react'
-import {
-  enabledWebappExportFormats,
-  isWebappExportFormatEnabled,
-} from '../../export-formats'
+import { enabledWebappExportFormats } from '../../export-formats'
 import { useCurrentProject, useCurrentViewId } from '../../hooks'
 import { ColorSchemeToggle } from '../ColorSchemeToggle'
 import { NavigationPanel } from './NavigationPanel'
@@ -104,7 +101,7 @@ function ExportButton() {
   const [isDrawioLoading, setIsDrawioLoading] = useState(false)
   const project = useCurrentProject()
   const viewId = useCurrentViewId()
-  const enabledFormats = enabledWebappExportFormats(project)
+  const enabledFormats = new Set(enabledWebappExportFormats(project))
 
   const handleDrawioExport = useCallback(async () => {
     try {
@@ -120,7 +117,7 @@ function ExportButton() {
     }
   }, [project.id, viewId])
 
-  if (enabledFormats.length === 0) {
+  if (enabledFormats.size === 0) {
     return null
   }
 
@@ -140,7 +137,7 @@ function ExportButton() {
 
       <MenuDropdown>
         <MenuLabel>Current view</MenuLabel>
-        {isWebappExportFormatEnabled(project, 'png') && (
+        {enabledFormats.has('png') && (
           <MenuItem
             renderRoot={(props) => (
               <Link
@@ -153,7 +150,7 @@ function ExportButton() {
             Export as .png
           </MenuItem>
         )}
-        {isWebappExportFormatEnabled(project, 'jpg') && (
+        {enabledFormats.has('jpg') && (
           <MenuItem
             renderRoot={(props) => (
               <Link
@@ -166,7 +163,7 @@ function ExportButton() {
             Export as .jpg
           </MenuItem>
         )}
-        {isWebappExportFormatEnabled(project, 'dot') && (
+        {enabledFormats.has('dot') && (
           <MenuItem
             renderRoot={(props) => (
               <Link
@@ -178,7 +175,7 @@ function ExportButton() {
             Export as .dot
           </MenuItem>
         )}
-        {isWebappExportFormatEnabled(project, 'd2') && (
+        {enabledFormats.has('d2') && (
           <MenuItem
             renderRoot={(props) => (
               <Link
@@ -190,7 +187,7 @@ function ExportButton() {
             Export as .d2
           </MenuItem>
         )}
-        {isWebappExportFormatEnabled(project, 'mmd') && (
+        {enabledFormats.has('mmd') && (
           <MenuItem
             renderRoot={(props) => (
               <Link
@@ -201,7 +198,7 @@ function ExportButton() {
             Export as .mmd
           </MenuItem>
         )}
-        {isWebappExportFormatEnabled(project, 'puml') && (
+        {enabledFormats.has('puml') && (
           <MenuItem
             renderRoot={(props) => (
               <Link
@@ -212,7 +209,7 @@ function ExportButton() {
             Export as .puml
           </MenuItem>
         )}
-        {isWebappExportFormatEnabled(project, 'drawio') && (
+        {enabledFormats.has('drawio') && (
           <MenuItem disabled={isDrawioLoading} onClick={handleDrawioExport}>Export to Draw.io</MenuItem>
         )}
         <MenuItem disabled>Export to Miro</MenuItem>

--- a/packages/likec4-spa/src/export-formats.spec.ts
+++ b/packages/likec4-spa/src/export-formats.spec.ts
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import type { WebappExportFormat } from '@likec4/config'
+import { describe, it } from 'vitest'
+import {
+  enabledWebappExportFormats,
+  hasAnyWebappExportFormatEnabled,
+  isImageExportFormatEnabled,
+  isWebappExportFormatEnabled,
+} from './export-formats'
+
+describe('SPA webapp export format helpers', () => {
+  it('defaults to every export format for older project metadata', ({ expect }) => {
+    expect(enabledWebappExportFormats({})).toEqual(['png', 'jpg', 'dot', 'd2', 'mmd', 'puml', 'drawio'])
+    expect(hasAnyWebappExportFormatEnabled({})).toBe(true)
+  })
+
+  it('keeps an empty export format list disabled', ({ expect }) => {
+    expect(enabledWebappExportFormats({ exportFormats: [] })).toEqual([])
+    expect(hasAnyWebappExportFormatEnabled({ exportFormats: [] })).toBe(false)
+  })
+
+  it('normalizes enabled formats to the fixed LikeC4 menu order', ({ expect }) => {
+    expect(enabledWebappExportFormats({ exportFormats: ['drawio', 'jpg', 'dot'] })).toEqual([
+      'jpg',
+      'dot',
+      'drawio',
+    ])
+  })
+
+  it('checks text and image export formats against project capabilities', ({ expect }) => {
+    const project: { exportFormats: WebappExportFormat[] } = { exportFormats: ['png', 'drawio'] }
+
+    expect(isWebappExportFormatEnabled(project, 'drawio')).toBe(true)
+    expect(isWebappExportFormatEnabled(project, 'dot')).toBe(false)
+    expect(isImageExportFormatEnabled(project, 'png')).toBe(true)
+    expect(isImageExportFormatEnabled(project, 'jpeg')).toBe(false)
+  })
+})

--- a/packages/likec4-spa/src/export-formats.ts
+++ b/packages/likec4-spa/src/export-formats.ts
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import type { WebappExportFormat } from '@likec4/config'
+
+const WEBAPP_EXPORT_FORMATS = [
+  'png',
+  'jpg',
+  'dot',
+  'd2',
+  'mmd',
+  'puml',
+  'drawio',
+] as const satisfies readonly WebappExportFormat[]
+
+type ProjectExportCapabilities = {
+  exportFormats?: readonly WebappExportFormat[] | undefined
+}
+
+type ImageExportSearchFormat = 'png' | 'jpeg'
+
+export function enabledWebappExportFormats(project: ProjectExportCapabilities): WebappExportFormat[] {
+  const configured = project.exportFormats
+  if (!configured) {
+    return [...WEBAPP_EXPORT_FORMATS]
+  }
+  const enabledFormats = new Set(configured)
+  return WEBAPP_EXPORT_FORMATS.filter(format => enabledFormats.has(format))
+}
+
+export function hasAnyWebappExportFormatEnabled(project: ProjectExportCapabilities): boolean {
+  return enabledWebappExportFormats(project).length > 0
+}
+
+export function isWebappExportFormatEnabled(
+  project: ProjectExportCapabilities,
+  format: WebappExportFormat,
+): boolean {
+  return enabledWebappExportFormats(project).includes(format)
+}
+
+export function isImageExportFormatEnabled(
+  project: ProjectExportCapabilities,
+  format: ImageExportSearchFormat,
+): boolean {
+  return isWebappExportFormatEnabled(project, format === 'jpeg' ? 'jpg' : format)
+}

--- a/packages/likec4-spa/src/export-formats.ts
+++ b/packages/likec4-spa/src/export-formats.ts
@@ -2,17 +2,7 @@
 //
 // Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
-import type { WebappExportFormat } from '@likec4/config'
-
-const WEBAPP_EXPORT_FORMATS = [
-  'png',
-  'jpg',
-  'dot',
-  'd2',
-  'mmd',
-  'puml',
-  'drawio',
-] as const satisfies readonly WebappExportFormat[]
+import { type WebappExportFormat, WebappExportFormats } from '@likec4/config'
 
 type ProjectExportCapabilities = {
   exportFormats?: readonly WebappExportFormat[] | undefined
@@ -23,10 +13,10 @@ type ImageExportSearchFormat = 'png' | 'jpeg'
 export function enabledWebappExportFormats(project: ProjectExportCapabilities): WebappExportFormat[] {
   const configured = project.exportFormats
   if (!configured) {
-    return [...WEBAPP_EXPORT_FORMATS]
+    return [...WebappExportFormats]
   }
   const enabledFormats = new Set(configured)
-  return WEBAPP_EXPORT_FORMATS.filter(format => enabledFormats.has(format))
+  return WebappExportFormats.filter(format => enabledFormats.has(format))
 }
 
 export function hasAnyWebappExportFormatEnabled(project: ProjectExportCapabilities): boolean {

--- a/packages/likec4-spa/src/pages/ExportPage.spec.ts
+++ b/packages/likec4-spa/src/pages/ExportPage.spec.ts
@@ -19,7 +19,10 @@ const testState = vi.hoisted(() => ({
   },
   search: {
     format: 'png',
+    relationships: undefined as string | undefined,
+    relationshipScope: undefined as string | undefined,
   },
+  model: {},
 }))
 
 vi.mock('@likec4/diagram', () => ({
@@ -51,6 +54,10 @@ vi.mock('@mantine/core', () => ({
   LoadingOverlay: React.forwardRef<HTMLDivElement>((props, ref) => React.createElement('div', { ...props, ref })),
 }))
 
+vi.mock('@nanostores/react', () => ({
+  useStore: () => testState.model,
+}))
+
 vi.mock('@tanstack/react-router', () => ({
   useSearch: () => testState.search,
 }))
@@ -62,13 +69,31 @@ vi.mock('../components/NotFound', () => ({
 vi.mock('../hooks', () => ({
   useCurrentProject: () => testState.project,
   useCurrentView: () => [testState.diagram],
+  useCurrentViewId: () => testState.diagram.id,
   useTransparentBackground: vi.fn(),
+}))
+
+vi.mock('../context/safeCtx', () => ({
+  useLikeC4ModelAtom: () => ({}),
+}))
+
+vi.mock('../relationship-export', async importOriginal => ({
+  ...(await importOriginal<typeof import('../relationship-export')>()),
+  createRelationshipExportView: ({ subjectId }: { subjectId: string }) => {
+    if (subjectId === 'missing') {
+      throw new Error('Unknown element')
+    }
+    return testState.diagram
+  },
+  normalizeRelationshipScope: (scope: string | undefined) => scope ?? 'view',
 }))
 
 describe('ExportPage', () => {
   beforeEach(() => {
     testState.project.exportFormats = ['drawio']
     testState.search.format = 'png'
+    testState.search.relationships = undefined
+    testState.search.relationshipScope = undefined
   })
 
   it('keeps the image export route available when webapp image downloads are disabled', () => {
@@ -76,5 +101,14 @@ describe('ExportPage', () => {
 
     expect(markup).toContain('data-testid="export-page"')
     expect(markup).not.toContain('data-testid="not-found"')
+  })
+
+  it('renders not found for an unknown relationship export subject', () => {
+    testState.search.relationships = 'missing'
+
+    const markup = renderToStaticMarkup(React.createElement(ExportPage))
+
+    expect(markup).toContain('data-testid="not-found"')
+    expect(markup).not.toContain('data-testid="export-page"')
   })
 })

--- a/packages/likec4-spa/src/pages/ExportPage.spec.ts
+++ b/packages/likec4-spa/src/pages/ExportPage.spec.ts
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ExportPage } from './ExportPage'
+
+const testState = vi.hoisted(() => ({
+  diagram: {
+    id: 'index',
+    bounds: { x: 0, y: 0, width: 640, height: 480 },
+    description: null,
+    notation: null,
+  },
+  project: {
+    exportFormats: ['drawio'],
+  },
+  search: {
+    format: 'png',
+  },
+}))
+
+vi.mock('@likec4/diagram', () => ({
+  LikeC4Diagram: () => React.createElement('div', { 'data-testid': 'diagram' }),
+  pickViewBounds: () => testState.diagram.bounds,
+  useLikeC4Styles: () => ({
+    colors: () => ({
+      elements: {
+        fill: '#fff',
+        stroke: '#000',
+        hiContrast: '#000',
+        loContrast: '#fff',
+      },
+    }),
+  }),
+}))
+
+vi.mock('@likec4/diagram/custom', () => ({
+  ElementShape: () => React.createElement('div'),
+  Markdown: ({ children }: { children: React.ReactNode }) => React.createElement('div', null, children),
+}))
+
+vi.mock('@likec4/styles/jsx', () => ({
+  Box: ({ children, css: _css, ...props }: React.PropsWithChildren<Record<string, unknown>>) =>
+    React.createElement('div', props, children),
+}))
+
+vi.mock('@mantine/core', () => ({
+  LoadingOverlay: React.forwardRef<HTMLDivElement>((props, ref) => React.createElement('div', { ...props, ref })),
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  useSearch: () => testState.search,
+}))
+
+vi.mock('../components/NotFound', () => ({
+  NotFound: () => React.createElement('div', { 'data-testid': 'not-found' }, 'not found'),
+}))
+
+vi.mock('../hooks', () => ({
+  useCurrentProject: () => testState.project,
+  useCurrentView: () => [testState.diagram],
+  useTransparentBackground: vi.fn(),
+}))
+
+describe('ExportPage', () => {
+  beforeEach(() => {
+    testState.project.exportFormats = ['drawio']
+    testState.search.format = 'png'
+  })
+
+  it('keeps the image export route available when webapp image downloads are disabled', () => {
+    const markup = renderToStaticMarkup(React.createElement(ExportPage))
+
+    expect(markup).toContain('data-testid="export-page"')
+    expect(markup).not.toContain('data-testid="not-found"')
+  })
+})

--- a/packages/likec4-spa/src/pages/ExportPage.tsx
+++ b/packages/likec4-spa/src/pages/ExportPage.tsx
@@ -13,9 +13,7 @@ import { LoadingOverlay } from '@mantine/core'
 import { useSearch } from '@tanstack/react-router'
 import type { CSSProperties } from 'react'
 import { useRef } from 'react'
-import { NotFound } from '../components/NotFound'
-import { isImageExportFormatEnabled } from '../export-formats'
-import { useCurrentProject, useCurrentView, useTransparentBackground } from '../hooks'
+import { useCurrentView, useTransparentBackground } from '../hooks'
 import {
   computeExportPageLayout,
   EXPORT_DESCRIPTION_BODY_TOP_GAP,
@@ -118,15 +116,10 @@ async function downloadAsJpeg({
 export function ExportPage() {
   const [diagram] = useCurrentView()
   const { format } = useSearch({ strict: false })
-  const project = useCurrentProject()
   const imageFormat = format ?? 'png'
   const isJpeg = imageFormat === 'jpeg'
 
   useTransparentBackground(!isJpeg)
-
-  if (!isImageExportFormatEnabled(project, imageFormat)) {
-    return <NotFound />
-  }
 
   if (!diagram) {
     return <div>Loading...</div>

--- a/packages/likec4-spa/src/pages/ExportPage.tsx
+++ b/packages/likec4-spa/src/pages/ExportPage.tsx
@@ -13,7 +13,7 @@ import { LoadingOverlay } from '@mantine/core'
 import { useStore } from '@nanostores/react'
 import { useSearch } from '@tanstack/react-router'
 import type { CSSProperties } from 'react'
-import { useRef } from 'react'
+import { useMemo, useRef } from 'react'
 import { useLikeC4ModelAtom } from '../context/safeCtx'
 import { useCurrentView, useCurrentViewId, useTransparentBackground } from '../hooks'
 import { createRelationshipExportView, normalizeRelationshipScope } from '../relationship-export'
@@ -126,14 +126,17 @@ export function ExportPage() {
 
   useTransparentBackground(!isJpeg)
 
-  const exportDiagram = relationships
-    ? createRelationshipExportView({
+  const exportDiagram = useMemo(() => {
+    if (!relationships) {
+      return diagram
+    }
+    return createRelationshipExportView({
       model,
       baseViewId: viewId,
       subjectId: relationships,
       scope: normalizeRelationshipScope(relationshipScope),
     })
-    : diagram
+  }, [diagram, model, relationshipScope, relationships, viewId])
 
   if (!exportDiagram) {
     return <div>Loading...</div>

--- a/packages/likec4-spa/src/pages/ExportPage.tsx
+++ b/packages/likec4-spa/src/pages/ExportPage.tsx
@@ -14,6 +14,7 @@ import { useStore } from '@nanostores/react'
 import { useSearch } from '@tanstack/react-router'
 import type { CSSProperties } from 'react'
 import { useMemo, useRef } from 'react'
+import { NotFound } from '../components/NotFound'
 import { useLikeC4ModelAtom } from '../context/safeCtx'
 import { useCurrentView, useCurrentViewId, useTransparentBackground } from '../hooks'
 import { createRelationshipExportView, normalizeRelationshipScope } from '../relationship-export'
@@ -130,13 +131,22 @@ export function ExportPage() {
     if (!relationships) {
       return diagram
     }
-    return createRelationshipExportView({
-      model,
-      baseViewId: viewId,
-      subjectId: relationships,
-      scope: normalizeRelationshipScope(relationshipScope),
-    })
+    try {
+      return createRelationshipExportView({
+        model,
+        baseViewId: viewId,
+        subjectId: relationships,
+        scope: normalizeRelationshipScope(relationshipScope),
+      })
+    } catch (error) {
+      console.error(error)
+      return null
+    }
   }, [diagram, model, relationshipScope, relationships, viewId])
+
+  if (relationships && !exportDiagram) {
+    return <NotFound />
+  }
 
   if (!exportDiagram) {
     return <div>Loading...</div>

--- a/packages/likec4-spa/src/pages/ExportPage.tsx
+++ b/packages/likec4-spa/src/pages/ExportPage.tsx
@@ -13,7 +13,9 @@ import { LoadingOverlay } from '@mantine/core'
 import { useSearch } from '@tanstack/react-router'
 import type { CSSProperties } from 'react'
 import { useRef } from 'react'
-import { useCurrentView, useTransparentBackground } from '../hooks'
+import { NotFound } from '../components/NotFound'
+import { isImageExportFormatEnabled } from '../export-formats'
+import { useCurrentProject, useCurrentView, useTransparentBackground } from '../hooks'
 import {
   computeExportPageLayout,
   EXPORT_DESCRIPTION_BODY_TOP_GAP,
@@ -116,9 +118,15 @@ async function downloadAsJpeg({
 export function ExportPage() {
   const [diagram] = useCurrentView()
   const { format } = useSearch({ strict: false })
-  const isJpeg = format === 'jpeg'
+  const project = useCurrentProject()
+  const imageFormat = format ?? 'png'
+  const isJpeg = imageFormat === 'jpeg'
 
   useTransparentBackground(!isJpeg)
+
+  if (!isImageExportFormatEnabled(project, imageFormat)) {
+    return <NotFound />
+  }
 
   if (!diagram) {
     return <div>Loading...</div>

--- a/packages/likec4-spa/src/pages/ExportPage.tsx
+++ b/packages/likec4-spa/src/pages/ExportPage.tsx
@@ -10,10 +10,13 @@ import { LikeC4Diagram, pickViewBounds, useLikeC4Styles } from '@likec4/diagram'
 import { ElementShape, Markdown } from '@likec4/diagram/custom'
 import { Box } from '@likec4/styles/jsx'
 import { LoadingOverlay } from '@mantine/core'
+import { useStore } from '@nanostores/react'
 import { useSearch } from '@tanstack/react-router'
 import type { CSSProperties } from 'react'
 import { useRef } from 'react'
-import { useCurrentView, useTransparentBackground } from '../hooks'
+import { useLikeC4ModelAtom } from '../context/safeCtx'
+import { useCurrentView, useCurrentViewId, useTransparentBackground } from '../hooks'
+import { createRelationshipExportView, normalizeRelationshipScope } from '../relationship-export'
 import {
   computeExportPageLayout,
   EXPORT_DESCRIPTION_BODY_TOP_GAP,
@@ -115,17 +118,28 @@ async function downloadAsJpeg({
  */
 export function ExportPage() {
   const [diagram] = useCurrentView()
-  const { format } = useSearch({ strict: false })
+  const viewId = useCurrentViewId()
+  const { format, relationships, relationshipScope } = useSearch({ strict: false })
+  const model = useStore(useLikeC4ModelAtom())
   const imageFormat = format ?? 'png'
   const isJpeg = imageFormat === 'jpeg'
 
   useTransparentBackground(!isJpeg)
 
-  if (!diagram) {
+  const exportDiagram = relationships
+    ? createRelationshipExportView({
+      model,
+      baseViewId: viewId,
+      subjectId: relationships,
+      scope: normalizeRelationshipScope(relationshipScope),
+    })
+    : diagram
+
+  if (!exportDiagram) {
     return <div>Loading...</div>
   }
 
-  return <GuardedExportPage diagram={diagram} isJpeg={isJpeg} />
+  return <GuardedExportPage diagram={exportDiagram} isJpeg={isJpeg} />
 }
 
 /**

--- a/packages/likec4-spa/src/pages/RelationshipExportMenu.tsx
+++ b/packages/likec4-spa/src/pages/RelationshipExportMenu.tsx
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import {
+  type RelationshipBrowserActionProps,
+  useLikeC4Model,
+} from '@likec4/diagram'
+import {
+  ActionIcon,
+  Menu,
+  MenuDropdown,
+  MenuItem,
+  MenuLabel,
+  MenuTarget,
+  Tooltip,
+} from '@mantine/core'
+import { IconDownload } from '@tabler/icons-react'
+import { Link, useMatches } from '@tanstack/react-router'
+import { useState } from 'react'
+import {
+  enabledWebappExportFormats,
+  isImageExportFormatEnabled,
+  isWebappExportFormatEnabled,
+} from '../export-formats'
+import { useCurrentProject } from '../hooks'
+import { generateRelationshipDrawioEditUrl } from '../relationship-export'
+
+export function RelationshipExportMenu({
+  subjectId,
+  viewId,
+  scope,
+}: RelationshipBrowserActionProps) {
+  const project = useCurrentProject()
+  const model = useLikeC4Model()
+  const [isDrawioLoading, setIsDrawioLoading] = useState(false)
+  const enabledFormats = enabledWebappExportFormats(project)
+  const isInsideProject = useMatches({
+    select: matches => matches.some(({ routeId }) => routeId === '/project/$projectId'),
+  })
+
+  if (enabledFormats.length === 0) {
+    return null
+  }
+
+  const addRelationshipSearch = <P extends Record<string, unknown>>(params: P) => ({
+    ...params,
+    relationships: subjectId,
+    relationshipScope: scope,
+  })
+  const addRelationshipDownload = <P extends Record<string, unknown>>(params: P) => ({
+    ...addRelationshipSearch(params),
+    download: true,
+  })
+  const addRelationshipJpegDownload = <P extends Record<string, unknown>>(params: P) => ({
+    ...addRelationshipDownload(params),
+    format: 'jpeg' as const,
+  })
+
+  const handleDrawioExport = async () => {
+    try {
+      setIsDrawioLoading(true)
+      const url = await generateRelationshipDrawioEditUrl({
+        model,
+        baseViewId: viewId as never,
+        subjectId: subjectId as never,
+        scope,
+      })
+      window.open(url, '_blank', 'noopener,noreferrer')
+    } catch (error) {
+      console.error('Failed to export relationship view to Draw.io:', error)
+    } finally {
+      setIsDrawioLoading(false)
+    }
+  }
+
+  return (
+    <Menu shadow="md" width={190} trigger="click-hover" openDelay={200} withinPortal={false}>
+      <MenuTarget>
+        <Tooltip label="Export relationship view" color="dark" fz="xs" openDelay={400} withinPortal={false}>
+          <ActionIcon
+            variant="default"
+            color="gray"
+            aria-label="Export relationship view">
+            <IconDownload />
+          </ActionIcon>
+        </Tooltip>
+      </MenuTarget>
+      <MenuDropdown>
+        <MenuLabel>Relationship view</MenuLabel>
+        {isImageExportFormatEnabled(project, 'png') && (
+          <MenuItem
+            renderRoot={props => (
+              <Link
+                target="_blank"
+                to={isInsideProject ? '/project/$projectId/export/$viewId/' : '/export/$viewId/'}
+                search={addRelationshipDownload}
+                {...props} />
+            )}>
+            Export as .png
+          </MenuItem>
+        )}
+        {isImageExportFormatEnabled(project, 'jpeg') && (
+          <MenuItem
+            renderRoot={props => (
+              <Link
+                target="_blank"
+                to={isInsideProject ? '/project/$projectId/export/$viewId/' : '/export/$viewId/'}
+                search={addRelationshipJpegDownload}
+                {...props} />
+            )}>
+            Export as .jpg
+          </MenuItem>
+        )}
+        {isWebappExportFormatEnabled(project, 'dot') && (
+          <MenuItem
+            renderRoot={props => (
+              <Link
+                to={isInsideProject ? '/project/$projectId/view/$viewId/dot/' : '/view/$viewId/dot/'}
+                search={addRelationshipSearch}
+                {...props} />
+            )}>
+            Export as .dot
+          </MenuItem>
+        )}
+        {isWebappExportFormatEnabled(project, 'd2') && (
+          <MenuItem
+            renderRoot={props => (
+              <Link
+                to={isInsideProject ? '/project/$projectId/view/$viewId/d2/' : '/view/$viewId/d2/'}
+                search={addRelationshipSearch}
+                {...props} />
+            )}>
+            Export as .d2
+          </MenuItem>
+        )}
+        {isWebappExportFormatEnabled(project, 'mmd') && (
+          <MenuItem
+            renderRoot={props => (
+              <Link
+                to={isInsideProject ? '/project/$projectId/view/$viewId/mmd/' : '/view/$viewId/mmd/'}
+                search={addRelationshipSearch}
+                {...props} />
+            )}>
+            Export as .mmd
+          </MenuItem>
+        )}
+        {isWebappExportFormatEnabled(project, 'puml') && (
+          <MenuItem
+            renderRoot={props => (
+              <Link
+                to={isInsideProject ? '/project/$projectId/view/$viewId/puml/' : '/view/$viewId/puml/'}
+                search={addRelationshipSearch}
+                {...props} />
+            )}>
+            Export as .puml
+          </MenuItem>
+        )}
+        {isWebappExportFormatEnabled(project, 'drawio') && (
+          <MenuItem disabled={isDrawioLoading} onClick={handleDrawioExport}>Export to Draw.io</MenuItem>
+        )}
+      </MenuDropdown>
+    </Menu>
+  )
+}

--- a/packages/likec4-spa/src/pages/RelationshipExportMenu.tsx
+++ b/packages/likec4-spa/src/pages/RelationshipExportMenu.tsx
@@ -58,6 +58,11 @@ export function RelationshipExportMenu({
   })
 
   const handleDrawioExport = async () => {
+    const popup = window.open('', '_blank')
+    if (!popup) {
+      return
+    }
+    popup.opener = null
     try {
       setIsDrawioLoading(true)
       const url = await generateRelationshipDrawioEditUrl({
@@ -66,8 +71,9 @@ export function RelationshipExportMenu({
         subjectId: subjectId as never,
         scope,
       })
-      window.open(url, '_blank', 'noopener,noreferrer')
+      popup.location.href = url
     } catch (error) {
+      popup.close()
       console.error('Failed to export relationship view to Draw.io:', error)
     } finally {
       setIsDrawioLoading(false)

--- a/packages/likec4-spa/src/pages/ViewEditor.tsx
+++ b/packages/likec4-spa/src/pages/ViewEditor.tsx
@@ -14,6 +14,7 @@ import { LazyAIChat } from '../aichat'
 import { NotFound } from '../components/NotFound'
 import { useLikeC4ModelAtom } from '../context/safeCtx'
 import { useCurrentProject, useCurrentView } from '../hooks'
+import { RelationshipExportMenu } from './RelationshipExportMenu'
 import { FocusElementFromUrl, ListenForDynamicVariantChange, OpenRelationshipBrowserFromUrl } from './ViewReact'
 
 export function ViewEditor() {
@@ -88,6 +89,7 @@ export function ViewEditor() {
         enableElementTags
         enableCompareWithLatest
         dynamicViewVariant={dynamic}
+        renderRelationshipBrowserActions={props => <RelationshipExportMenu {...props} />}
         onNavigateTo={onNavigateTo}
         onLayoutTypeChange={setLayoutType}
         onLogoClick={() => {

--- a/packages/likec4-spa/src/pages/ViewReact.tsx
+++ b/packages/likec4-spa/src/pages/ViewReact.tsx
@@ -21,6 +21,7 @@ import { pageTitle as defaultPageTitle } from 'likec4:app-config'
 import { useRef } from 'react'
 import { NotFound } from '../components/NotFound'
 import { useCurrentView } from '../hooks'
+import { RelationshipExportMenu } from './RelationshipExportMenu'
 
 export function ViewReact() {
   const navigate = useNavigate()
@@ -77,6 +78,7 @@ export function ViewReact() {
       enableCompareWithLatest
       enableNotations={hasNotations}
       nodesSelectable
+      renderRelationshipBrowserActions={props => <RelationshipExportMenu {...props} />}
       onNavigateTo={onNavigateTo}
       onLayoutTypeChange={setLayoutType}
       onLogoClick={() => {
@@ -100,7 +102,7 @@ export function ViewReact() {
 export function OpenRelationshipBrowserFromUrl() {
   const router = useRouter()
   const diagram = useDiagram()
-  const { relationships } = useSearch({
+  const { relationships, relationshipScope } = useSearch({
     from: '__root__',
   })
   const processedRef = useRef<Fqn | null>(null)
@@ -113,10 +115,10 @@ export function OpenRelationshipBrowserFromUrl() {
       if (!isMounted() || processedRef.current === fqn) return
       try {
         processedRef.current = fqn
-        diagram.openRelationshipsBrowser(fqn)
+        diagram.openRelationshipsBrowser(fqn, relationshipScope)
         await router.buildAndCommitLocation({
           search: (s: Record<string, unknown>) => {
-            const { relationships: _, ...rest } = s
+            const { relationships: _, relationshipScope: _scope, ...rest } = s
             return rest
           },
           replace: true,

--- a/packages/likec4-spa/src/pages/export-page-params.spec.ts
+++ b/packages/likec4-spa/src/pages/export-page-params.spec.ts
@@ -3,7 +3,7 @@
 // Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import { describe, expect, it } from 'vitest'
-import { isExportSearchFlagEnabled } from './export-page-params'
+import { exportPageSearchDefaults, exportPageSearchSchema, isExportSearchFlagEnabled } from './export-page-params'
 
 describe('isExportSearchFlagEnabled', () => {
   it('accepts boolean and URL string true values', () => {
@@ -16,5 +16,23 @@ describe('isExportSearchFlagEnabled', () => {
     expect(isExportSearchFlagEnabled('false')).toBe(false)
     expect(isExportSearchFlagEnabled(undefined)).toBe(false)
     expect(isExportSearchFlagEnabled('')).toBe(false)
+  })
+})
+
+describe('exportPageSearchSchema', () => {
+  it('keeps relationship export params and strips their defaults', () => {
+    expect(exportPageSearchSchema.parse({
+      relationships: 'cloud.backend',
+      relationshipScope: 'global',
+      format: 'jpeg',
+    })).toMatchObject({
+      relationships: 'cloud.backend',
+      relationshipScope: 'global',
+      format: 'jpeg',
+    })
+    expect(exportPageSearchDefaults).toMatchObject({
+      relationships: undefined,
+      relationshipScope: undefined,
+    })
   })
 })

--- a/packages/likec4-spa/src/pages/export-page-params.ts
+++ b/packages/likec4-spa/src/pages/export-page-params.ts
@@ -2,6 +2,27 @@
 //
 // Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
+import { z } from 'zod'
+import { relationshipExportSearchSchema } from '../relationship-export'
+
+export const exportPageSearchSchema = relationshipExportSearchSchema.extend({
+  description: z.boolean().optional().catch(false),
+  download: z.boolean().optional().catch(false),
+  format: z.enum(['png', 'jpeg']).optional().catch('png'),
+  notation: z.boolean().optional().catch(false),
+  quality: z.number().min(0).max(1).optional().catch(undefined),
+})
+
+export const exportPageSearchDefaults = {
+  description: false,
+  download: false,
+  format: 'png',
+  notation: false,
+  quality: undefined,
+  relationships: undefined,
+  relationshipScope: undefined,
+} as const
+
 /**
  * Normalizes boolean export search params that can arrive from TanStack Router or URL strings.
  */

--- a/packages/likec4-spa/src/relationship-export.spec.ts
+++ b/packages/likec4-spa/src/relationship-export.spec.ts
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import { Builder } from '@likec4/core/builder'
+import { describe, it } from 'vitest'
+import {
+  createRelationshipExportView,
+  createRelationshipExportViewModel,
+  generateRelationshipDrawioEditUrl,
+  generateRelationshipExportSource,
+  normalizeRelationshipScope,
+  relationshipExportFilename,
+  relationshipExportSearchSchema,
+  renderRelationshipDotSvg,
+} from './relationship-export'
+
+describe('relationship export helpers', () => {
+  const specs = Builder
+    .specification({
+      elements: {
+        el: {},
+      },
+    })
+
+  const model = specs
+    .model(({ el, rel }, _) =>
+      _(
+        el('cloud', 'Cloud').with(
+          el('backend', 'Backend'),
+        ),
+        el('amazon', 'Amazon'),
+        rel('cloud.backend', 'amazon', 'uses'),
+      )
+    )
+    .views(({ view, $include }, _) =>
+      _(
+        view('index', 'Context').with(
+          $include('cloud.*'),
+          $include('amazon'),
+        ),
+      )
+    )
+    .toLikeC4Model()
+
+  it('defaults relationship export scope to the current view', ({ expect }) => {
+    expect(normalizeRelationshipScope(undefined)).toBe('view')
+    expect(normalizeRelationshipScope('global')).toBe('global')
+  })
+
+  it('parses relationship export search params', ({ expect }) => {
+    expect(relationshipExportSearchSchema.parse({ relationships: 'cloud.backend', relationshipScope: 'global' }))
+      .toEqual({
+        relationships: 'cloud.backend',
+        relationshipScope: 'global',
+      })
+    expect(relationshipExportSearchSchema.parse({ relationships: '', relationshipScope: 'local' })).toEqual({
+      relationships: undefined,
+      relationshipScope: undefined,
+    })
+  })
+
+  it('creates a stable filename from the base view and subject', ({ expect }) => {
+    expect(relationshipExportFilename('index', 'cloud.backend', 'png')).toBe(
+      'index-relationships-cloud.backend.png',
+    )
+  })
+
+  it('wraps the generated relationship view as a generator-compatible view model', ({ expect }) => {
+    const view = createRelationshipExportView({
+      model,
+      baseViewId: 'index',
+      subjectId: 'cloud.backend',
+      scope: 'view',
+    })
+    const viewmodel = createRelationshipExportViewModel(model, view)
+
+    expect(viewmodel.titleOrId).toBe('Context relationships of Backend')
+    expect(viewmodel.$view.id).toBe('index-relationships-cloud.backend')
+    expect(viewmodel.$model).toBe(model)
+    expect(viewmodel.$styles).toBe(model.$styles)
+  })
+
+  it('generates DOT, D2, Mermaid, PlantUML and Draw.io sources for relationship views', async ({ expect }) => {
+    const params = {
+      model,
+      baseViewId: 'index',
+      subjectId: 'cloud.backend',
+      scope: 'view',
+    } as const
+
+    await expect(generateRelationshipExportSource('dot', params)).resolves.toContain('"Backend"')
+    await expect(generateRelationshipExportSource('d2', params)).resolves.toContain('Backend')
+    await expect(generateRelationshipExportSource('mmd', params)).resolves.toContain('Backend')
+    await expect(generateRelationshipExportSource('puml', params)).resolves.toContain('Backend')
+    await expect(generateRelationshipExportSource('drawio', params)).resolves.toContain('<mxfile ')
+  })
+
+  it('renders relationship DOT as an SVG preview', async ({ expect }) => {
+    const dot = await generateRelationshipExportSource('dot', {
+      model,
+      baseViewId: 'index',
+      subjectId: 'cloud.backend',
+      scope: 'view',
+    })
+
+    await expect(renderRelationshipDotSvg(dot)).resolves.toContain('<svg')
+  })
+
+  it('generates a draw.io edit URL for relationship views', async ({ expect }) => {
+    const url = await generateRelationshipDrawioEditUrl({
+      model,
+      baseViewId: 'index',
+      subjectId: 'cloud.backend',
+      scope: 'view',
+    })
+
+    expect(url).toMatch(/^https:\/\/app\.diagrams\.net\/#create=/)
+  })
+})

--- a/packages/likec4-spa/src/relationship-export.ts
+++ b/packages/likec4-spa/src/relationship-export.ts
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import type { WebappExportFormat } from '@likec4/config'
+import {
+  type RelationshipViewExportParams,
+  type RelationshipViewExportScope,
+  computeRelationshipViewExport,
+} from '@likec4/core/compute-view'
+import type { LikeC4Model, LikeC4ViewModel } from '@likec4/core/model'
+import type { LikeC4Styles } from '@likec4/core/styles'
+import type { AnyAux, aux, Fqn, LayoutedElementView, ProcessedView } from '@likec4/core/types'
+import { z } from 'zod'
+
+export type RelationshipSourceExportFormat = Extract<WebappExportFormat, 'dot' | 'd2' | 'mmd' | 'puml' | 'drawio'>
+
+export type RelationshipExportViewModel = {
+  readonly titleOrId: string
+  readonly $view: ProcessedView
+  readonly $model: LikeC4Model<any>
+  readonly $styles: LikeC4Styles
+}
+
+export const relationshipExportSearchSchema = z.object({
+  relationships: z.string()
+    .nonempty()
+    .optional()
+    .catch(undefined)
+    .transform(v => v as Fqn | undefined),
+  relationshipScope: z.enum(['view', 'global'])
+    .optional()
+    .catch(undefined),
+})
+
+export type RelationshipExportSearch = z.infer<typeof relationshipExportSearchSchema>
+
+export function normalizeRelationshipScope(
+  scope: RelationshipViewExportScope | undefined,
+): RelationshipViewExportScope {
+  return scope ?? 'view'
+}
+
+export function relationshipExportFilename(
+  baseViewId: string,
+  subjectId: string,
+  extension: string,
+): string {
+  return `${baseViewId}-relationships-${subjectId}.${extension}`
+}
+
+export function createRelationshipExportView<M extends AnyAux>(
+  params: RelationshipViewExportParams<M>,
+): LayoutedElementView<aux.toLayouted<M>> {
+  return computeRelationshipViewExport({
+    ...params,
+    scope: normalizeRelationshipScope(params.scope),
+  })
+}
+
+export function createRelationshipExportViewModel<M extends AnyAux>(
+  model: LikeC4Model<M>,
+  view: LayoutedElementView<aux.toLayouted<M>>,
+): RelationshipExportViewModel {
+  return {
+    titleOrId: view.title ?? view.id,
+    $view: view,
+    $model: model,
+    $styles: model.$styles,
+  }
+}
+
+export async function generateRelationshipExportSource<M extends AnyAux>(
+  format: RelationshipSourceExportFormat,
+  params: RelationshipViewExportParams<M>,
+): Promise<string> {
+  const view = createRelationshipExportView(params)
+  if (format === 'dot') {
+    return generateRelationshipDotSource(view)
+  }
+
+  const viewmodel = createRelationshipExportViewModel(params.model, view)
+
+  switch (format) {
+    case 'd2': {
+      const { generateD2 } = await import('@likec4/generators')
+      return generateD2(viewmodel as unknown as LikeC4ViewModel<aux.Unknown>)
+    }
+    case 'mmd': {
+      const { generateMermaid } = await import('@likec4/generators')
+      return generateMermaid(viewmodel as unknown as LikeC4ViewModel<aux.Unknown>)
+    }
+    case 'puml': {
+      const { generatePuml } = await import('@likec4/generators')
+      return generatePuml(viewmodel as unknown as LikeC4ViewModel<aux.Unknown>)
+    }
+    case 'drawio': {
+      const { generateDrawio } = await import('@likec4/generators')
+      return generateDrawio(viewmodel)
+    }
+  }
+}
+
+export async function renderRelationshipDotSvg(dot: string): Promise<string> {
+  const { Graphviz } = await import('@hpcc-js/wasm-graphviz')
+  const graphviz = await Graphviz.load()
+  return graphviz.layout(dot, 'svg')
+}
+
+export async function generateRelationshipDrawioEditUrl<M extends AnyAux>(
+  params: RelationshipViewExportParams<M>,
+): Promise<string> {
+  const view = createRelationshipExportView(params)
+  const viewmodel = createRelationshipExportViewModel(params.model, view)
+  const { generateDrawio, generateDrawioEditUrl } = await import('@likec4/generators')
+  return generateDrawioEditUrl(generateDrawio(viewmodel))
+}
+
+function generateRelationshipDotSource(view: LayoutedElementView<AnyAux>): string {
+  const lines = [
+    `digraph ${dotString(view.id)} {`,
+    `  graph [rankdir=${dotString(view.autoLayout.direction)}];`,
+    '  node [shape=box, style=rounded];',
+  ]
+
+  for (const node of view.nodes) {
+    lines.push(`  ${dotString(node.id)} [label=${dotString(node.title)}];`)
+  }
+  for (const edge of view.edges) {
+    lines.push(`  ${dotString(edge.source)} -> ${dotString(edge.target)} [label=${dotString(edge.label ?? '')}];`)
+  }
+  lines.push('}')
+  return lines.join('\n')
+}
+
+function dotString(value: string): string {
+  return JSON.stringify(value)
+}

--- a/packages/likec4-spa/src/relationship-source-route.spec.ts
+++ b/packages/likec4-spa/src/relationship-source-route.spec.ts
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import { isNotFound } from '@tanstack/react-router'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { loadRelationshipDotSource, loadRelationshipTextSource } from './relationship-source-route'
+
+const testState = vi.hoisted(() => ({
+  projects: [
+    {
+      id: 'default',
+      exportFormats: ['drawio'],
+    },
+  ],
+  loadModel: vi.fn(),
+}))
+
+vi.mock('likec4:projects', () => ({
+  projects: testState.projects,
+}))
+
+vi.mock('likec4:model', () => ({
+  loadModel: testState.loadModel,
+}))
+
+describe('relationship source route helpers', () => {
+  beforeEach(() => {
+    testState.projects[0] = {
+      id: 'default',
+      exportFormats: ['drawio'],
+    }
+    testState.loadModel.mockReset()
+  })
+
+  it('keeps normal full-view source fallback when no relationship subject is requested', async () => {
+    await expect(loadRelationshipTextSource('d2', 'default' as never, 'index', {
+      relationships: undefined,
+    })).resolves.toBeNull()
+    expect(testState.loadModel).not.toHaveBeenCalled()
+  })
+
+  it('rejects disabled relationship text source export instead of falling back to full-view source', async () => {
+    const error = await loadRelationshipTextSource('d2', 'default' as never, 'index', {
+      relationships: 'cloud.backend' as never,
+    }).catch(error => error)
+
+    expect(isNotFound(error)).toBe(true)
+    expect(testState.loadModel).not.toHaveBeenCalled()
+  })
+
+  it('rejects disabled relationship DOT export instead of falling back to full-view source', async () => {
+    const error = await loadRelationshipDotSource('default' as never, 'index', {
+      relationships: 'cloud.backend' as never,
+    }).catch(error => error)
+
+    expect(isNotFound(error)).toBe(true)
+    expect(testState.loadModel).not.toHaveBeenCalled()
+  })
+})

--- a/packages/likec4-spa/src/relationship-source-route.ts
+++ b/packages/likec4-spa/src/relationship-source-route.ts
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import type { ProjectId } from '@likec4/core/types'
+import { loadModel } from 'likec4:model'
+import {
+  type RelationshipExportSearch,
+  type RelationshipSourceExportFormat,
+  generateRelationshipExportSource,
+  normalizeRelationshipScope,
+  renderRelationshipDotSvg,
+} from './relationship-export'
+
+export async function loadRelationshipTextSource(
+  format: Exclude<RelationshipSourceExportFormat, 'dot' | 'drawio'>,
+  projectId: ProjectId,
+  viewId: string,
+  search: RelationshipExportSearch,
+): Promise<string | null> {
+  if (!search.relationships) {
+    return null
+  }
+  const { $likec4model } = await loadModel(projectId)
+  return await generateRelationshipExportSource(format, {
+    model: $likec4model.get(),
+    baseViewId: viewId as never,
+    subjectId: search.relationships as never,
+    scope: normalizeRelationshipScope(search.relationshipScope),
+  })
+}
+
+export async function loadRelationshipDotSource(
+  projectId: ProjectId,
+  viewId: string,
+  search: RelationshipExportSearch,
+): Promise<{ dot: string; dotSvg: string } | null> {
+  if (!search.relationships) {
+    return null
+  }
+  const { $likec4model } = await loadModel(projectId)
+  const dot = await generateRelationshipExportSource('dot', {
+    model: $likec4model.get(),
+    baseViewId: viewId as never,
+    subjectId: search.relationships as never,
+    scope: normalizeRelationshipScope(search.relationshipScope),
+  })
+  return {
+    dot,
+    dotSvg: await renderRelationshipDotSvg(dot),
+  }
+}

--- a/packages/likec4-spa/src/relationship-source-route.ts
+++ b/packages/likec4-spa/src/relationship-source-route.ts
@@ -3,6 +3,7 @@
 // Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import type { ProjectId } from '@likec4/core/types'
+import { notFound } from '@tanstack/react-router'
 import { loadModel } from 'likec4:model'
 import { projects } from 'likec4:projects'
 import { isWebappExportFormatEnabled } from './export-formats'
@@ -28,8 +29,11 @@ export async function loadRelationshipTextSource(
   viewId: string,
   search: RelationshipExportSearch,
 ): Promise<string | null> {
-  if (!search.relationships || !isRelationshipSourceExportEnabled(projectId, format)) {
+  if (!search.relationships) {
     return null
+  }
+  if (!isRelationshipSourceExportEnabled(projectId, format)) {
+    throw notFound()
   }
   const { $likec4model } = await loadModel(projectId)
   return await generateRelationshipExportSource(format, {
@@ -45,8 +49,11 @@ export async function loadRelationshipDotSource(
   viewId: string,
   search: RelationshipExportSearch,
 ): Promise<{ dot: string; dotSvg: string } | null> {
-  if (!search.relationships || !isRelationshipSourceExportEnabled(projectId, 'dot')) {
+  if (!search.relationships) {
     return null
+  }
+  if (!isRelationshipSourceExportEnabled(projectId, 'dot')) {
+    throw notFound()
   }
   const { $likec4model } = await loadModel(projectId)
   const dot = await generateRelationshipExportSource('dot', {

--- a/packages/likec4-spa/src/relationship-source-route.ts
+++ b/packages/likec4-spa/src/relationship-source-route.ts
@@ -4,6 +4,8 @@
 
 import type { ProjectId } from '@likec4/core/types'
 import { loadModel } from 'likec4:model'
+import { projects } from 'likec4:projects'
+import { isWebappExportFormatEnabled } from './export-formats'
 import {
   type RelationshipExportSearch,
   type RelationshipSourceExportFormat,
@@ -12,13 +14,21 @@ import {
   renderRelationshipDotSvg,
 } from './relationship-export'
 
+function isRelationshipSourceExportEnabled(
+  projectId: ProjectId,
+  format: RelationshipSourceExportFormat,
+): boolean {
+  const project = projects.find(project => project.id === projectId)
+  return !!project && isWebappExportFormatEnabled(project, format)
+}
+
 export async function loadRelationshipTextSource(
   format: Exclude<RelationshipSourceExportFormat, 'dot' | 'drawio'>,
   projectId: ProjectId,
   viewId: string,
   search: RelationshipExportSearch,
 ): Promise<string | null> {
-  if (!search.relationships) {
+  if (!search.relationships || !isRelationshipSourceExportEnabled(projectId, format)) {
     return null
   }
   const { $likec4model } = await loadModel(projectId)
@@ -35,7 +45,7 @@ export async function loadRelationshipDotSource(
   viewId: string,
   search: RelationshipExportSearch,
 ): Promise<{ dot: string; dotSvg: string } | null> {
-  if (!search.relationships) {
+  if (!search.relationships || !isRelationshipSourceExportEnabled(projectId, 'dot')) {
     return null
   }
   const { $likec4model } = await loadModel(projectId)

--- a/packages/likec4-spa/src/routes/__root.tsx
+++ b/packages/likec4-spa/src/routes/__root.tsx
@@ -34,6 +34,7 @@ export const Route = createRootRouteWithContext<Context>()({
         theme: undefined,
         dynamic: 'diagram',
         relationships: undefined,
+        relationshipScope: undefined,
         focusOnElement: undefined,
       }),
     ],

--- a/packages/likec4-spa/src/routes/_single/export.$viewId.tsx
+++ b/packages/likec4-spa/src/routes/_single/export.$viewId.tsx
@@ -6,26 +6,14 @@
 // Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
 
 import { createFileRoute, stripSearchParams } from '@tanstack/react-router'
-import { z } from 'zod'
+import { exportPageSearchDefaults, exportPageSearchSchema } from '../../pages/export-page-params'
 import { ExportPage } from '../../pages/ExportPage'
 
 export const Route = createFileRoute('/_single/export/$viewId')({
-  validateSearch: z.object({
-    description: z.boolean().optional().catch(false),
-    download: z.boolean().optional().catch(false),
-    format: z.enum(['png', 'jpeg']).optional().catch('png'),
-    notation: z.boolean().optional().catch(false),
-    quality: z.number().min(0).max(1).optional().catch(undefined),
-  }),
+  validateSearch: exportPageSearchSchema,
   search: {
     middlewares: [
-      stripSearchParams({
-        description: false,
-        download: false,
-        format: 'png',
-        notation: false,
-        quality: undefined,
-      }),
+      stripSearchParams(exportPageSearchDefaults),
     ],
   },
   component: ExportPage,

--- a/packages/likec4-spa/src/routes/_single/view.$viewId.d2.tsx
+++ b/packages/likec4-spa/src/routes/_single/view.$viewId.d2.tsx
@@ -1,14 +1,31 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { createFileRoute, notFound } from '@tanstack/react-router'
 import { loadD2Sources } from 'likec4:d2'
 import { ViewAsD2 } from '../../pages/ViewAsD2'
+import { relationshipExportSearchSchema } from '../../relationship-export'
+import { loadRelationshipTextSource } from '../../relationship-source-route'
 
 export const Route = createFileRoute('/_single/view/$viewId/d2')({
   component: Page,
   staleTime: Infinity,
-  loader: async ({ context, params }) => {
+  validateSearch: relationshipExportSearchSchema,
+  loaderDeps: ({ search }) => search,
+  loader: async ({ context, params, deps }) => {
     const projectId = context.projectId
     const { viewId } = params
     try {
+      const relationshipSource = await loadRelationshipTextSource('d2', projectId, viewId, deps)
+      if (relationshipSource) {
+        return {
+          source: relationshipSource,
+        }
+      }
       const { d2Source } = await loadD2Sources(projectId)
       return {
         source: d2Source(viewId),

--- a/packages/likec4-spa/src/routes/_single/view.$viewId.dot.tsx
+++ b/packages/likec4-spa/src/routes/_single/view.$viewId.dot.tsx
@@ -1,14 +1,29 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { createFileRoute, notFound } from '@tanstack/react-router'
 import { loadDotSources } from 'likec4:dot'
 import { ViewAsDot } from '../../pages/ViewAsDot'
+import { relationshipExportSearchSchema } from '../../relationship-export'
+import { loadRelationshipDotSource } from '../../relationship-source-route'
 
 export const Route = createFileRoute('/_single/view/$viewId/dot')({
   component: Page,
   staleTime: Infinity,
-  loader: async ({ params, context }) => {
+  validateSearch: relationshipExportSearchSchema,
+  loaderDeps: ({ search }) => search,
+  loader: async ({ params, context, deps }) => {
     const projectId = context.projectId
     const { viewId } = params
     try {
+      const relationshipSource = await loadRelationshipDotSource(projectId, viewId, deps)
+      if (relationshipSource) {
+        return relationshipSource
+      }
       const { dotSource, svgSource } = await loadDotSources(projectId)
       const dot = dotSource(viewId)
       const dotSvg = svgSource(viewId)

--- a/packages/likec4-spa/src/routes/_single/view.$viewId.mmd.tsx
+++ b/packages/likec4-spa/src/routes/_single/view.$viewId.mmd.tsx
@@ -1,14 +1,31 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { createFileRoute, notFound } from '@tanstack/react-router'
 import { loadMmdSources } from 'likec4:mmd'
 import { ViewAsMmd } from '../../pages/ViewAsMmd'
+import { relationshipExportSearchSchema } from '../../relationship-export'
+import { loadRelationshipTextSource } from '../../relationship-source-route'
 
 export const Route = createFileRoute('/_single/view/$viewId/mmd')({
   component: Page,
   staleTime: Infinity,
-  loader: async ({ params, context }) => {
+  validateSearch: relationshipExportSearchSchema,
+  loaderDeps: ({ search }) => search,
+  loader: async ({ params, context, deps }) => {
     const projectId = context.projectId
     const { viewId } = params
     try {
+      const relationshipSource = await loadRelationshipTextSource('mmd', projectId, viewId, deps)
+      if (relationshipSource) {
+        return {
+          source: relationshipSource,
+        }
+      }
       const { mmdSource } = await loadMmdSources(projectId)
       return {
         source: mmdSource(viewId),

--- a/packages/likec4-spa/src/routes/_single/view.$viewId.puml.tsx
+++ b/packages/likec4-spa/src/routes/_single/view.$viewId.puml.tsx
@@ -1,14 +1,31 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { createFileRoute, notFound } from '@tanstack/react-router'
 import { loadPumlSources } from 'likec4:puml'
 import { ViewAsPuml } from '../../pages/ViewAsPuml'
+import { relationshipExportSearchSchema } from '../../relationship-export'
+import { loadRelationshipTextSource } from '../../relationship-source-route'
 
 export const Route = createFileRoute('/_single/view/$viewId/puml')({
   component: Page,
   staleTime: Infinity,
-  loader: async ({ params, context }) => {
+  validateSearch: relationshipExportSearchSchema,
+  loaderDeps: ({ search }) => search,
+  loader: async ({ params, context, deps }) => {
     const projectId = context.projectId
     const { viewId } = params
     try {
+      const relationshipSource = await loadRelationshipTextSource('puml', projectId, viewId, deps)
+      if (relationshipSource) {
+        return {
+          source: relationshipSource,
+        }
+      }
       const { pumlSource } = await loadPumlSources(projectId)
       return {
         source: pumlSource(viewId),

--- a/packages/likec4-spa/src/routes/project.$projectId/export.$viewId.tsx
+++ b/packages/likec4-spa/src/routes/project.$projectId/export.$viewId.tsx
@@ -6,26 +6,14 @@
 // Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
 
 import { createFileRoute, stripSearchParams } from '@tanstack/react-router'
-import { z } from 'zod'
+import { exportPageSearchDefaults, exportPageSearchSchema } from '../../pages/export-page-params'
 import { ExportPage } from '../../pages/ExportPage'
 
 export const Route = createFileRoute('/project/$projectId/export/$viewId')({
-  validateSearch: z.object({
-    description: z.boolean().optional().catch(false),
-    download: z.boolean().optional().catch(false),
-    format: z.enum(['png', 'jpeg']).optional().catch('png'),
-    notation: z.boolean().optional().catch(false),
-    quality: z.number().min(0).max(1).optional().catch(undefined),
-  }),
+  validateSearch: exportPageSearchSchema,
   search: {
     middlewares: [
-      stripSearchParams({
-        description: false,
-        download: false,
-        format: 'png',
-        notation: false,
-        quality: undefined,
-      }),
+      stripSearchParams(exportPageSearchDefaults),
     ],
   },
   component: ExportPage,

--- a/packages/likec4-spa/src/routes/project.$projectId/view.$viewId.d2.tsx
+++ b/packages/likec4-spa/src/routes/project.$projectId/view.$viewId.d2.tsx
@@ -1,12 +1,29 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { createFileRoute, notFound } from '@tanstack/react-router'
 import { loadD2Sources } from 'likec4:d2'
 import { ViewAsD2 } from '../../pages/ViewAsD2'
+import { relationshipExportSearchSchema } from '../../relationship-export'
+import { loadRelationshipTextSource } from '../../relationship-source-route'
 
 export const Route = createFileRoute('/project/$projectId/view/$viewId/d2')({
-  loader: async ({ context, params }) => {
+  validateSearch: relationshipExportSearchSchema,
+  loaderDeps: ({ search }) => search,
+  loader: async ({ context, params, deps }) => {
     const projectId = context.projectId
     const { viewId } = params
     try {
+      const relationshipSource = await loadRelationshipTextSource('d2', projectId, viewId, deps)
+      if (relationshipSource) {
+        return {
+          source: relationshipSource,
+        }
+      }
       const { d2Source } = await loadD2Sources(projectId)
       return {
         source: d2Source(viewId),

--- a/packages/likec4-spa/src/routes/project.$projectId/view.$viewId.dot.tsx
+++ b/packages/likec4-spa/src/routes/project.$projectId/view.$viewId.dot.tsx
@@ -1,13 +1,28 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { createFileRoute, notFound } from '@tanstack/react-router'
 import { loadDotSources } from 'likec4:dot'
 import { ViewAsDot } from '../../pages/ViewAsDot'
+import { relationshipExportSearchSchema } from '../../relationship-export'
+import { loadRelationshipDotSource } from '../../relationship-source-route'
 
 export const Route = createFileRoute('/project/$projectId/view/$viewId/dot')({
   component: Page,
-  loader: async ({ params, context }) => {
+  validateSearch: relationshipExportSearchSchema,
+  loaderDeps: ({ search }) => search,
+  loader: async ({ params, context, deps }) => {
     const projectId = context.projectId
     const { viewId } = params
     try {
+      const relationshipSource = await loadRelationshipDotSource(projectId, viewId, deps)
+      if (relationshipSource) {
+        return relationshipSource
+      }
       const { dotSource, svgSource } = await loadDotSources(projectId)
       const dot = dotSource(viewId)
       const dotSvg = svgSource(viewId)

--- a/packages/likec4-spa/src/routes/project.$projectId/view.$viewId.mmd.tsx
+++ b/packages/likec4-spa/src/routes/project.$projectId/view.$viewId.mmd.tsx
@@ -1,14 +1,31 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { createFileRoute, notFound } from '@tanstack/react-router'
 import { loadMmdSources } from 'likec4:mmd'
 import { ViewAsMmd } from '../../pages/ViewAsMmd'
+import { relationshipExportSearchSchema } from '../../relationship-export'
+import { loadRelationshipTextSource } from '../../relationship-source-route'
 
 export const Route = createFileRoute('/project/$projectId/view/$viewId/mmd')({
   component: Page,
   staleTime: Infinity,
-  loader: async ({ params, context }) => {
+  validateSearch: relationshipExportSearchSchema,
+  loaderDeps: ({ search }) => search,
+  loader: async ({ params, context, deps }) => {
     const projectId = context.projectId
     const { viewId } = params
     try {
+      const relationshipSource = await loadRelationshipTextSource('mmd', projectId, viewId, deps)
+      if (relationshipSource) {
+        return {
+          source: relationshipSource,
+        }
+      }
       const { mmdSource } = await loadMmdSources(projectId)
       return {
         source: mmdSource(viewId),

--- a/packages/likec4-spa/src/routes/project.$projectId/view.$viewId.puml.tsx
+++ b/packages/likec4-spa/src/routes/project.$projectId/view.$viewId.puml.tsx
@@ -1,14 +1,31 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { createFileRoute, notFound } from '@tanstack/react-router'
 import { loadPumlSources } from 'likec4:puml'
 import { ViewAsPuml } from '../../pages/ViewAsPuml'
+import { relationshipExportSearchSchema } from '../../relationship-export'
+import { loadRelationshipTextSource } from '../../relationship-source-route'
 
 export const Route = createFileRoute('/project/$projectId/view/$viewId/puml')({
   component: Page,
   staleTime: Infinity,
-  loader: async ({ params, context }) => {
+  validateSearch: relationshipExportSearchSchema,
+  loaderDeps: ({ search }) => search,
+  loader: async ({ params, context, deps }) => {
     const projectId = context.projectId
     const { viewId } = params
     try {
+      const relationshipSource = await loadRelationshipTextSource('puml', projectId, viewId, deps)
+      if (relationshipSource) {
+        return {
+          source: relationshipSource,
+        }
+      }
       const { pumlSource } = await loadPumlSources(projectId)
       return {
         source: pumlSource(viewId),

--- a/packages/likec4-spa/src/searchParams.spec.ts
+++ b/packages/likec4-spa/src/searchParams.spec.ts
@@ -1,5 +1,12 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { describe, expect, it } from 'vitest'
-import { resolveForceColorScheme } from './searchParams'
+import { resolveForceColorScheme, searchParamsSchema } from './searchParams'
 
 describe('resolveForceColorScheme', () => {
   it('should force light/dark and pass through auto/undefined', () => {
@@ -7,6 +14,17 @@ describe('resolveForceColorScheme', () => {
     expect(resolveForceColorScheme('dark')).toBe('dark')
     expect(resolveForceColorScheme('auto')).toBeUndefined()
     expect(resolveForceColorScheme(undefined)).toBeUndefined()
+  })
+})
+
+describe('relationshipScope search parameter', () => {
+  it('accepts view and global scopes', () => {
+    expect(searchParamsSchema.parse({ relationshipScope: 'view' }).relationshipScope).toBe('view')
+    expect(searchParamsSchema.parse({ relationshipScope: 'global' }).relationshipScope).toBe('global')
+  })
+
+  it('drops invalid scopes', () => {
+    expect(searchParamsSchema.parse({ relationshipScope: 'local' }).relationshipScope).toBeUndefined()
   })
 })
 

--- a/packages/likec4-spa/src/searchParams.ts
+++ b/packages/likec4-spa/src/searchParams.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import type { Fqn } from '@likec4/core/types'
 import { z } from 'zod'
 
@@ -17,6 +24,9 @@ export const searchParamsSchema = z.object({
     .optional()
     .catch(undefined)
     .transform(v => v as Fqn | undefined),
+  relationshipScope: z.enum(['view', 'global'])
+    .optional()
+    .catch(undefined),
   focusOnElement: z.string()
     .nonempty()
     .optional()

--- a/packages/likec4/package.json
+++ b/packages/likec4/package.json
@@ -123,6 +123,7 @@
   "dependencies": {
     "@hpcc-js/wasm-graphviz": "catalog:externals",
     "@likec4/core": "workspace:*",
+    "@likec4/generators": "workspace:*",
     "@likec4/icons": "workspace:*",
     "@vitejs/plugin-react": "catalog:vite",
     "bundle-require": "catalog:externals",
@@ -185,7 +186,6 @@
     "@likec4/vite-plugin": "workspace:*",
     "@likec4/react": "workspace:*",
     "@likec4/spa": "workspace:*",
-    "@likec4/generators": "workspace:*",
     "@likec4/style-preset": "workspace:*",
     "@likec4/styles": "workspace:*",
     "@likec4/tsconfig": "workspace:*",

--- a/packages/vite-plugin/src/modules.d.ts
+++ b/packages/vite-plugin/src/modules.d.ts
@@ -1,4 +1,12 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 declare module 'likec4:projects' {
+  import type { WebappExportFormat } from '@likec4/config'
   import type { ProjectId } from 'likec4/model'
   type LandingPageConfig =
     | { redirect: true }
@@ -8,6 +16,7 @@ declare module 'likec4:projects' {
     id: ProjectId
     title?: string
     landingPage?: LandingPageConfig
+    exportFormats: readonly WebappExportFormat[]
   }
   export const isSingleProject: boolean
   export const projects: readonly [Project, ...Project[]]

--- a/packages/vite-plugin/src/plugin.ts
+++ b/packages/vite-plugin/src/plugin.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import type { ProjectId } from '@likec4/core/types'
 import type { LikeC4LanguageServices } from '@likec4/language-services'
 import { fromWorkspace } from '@likec4/language-services/node'
@@ -19,6 +26,7 @@ import { type AppConfig, createAppConfigModule } from './virtuals/app-config'
 import { d2Module, projectD2Module } from './virtuals/d2'
 import { dotModule, projectDotSourcesModule } from './virtuals/dot'
 import { drawioModule, projectDrawioModule } from './virtuals/drawio'
+import { effectiveWebappExportFormats } from './virtuals/export-formats'
 import { iconsModule, projectIconsModule } from './virtuals/icons'
 import { mmdModule, projectMmdSourcesModule } from './virtuals/mmd'
 import { modelModule, projectModelModule } from './virtuals/model'
@@ -245,6 +253,7 @@ export function LikeC4VitePlugin({
       title: p.title,
       folder: p.folder.toString(),
       landingPage: p.config.landingPage,
+      exportFormats: effectiveWebappExportFormats(p.config),
     })) satisfies (data: ProjectsData) => any
     let _last: any
     return <T extends ProjectsData>(update: T): boolean => {

--- a/packages/vite-plugin/src/virtuals/_shared.ts
+++ b/packages/vite-plugin/src/virtuals/_shared.ts
@@ -1,4 +1,11 @@
-import type { LikeC4ProjectConfig } from '@likec4/config'
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
+import type { LikeC4ProjectConfig, WebappExportFormat } from '@likec4/config'
 import type { LikeC4Project, NonEmptyArray, ProjectId } from '@likec4/core'
 import type { LikeC4LanguageServices } from '@likec4/language-services'
 import type { URI } from 'langium'
@@ -7,6 +14,7 @@ import { joinURL } from 'ufo'
 import type { Rolldown } from 'vite'
 import { type ViteLogger, logGenerating } from '../logger'
 import type { AIOptions } from '../plugin'
+import { isWebappExportFormatEnabled } from './export-formats'
 import { hardenJsonStringLiteralForEmbeddedScript } from './hardenJsonStringLiteralForEmbeddedScript'
 
 export { k }
@@ -51,6 +59,7 @@ export interface VirtualModule {
  * Project scoped virtual module
  */
 export interface ProjectVirtualModule {
+  exportFormat?: WebappExportFormat
   matches: (id: string) => ProjectId | null
   virtualId: (projectId: ProjectId) => string
   load(
@@ -81,14 +90,22 @@ export function generateMatches(moduleId: string, extension = '.js') {
   }
 }
 
-export function generateCombinedProjects(moduleId: string, fnName: string): VirtualModule {
+export function generateCombinedProjects(
+  moduleId: string,
+  fnName: string,
+  exportFormat?: WebappExportFormat,
+): VirtualModule {
   return {
     id: `likec4:${moduleId}`,
     virtualId: 'likec4:plugin/' + moduleId + '.js',
     async load({ projects }) {
       logGenerating(moduleId)
 
-      const cases = projects.map(({ id }) => {
+      const enabledProjects = exportFormat
+        ? projects.filter(({ config }) => isWebappExportFormatEnabled(config, exportFormat))
+        : projects
+
+      const cases = enabledProjects.map(({ id }) => {
         const idLiteral = hardenJsonStringLiteralForEmbeddedScript(JSON.stringify(id))
         const pkgLiteral = hardenJsonStringLiteralForEmbeddedScript(
           JSON.stringify(joinURL(`likec4:${moduleId}`, id)),
@@ -106,12 +123,18 @@ export async function ${fnName}(projectId) {
   if (!fn) {
     const projects = Object.keys(${fnName}Fn)
     console.error('Unknown projectId: ' + projectId + ' (available: ' + projects + ')')
+    ${
+        exportFormat
+          ? `throw new Error('Project does not enable ${exportFormat} export: ' + projectId)`
+          : `
     if (projects.length === 0) {
       throw new Error('No projects found, invalid state')
     }
     projectId = projects[0]
     console.warn('Falling back to project: ' + projectId)
     fn = ${fnName}Fn[projectId]
+    `
+      }
   }
   return await fn()
 }

--- a/packages/vite-plugin/src/virtuals/d2.ts
+++ b/packages/vite-plugin/src/virtuals/d2.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import type { LikeC4Model } from '@likec4/core/model'
 import { generateD2 } from '@likec4/generators'
 import { CompositeGeneratorNode, expandToNode, joinToNode, NL, toString } from 'langium/generate'
@@ -47,6 +54,7 @@ function code(model: LikeC4Model.Computed) {
 }
 
 export const projectD2Module: ProjectVirtualModule = {
+  exportFormat: 'd2',
   ...generateMatches('d2'),
   async load({ likec4, project }) {
     logGenerating('d2', project.id)
@@ -58,4 +66,4 @@ export const projectD2Module: ProjectVirtualModule = {
   },
 }
 
-export const d2Module = generateCombinedProjects('d2', 'loadD2Sources')
+export const d2Module = generateCombinedProjects('d2', 'loadD2Sources', 'd2')

--- a/packages/vite-plugin/src/virtuals/dot.ts
+++ b/packages/vite-plugin/src/virtuals/dot.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { CompositeGeneratorNode, expandToNode, joinToNode, NL, toString } from 'langium/generate'
 import { mapToObj } from 'remeda'
 import { logGenerating } from '../logger'
@@ -84,6 +91,7 @@ function code(
 }
 
 export const projectDotSourcesModule: ProjectVirtualModule = {
+  exportFormat: 'dot',
   ...generateMatches('dot'),
   async load({ likec4, project }) {
     logGenerating('dot', project.id)
@@ -96,4 +104,4 @@ export const projectDotSourcesModule: ProjectVirtualModule = {
   },
 }
 
-export const dotModule = generateCombinedProjects('dot', 'loadDotSources')
+export const dotModule = generateCombinedProjects('dot', 'loadDotSources', 'dot')

--- a/packages/vite-plugin/src/virtuals/drawio.ts
+++ b/packages/vite-plugin/src/virtuals/drawio.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import type { LikeC4Model } from '@likec4/core/model'
 import { generateDrawio, generateDrawioEditUrl } from '@likec4/generators'
 import { CompositeGeneratorNode, expandToNode, joinToNode, NL, toString } from 'langium/generate'
@@ -47,6 +54,7 @@ function code(model: LikeC4Model.Layouted) {
 }
 
 export const projectDrawioModule: ProjectVirtualModule = {
+  exportFormat: 'drawio',
   ...generateMatches('drawio'),
   async load({ likec4, project }) {
     logGenerating('drawio', project.id)
@@ -58,4 +66,4 @@ export const projectDrawioModule: ProjectVirtualModule = {
   },
 }
 
-export const drawioModule = generateCombinedProjects('drawio', 'loadDrawioSources')
+export const drawioModule = generateCombinedProjects('drawio', 'loadDrawioSources', 'drawio')

--- a/packages/vite-plugin/src/virtuals/export-formats.spec.ts
+++ b/packages/vite-plugin/src/virtuals/export-formats.spec.ts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import type { LikeC4ProjectConfig } from '@likec4/config'
+import { describe, it } from 'vitest'
+import {
+  effectiveWebappExportFormats,
+  isWebappExportFormatEnabled,
+} from './export-formats'
+
+describe('webapp export format capabilities', () => {
+  it('enables every export format when webapp config is omitted', ({ expect }) => {
+    expect(effectiveWebappExportFormats({})).toEqual(['png', 'jpg', 'dot', 'd2', 'mmd', 'puml', 'drawio'])
+  })
+
+  it('keeps disabled exports disabled', ({ expect }) => {
+    expect(effectiveWebappExportFormats({ webapp: { exportFormats: [] } })).toEqual([])
+  })
+
+  it('normalizes configured formats to the fixed LikeC4 menu order', ({ expect }) => {
+    expect(effectiveWebappExportFormats({ webapp: { exportFormats: ['drawio', 'jpg', 'dot'] } })).toEqual([
+      'jpg',
+      'dot',
+      'drawio',
+    ])
+  })
+
+  it('checks whether a project has an export format enabled', ({ expect }) => {
+    const config: Pick<LikeC4ProjectConfig, 'webapp'> = { webapp: { exportFormats: ['png', 'drawio'] } }
+
+    expect(isWebappExportFormatEnabled(config, 'png')).toBe(true)
+    expect(isWebappExportFormatEnabled(config, 'dot')).toBe(false)
+  })
+})

--- a/packages/vite-plugin/src/virtuals/export-formats.ts
+++ b/packages/vite-plugin/src/virtuals/export-formats.ts
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import type { LikeC4ProjectConfig, WebappExportFormat } from '@likec4/config'
+import { WebappExportFormats } from '@likec4/config'
+
+type WebappExportConfig = Pick<LikeC4ProjectConfig, 'webapp'>
+
+export function effectiveWebappExportFormats(config: WebappExportConfig): WebappExportFormat[] {
+  const configured = config.webapp?.exportFormats
+  if (!configured) {
+    return [...WebappExportFormats]
+  }
+  const enabledFormats = new Set(configured)
+  return WebappExportFormats.filter(format => enabledFormats.has(format))
+}
+
+export function isWebappExportFormatEnabled(config: WebappExportConfig, format: WebappExportFormat): boolean {
+  return effectiveWebappExportFormats(config).includes(format)
+}

--- a/packages/vite-plugin/src/virtuals/mmd.ts
+++ b/packages/vite-plugin/src/virtuals/mmd.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import type { LikeC4Model } from '@likec4/core/model'
 import { generateMermaid } from '@likec4/generators'
 import { CompositeGeneratorNode, expandToNode, joinToNode, NL, toString } from 'langium/generate'
@@ -49,6 +56,7 @@ function code(model: LikeC4Model.Computed) {
 }
 
 export const projectMmdSourcesModule: ProjectVirtualModule = {
+  exportFormat: 'mmd',
   ...generateMatches('mmd'),
   async load({ likec4, project }) {
     logGenerating('mmd', project.id)
@@ -60,4 +68,4 @@ export const projectMmdSourcesModule: ProjectVirtualModule = {
   },
 }
 
-export const mmdModule = generateCombinedProjects('mmd', 'loadMmdSources')
+export const mmdModule = generateCombinedProjects('mmd', 'loadMmdSources', 'mmd')

--- a/packages/vite-plugin/src/virtuals/projects.spec.ts
+++ b/packages/vite-plugin/src/virtuals/projects.spec.ts
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import { describe, it } from 'vitest'
+import { generateCombinedProjects } from './_shared'
+import { projectsModule } from './projects'
+
+describe('projects virtual module export capabilities', () => {
+  it('publishes effective export formats for every project', async ({ expect }) => {
+    const result = await projectsModule.load.call({} as any, {
+      projects: [
+        {
+          id: 'all',
+          title: undefined,
+          config: {},
+        },
+        {
+          id: 'configured',
+          title: 'Configured',
+          config: {
+            webapp: {
+              exportFormats: ['drawio', 'jpg', 'dot'],
+            },
+          },
+        },
+      ],
+    } as any)
+
+    expect(result).toMatchObject({
+      moduleType: 'js',
+    })
+    const code = typeof result === 'string' ? result : result.code
+    expect(code).toContain('exportFormats: [\n      \'png\',')
+    expect(code).toContain('id: \'configured\'')
+    expect(code).toContain('exportFormats: [\n      \'jpg\',\n      \'dot\',\n      \'drawio\'')
+  })
+
+  it('generates combined export modules only for projects that enable the format', async ({ expect }) => {
+    const mod = generateCombinedProjects('dot', 'loadDotSources', 'dot')
+    const result = await mod.load.call({} as any, {
+      projects: [
+        {
+          id: 'exports-dot',
+          config: {
+            webapp: {
+              exportFormats: ['dot'],
+            },
+          },
+        },
+        {
+          id: 'without-dot',
+          config: {
+            webapp: {
+              exportFormats: ['png'],
+            },
+          },
+        },
+      ],
+    } as any)
+
+    const code = typeof result === 'string' ? result : result.code
+    expect(code).toContain('exports-dot')
+    expect(code).not.toContain('without-dot')
+    expect(code).toContain('throw new Error(\'Project does not enable dot export: \' + projectId)')
+    expect(code).not.toContain('Falling back to project')
+  })
+})

--- a/packages/vite-plugin/src/virtuals/projects.ts
+++ b/packages/vite-plugin/src/virtuals/projects.ts
@@ -1,14 +1,23 @@
-import type { LikeC4ProjectConfig } from '@likec4/config'
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
+import type { LikeC4ProjectConfig, WebappExportFormat } from '@likec4/config'
 import type { NonEmptyArray } from '@likec4/core'
 import JSON5 from 'json5'
 import { map } from 'remeda'
 import { logGenerating } from '../logger'
 import type { VirtualModule } from './_shared'
+import { effectiveWebappExportFormats } from './export-formats'
 
 type ProjectData = {
   id: string
   title: string | undefined
   landingPage: LikeC4ProjectConfig['landingPage']
+  exportFormats: WebappExportFormat[]
 }
 
 const code = (projects: NonEmptyArray<ProjectData>) => `
@@ -53,6 +62,7 @@ export const projectsModule = {
         id: p.id,
         title: p.title,
         landingPage: p.config.landingPage,
+        exportFormats: effectiveWebappExportFormats(p.config),
       }))),
       moduleType: 'js',
     }

--- a/packages/vite-plugin/src/virtuals/puml.ts
+++ b/packages/vite-plugin/src/virtuals/puml.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import type { LikeC4Model } from '@likec4/core/model'
 import { generatePuml } from '@likec4/generators'
 import { CompositeGeneratorNode, expandToNode, joinToNode, NL, toString } from 'langium/generate'
@@ -48,6 +55,7 @@ function code(model: LikeC4Model.Computed) {
 }
 
 export const projectPumlModule: ProjectVirtualModule = {
+  exportFormat: 'puml',
   ...generateMatches('puml'),
   async load({ likec4, project }) {
     logGenerating('puml', project.id)
@@ -59,4 +67,4 @@ export const projectPumlModule: ProjectVirtualModule = {
   },
 }
 
-export const pumlModule = generateCombinedProjects('puml', 'loadPumlSources')
+export const pumlModule = generateCombinedProjects('puml', 'loadPumlSources', 'puml')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1786,6 +1786,9 @@ importers:
       '@likec4/core':
         specifier: workspace:*
         version: link:../core
+      '@likec4/generators':
+        specifier: workspace:*
+        version: link:../generators
       '@likec4/icons':
         specifier: workspace:*
         version: link:../icons
@@ -1862,9 +1865,6 @@ importers:
       '@likec4/diagram':
         specifier: workspace:*
         version: link:../diagram
-      '@likec4/generators':
-        specifier: workspace:*
-        version: link:../generators
       '@likec4/language-server':
         specifier: workspace:*
         version: link:../language-server
@@ -2072,9 +2072,15 @@ importers:
 
   packages/likec4-spa:
     dependencies:
+      '@hpcc-js/wasm-graphviz':
+        specifier: catalog:externals
+        version: 1.22.2
       '@likec4/core':
         specifier: workspace:*
         version: link:../core
+      '@likec4/generators':
+        specifier: workspace:*
+        version: link:../generators
       immer:
         specifier: catalog:utils
         version: 11.1.8


### PR DESCRIPTION
## Summary
- Adds relationship-browser export actions for image, source, and Draw.io formats.
- Supports relationship export routes with the same `webapp.exportFormats` restrictions.
- Fixes relationship image exports so generated edge paths render without the React Flow spline error.

Stacked on #3078.

## Screenshots
Public LikeC4 e2e examples only.

Before: relationship browser had no export action.
![Before relationship browser](https://raw.githubusercontent.com/likec4/likec4/cgk/pr-assets-export-screenshots-20260629/.github/pr-screenshots/export-formats-20260629/likec4-pr2-before-relationship-browser.png)

After: relationship browser export menu.
![Relationship export menu](https://raw.githubusercontent.com/likec4/likec4/cgk/pr-assets-export-screenshots-20260629/.github/pr-screenshots/export-formats-20260629/likec4-pr2-after-relationship-export-menu.png)

After: relationship image export route renders without the previous error overlay.
![Relationship image export](https://raw.githubusercontent.com/likec4/likec4/cgk/pr-assets-export-screenshots-20260629/.github/pr-screenshots/export-formats-20260629/likec4-pr2-after-relationship-image-export.png)

## Validation
- `pnpm pretest:e2e`
- e2e search-params Playwright suite, 17 tests against locally built preview
- `pnpm --filter @likec4/core test -- src/compute-view/relationships-view/layout.spec.ts`
- `pnpm --filter @likec4/spa test -- src/export-formats.spec.ts`
- `python3 /home/ckeller/src/agent-skills/skills/likec4-license-headers/scripts/apply_likec4_headers.py --check --base origin/main`
