### PR TITLE
fix: preserve relationship export view styles

### DIFF
--- a/.changeset/fix-relationship-export-styles.md
+++ b/.changeset/fix-relationship-export-styles.md
@@ -1,0 +1,5 @@
+---
+'@likec4/core': patch
+---
+
+Fix relationship exports to preserve scoped view styling.

--- a/.changeset/fix-relationship-export-styles.md
+++ b/.changeset/fix-relationship-export-styles.md
@@ -1,5 +1,6 @@
 ---
 '@likec4/core': patch
+'@likec4/diagram': patch
 ---
 
 Fix relationship exports to preserve scoped view styling.

--- a/e2e/tests/search-params.spec.ts
+++ b/e2e/tests/search-params.spec.ts
@@ -5,7 +5,7 @@
 //
 // Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
 
-import type { Page } from '@playwright/test'
+import type { Locator, Page } from '@playwright/test'
 import { expect, test } from '@playwright/test'
 import { canvas } from '../helpers/selectors'
 import { TIMEOUT_CANVAS, TIMEOUT_MENU } from '../helpers/timeouts'
@@ -63,6 +63,25 @@ const COLOR_SCHEME_ATTR = 'data-mantine-color-scheme'
 async function gotoAndWaitForCanvas(page: Page, url: string): Promise<void> {
   await page.goto(url)
   await expect(canvas(page)).toBeVisible({ timeout: TIMEOUT_CANVAS })
+}
+
+async function visibleNodeContainer(page: Page, rootSelector: string, nodeText: string): Promise<Locator> {
+  const node = page.locator(`${rootSelector} .react-flow__node`, { hasText: nodeText }).first()
+  await expect(node).toBeVisible({ timeout: TIMEOUT_CANVAS })
+
+  const container = node.locator('[data-likec4-color]').first()
+  await expect(container).toBeVisible({ timeout: TIMEOUT_CANVAS })
+  return container
+}
+
+async function visibleNodeVisualAttributes(container: Locator): Promise<Record<string, string | null>> {
+  return {
+    color: await container.getAttribute('data-likec4-color'),
+    shape: await container.getAttribute('data-likec4-shape'),
+    size: await container.getAttribute('data-likec4-shape-size'),
+    spacing: await container.getAttribute('data-likec4-spacing'),
+    textSize: await container.getAttribute('data-likec4-text-size'),
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -169,6 +188,41 @@ test.describe('?relationships= search parameter', () => {
     await expect(page.getByText('all points should be consumed')).toHaveCount(0)
     await expect(page.locator('.react-flow__node').first()).toBeVisible({ timeout: TIMEOUT_CANVAS })
     await expect(page.locator('.react-flow__edge').first()).toBeVisible({ timeout: TIMEOUT_CANVAS })
+  })
+
+  test('?relationships=<fqn> image export keeps relationship browser node styling', async ({ page }) => {
+    await gotoAndWaitForCanvas(page, viewUrl(STATIC_VIEW, { relationships: 'cloud', relationshipScope: 'view' }))
+    const browserCustomer = await visibleNodeContainer(page, RELATIONSHIPS_BROWSER, 'Cloud System Customer')
+    const browserVisuals = await visibleNodeVisualAttributes(browserCustomer)
+
+    await gotoAndWaitForCanvas(page, exportUrl(STATIC_VIEW, { relationships: 'cloud', relationshipScope: 'view' }))
+    const exportCustomer = await visibleNodeContainer(page, '[data-testid="export-page"]', 'Cloud System Customer')
+    expect(await exportCustomer.getAttribute('data-likec4-color')).toBe(browserVisuals.color)
+    expect(await exportCustomer.getAttribute('data-likec4-shape')).toBe(browserVisuals.shape)
+    expect(await exportCustomer.getAttribute('data-likec4-shape-size')).toBe(browserVisuals.size)
+    expect(await exportCustomer.getAttribute('data-likec4-spacing')).toBe(browserVisuals.spacing)
+    expect(await exportCustomer.getAttribute('data-likec4-text-size')).toBe(browserVisuals.textSize)
+  })
+
+  test('?relationships=<fqn> image export keeps relationship browser graph detail', async ({ page }) => {
+    const detailedNodes = [
+      'Customer Dashboard',
+      'Legacy Backend Services',
+      'PostgreSQL',
+      'Raw Data',
+    ] as const
+
+    await gotoAndWaitForCanvas(page, viewUrl(STATIC_VIEW, { relationships: 'cloud', relationshipScope: 'view' }))
+    for (const nodeTitle of detailedNodes) {
+      await expect(page.locator(`${RELATIONSHIPS_BROWSER} .react-flow__node`, { hasText: nodeTitle }))
+        .toHaveCount(1)
+    }
+
+    await gotoAndWaitForCanvas(page, exportUrl(STATIC_VIEW, { relationships: 'cloud', relationshipScope: 'view' }))
+    for (const nodeTitle of detailedNodes) {
+      await expect(page.locator('[data-testid="export-page"] .react-flow__node', { hasText: nodeTitle }))
+        .toHaveCount(1)
+    }
   })
 
   test('absent ?relationships= does not open overlay', async ({ page }) => {

--- a/e2e/tests/search-params.spec.ts
+++ b/e2e/tests/search-params.spec.ts
@@ -81,6 +81,12 @@ async function visibleNodeVisualAttributes(container: Locator): Promise<Record<s
     size: await container.getAttribute('data-likec4-shape-size'),
     spacing: await container.getAttribute('data-likec4-spacing'),
     textSize: await container.getAttribute('data-likec4-text-size'),
+    paletteFill: await container.evaluate(element =>
+      getComputedStyle(element).getPropertyValue('--likec4-palette-fill').trim()
+    ),
+    paletteStroke: await container.evaluate(element =>
+      getComputedStyle(element).getPropertyValue('--likec4-palette-stroke').trim()
+    ),
   }
 }
 
@@ -202,6 +208,16 @@ test.describe('?relationships= search parameter', () => {
     expect(await exportCustomer.getAttribute('data-likec4-shape-size')).toBe(browserVisuals.size)
     expect(await exportCustomer.getAttribute('data-likec4-spacing')).toBe(browserVisuals.spacing)
     expect(await exportCustomer.getAttribute('data-likec4-text-size')).toBe(browserVisuals.textSize)
+    expect(
+      await exportCustomer.evaluate(element =>
+        getComputedStyle(element).getPropertyValue('--likec4-palette-fill').trim()
+      ),
+    ).toBe(browserVisuals.paletteFill)
+    expect(
+      await exportCustomer.evaluate(element =>
+        getComputedStyle(element).getPropertyValue('--likec4-palette-stroke').trim()
+      ),
+    ).toBe(browserVisuals.paletteStroke)
   })
 
   test('?relationships=<fqn> image export keeps relationship browser graph detail', async ({ page }) => {
@@ -223,6 +239,17 @@ test.describe('?relationships= search parameter', () => {
       await expect(page.locator('[data-testid="export-page"] .react-flow__node', { hasText: nodeTitle }))
         .toHaveCount(1)
     }
+  })
+
+  test('?relationships=<fqn> image export renders relationship browser edge labels', async ({ page }) => {
+    await gotoAndWaitForCanvas(page, viewUrl(STATIC_VIEW, { relationships: 'cloud', relationshipScope: 'view' }))
+    const browserLabels = page.locator(`${RELATIONSHIPS_BROWSER} .likec4-edge-label`)
+    await expect.poll(() => browserLabels.count()).toBeGreaterThan(0)
+    const browserLabelCount = await browserLabels.count()
+
+    await gotoAndWaitForCanvas(page, exportUrl(STATIC_VIEW, { relationships: 'cloud', relationshipScope: 'view' }))
+    await expect(page.locator(`[data-testid="export-page"] ${RELATIONSHIPS_BROWSER}`)).toHaveCount(1)
+    await expect(page.locator('[data-testid="export-page"] .likec4-edge-label')).toHaveCount(browserLabelCount)
   })
 
   test('absent ?relationships= does not open overlay', async ({ page }) => {

--- a/packages/core/src/compute-view/index.ts
+++ b/packages/core/src/compute-view/index.ts
@@ -18,6 +18,7 @@ export {
   computeRelationshipViewExport,
   layoutRelationshipsView,
   relationshipViewExportId,
+  resolveRelationshipNodeStyle,
   treeFromElements,
 } from './relationships-view'
 export type {

--- a/packages/core/src/compute-view/relationships-view/export-view.spec.ts
+++ b/packages/core/src/compute-view/relationships-view/export-view.spec.ts
@@ -54,4 +54,262 @@ describe('computeRelationshipViewExport', () => {
     expect(view.nodes.map(n => n.id)).toContain('subject-cloud.backend')
     expect(view.edges).toHaveLength(1)
   })
+
+  it('inherits scoped view styling for relationship export nodes', ({ expect }) => {
+    const styledSpecs = Builder
+      .specification({
+        elements: {
+          el: {
+            style: {
+              opacity: 20,
+            },
+          },
+        },
+      })
+
+    const model = styledSpecs
+      .model(({ el, rel }, _) =>
+        _(
+          el('cloud').with(
+            el('backend', {
+              icon: 'tech:nestjs',
+            }),
+          ),
+          el('amazon'),
+          rel('cloud.backend', 'amazon', 'uses'),
+        )
+      )
+      .views(({ view, $include, $style }, _) =>
+        _(
+          view('index', 'Context').with(
+            $include('cloud.*'),
+            $include('amazon'),
+            $style('cloud.backend', {
+              color: 'green',
+              icon: 'none',
+              shape: 'component',
+              opacity: 80,
+            }),
+            $style('amazon', {
+              color: 'amber',
+              shape: 'queue',
+            }),
+          ),
+        )
+      )
+      .toLikeC4Model()
+
+    expect(model.element('cloud.backend').icon).toBe('tech:nestjs')
+
+    const view = computeRelationshipViewExport({
+      model,
+      baseViewId: 'index',
+      subjectId: 'cloud.backend',
+      scope: 'view',
+    })
+
+    expect(view.nodes.find(n => n.id === 'subject-cloud.backend')).toMatchObject({
+      color: 'green',
+      icon: null,
+      shape: 'component',
+      style: expect.objectContaining({
+        opacity: 80,
+      }),
+    })
+    expect(view.nodes.find(n => n.id === 'out-amazon')).toMatchObject({
+      color: 'amber',
+      shape: 'queue',
+    })
+  })
+
+  it('inherits scoped ancestor styling for relationship export nodes', ({ expect }) => {
+    const model = specs
+      .model(({ el, rel }, _) =>
+        _(
+          el('cloud', {
+            color: 'red',
+            shape: 'component',
+          }).with(
+            el('backend', {
+              shape: 'queue',
+            }),
+          ),
+          el('amazon'),
+          rel('cloud.backend', 'amazon', 'uses'),
+        )
+      )
+      .views(({ view, $include, $style }, _) =>
+        _(
+          view('index', 'Context').with(
+            $include('cloud'),
+            $include('amazon'),
+            $style('cloud', {
+              color: 'green',
+              shape: 'browser',
+              opacity: 80,
+            }),
+          ),
+        )
+      )
+      .toLikeC4Model()
+
+    const view = computeRelationshipViewExport({
+      model,
+      baseViewId: 'index',
+      subjectId: 'cloud.backend',
+      scope: 'view',
+    })
+
+    expect(view.nodes.find(n => n.id === 'subject-cloud.backend')).toMatchObject({
+      color: 'green',
+      shape: 'queue',
+      style: expect.objectContaining({
+        opacity: 80,
+      }),
+    })
+  })
+
+  it('preserves child styling when inheriting from a scoped ancestor', ({ expect }) => {
+    const model = specs
+      .model(({ el, rel }, _) =>
+        _(
+          el('cloud', {
+            icon: 'tech:cloud',
+          }).with(
+            el('backend', {
+              color: 'red',
+              icon: 'tech:nestjs',
+              shape: 'queue',
+              style: {
+                opacity: 40,
+                size: 'xs',
+              },
+            }),
+          ),
+          el('amazon'),
+          rel('cloud.backend', 'amazon', 'uses'),
+        )
+      )
+      .views(({ view, $include, $style }, _) =>
+        _(
+          view('index', 'Context').with(
+            $include('cloud'),
+            $include('amazon'),
+            $style('cloud', {
+              color: 'green',
+              icon: 'tech:aws',
+              opacity: 80,
+              shape: 'browser',
+              size: 'xl',
+            }),
+          ),
+        )
+      )
+      .toLikeC4Model()
+
+    const view = computeRelationshipViewExport({
+      model,
+      baseViewId: 'index',
+      subjectId: 'cloud.backend',
+      scope: 'view',
+    })
+
+    expect(view.nodes.find(n => n.id === 'subject-cloud.backend')).toMatchObject({
+      color: 'red',
+      icon: 'tech:nestjs',
+      shape: 'queue',
+      style: expect.objectContaining({
+        opacity: 40,
+        size: 'xs',
+      }),
+    })
+  })
+
+  it('inherits styling from the nearest scoped ancestor', ({ expect }) => {
+    const model = specs
+      .model(({ el, rel }, _) =>
+        _(
+          el('cloud').with(
+            el('region').with(
+              el('backend'),
+            ),
+          ),
+          el('amazon'),
+          rel('cloud.region.backend', 'amazon', 'uses'),
+        )
+      )
+      .views(({ view, $include, $style }, _) =>
+        _(
+          view('index', 'Context').with(
+            $include('cloud'),
+            $include('cloud.region'),
+            $include('amazon'),
+            $style('cloud', {
+              color: 'red',
+              opacity: 80,
+            }),
+            $style('cloud.region', {
+              color: 'green',
+              opacity: 60,
+            }),
+          ),
+        )
+      )
+      .toLikeC4Model()
+
+    const view = computeRelationshipViewExport({
+      model,
+      baseViewId: 'index',
+      subjectId: 'cloud.region.backend',
+      scope: 'view',
+    })
+
+    expect(view.nodes.find(n => n.id === 'subject-cloud.region.backend')).toMatchObject({
+      color: 'green',
+      style: expect.objectContaining({
+        opacity: 60,
+      }),
+    })
+  })
+
+  it('preserves computed element defaults for global relationship export nodes', ({ expect }) => {
+    const model = specs
+      .model(({ el, rel }, _) =>
+        _(
+          el('cloud').with(
+            el('backend'),
+          ),
+          el('amazon'),
+          rel('cloud.backend', 'amazon', 'uses'),
+        )
+      )
+      .views(({ view, $include }, _) =>
+        _(
+          view('index', 'Context').with(
+            $include('cloud.*'),
+            $include('amazon'),
+          ),
+        )
+      )
+      .toLikeC4Model({
+        id: 'test',
+        styles: {
+          defaults: {
+            size: 'lg',
+          },
+        },
+      })
+
+    const view = computeRelationshipViewExport({
+      model,
+      baseViewId: 'index',
+      subjectId: 'cloud.backend',
+      scope: 'global',
+    })
+
+    expect(view.nodes.find(n => n.id === 'subject-cloud.backend')?.style).toMatchObject({
+      opacity: 15,
+      size: 'lg',
+    })
+  })
 })

--- a/packages/core/src/compute-view/relationships-view/export-view.ts
+++ b/packages/core/src/compute-view/relationships-view/export-view.ts
@@ -36,7 +36,10 @@ export function computeRelationshipViewExport<M extends AnyAux>({
 
   const subject = model.element(subjectId)
   const relationships = computeRelationshipsView(subjectId, model, baseViewId, scope)
-  const layouted = layoutRelationshipsView(relationships)
+  const layouted = layoutRelationshipsView(
+    relationships,
+    scope === 'view' ? baseView : null,
+  )
 
   return exact({
     _stage: 'layouted',

--- a/packages/core/src/compute-view/relationships-view/index.ts
+++ b/packages/core/src/compute-view/relationships-view/index.ts
@@ -14,4 +14,5 @@ export {
   type RelationshipViewExportScope,
 } from './export-view'
 export { layoutRelationshipsView } from './layout'
+export { resolveRelationshipNodeStyle } from './resolve-node-style'
 export { treeFromElements } from './utils'

--- a/packages/core/src/compute-view/relationships-view/layout.spec.ts
+++ b/packages/core/src/compute-view/relationships-view/layout.spec.ts
@@ -4,8 +4,13 @@
 
 import { describe, it } from 'vitest'
 import { Builder } from '../../builder/Builder'
+import type { DiagramNode, Point } from '../../types'
 import { computeRelationshipsView } from './compute'
 import { layoutRelationshipsView } from './layout'
+
+function containsPoint(node: DiagramNode, [x, y]: Point) {
+  return x >= node.x && x <= node.x + node.width && y >= node.y && y <= node.y + node.height
+}
 
 describe('layoutRelationshipsView', () => {
   const specs = Builder
@@ -42,5 +47,138 @@ describe('layoutRelationshipsView', () => {
     expect(edge.relations).toHaveLength(2)
     expect(edge.points.length).toBeGreaterThan(0)
     expect((edge.points.length - 1) % 3).toBe(0)
+  })
+
+  it('keeps edge endpoints inside visible compound node bounds', ({ expect }) => {
+    const model = specs
+      .model(({ el, rel }, _) =>
+        _(
+          el('customer'),
+          el('cloud').with(
+            el('ui').with(
+              el('dashboard'),
+              el('mobile'),
+              el('supportPanel'),
+            ),
+            el('legacy').with(
+              el('backend').with(
+                el('services'),
+              ),
+            ),
+            el('next').with(
+              el('backend'),
+              el('events'),
+            ),
+          ),
+          el('amazon').with(
+            el('rds').with(
+              el('pg').with(
+                el('tblUsers'),
+              ),
+              el('aurora').with(
+                el('tblUsers'),
+              ),
+            ),
+            el('s3').with(
+              el('bucket1'),
+            ),
+            el('sqs').with(
+              el('queue1'),
+              el('queue2'),
+            ),
+          ),
+          rel('customer', 'cloud.ui.dashboard', 'opens'),
+          rel('customer', 'cloud.ui.mobile', 'opens mobile'),
+          rel('customer', 'cloud', 'uses'),
+          rel('cloud', 'amazon', 'uses'),
+          rel('cloud.legacy.backend.services', 'amazon.rds.pg.tblUsers', 'writes'),
+          rel('cloud.next.backend', 'amazon.rds.aurora.tblUsers', 'reads'),
+          rel('cloud.next.backend', 'amazon.s3.bucket1', 'writes'),
+          rel('cloud.next.events', 'amazon.sqs', 'publishes'),
+          rel('cloud.next.events', 'amazon.sqs.queue1', 'raw'),
+          rel('cloud.next.events', 'amazon.sqs.queue2', 'enriched'),
+          rel('cloud.ui.supportPanel', 'amazon.rds.aurora.tblUsers', 'reads'),
+        )
+      )
+      .toLikeC4Model()
+
+    const relations = new Map([...model.relationships()].map(relation => [relation.expression, relation]))
+    const relation = (expression: string) => {
+      const relationship = relations.get(expression)
+      if (!relationship) {
+        throw new Error(`Expected relationship ${expression}`)
+      }
+      return relationship
+    }
+
+    const layouted = layoutRelationshipsView({
+      incomers: new Set([
+        model.element('customer'),
+      ]),
+      incoming: new Set([
+        relation('customer -> cloud.ui.dashboard'),
+        relation('customer -> cloud.ui.mobile'),
+        relation('customer -> cloud'),
+      ]),
+      subjects: new Set([
+        model.element('cloud'),
+        model.element('cloud.ui'),
+        model.element('cloud.legacy'),
+        model.element('cloud.next'),
+        model.element('cloud.ui.dashboard'),
+        model.element('cloud.ui.mobile'),
+        model.element('cloud.ui.supportPanel'),
+        model.element('cloud.legacy.backend.services'),
+        model.element('cloud.next.backend'),
+        model.element('cloud.next.events'),
+      ]),
+      outgoing: new Set([
+        relation('cloud.legacy.backend.services -> amazon.rds.pg.tblUsers'),
+        relation('cloud.next.backend -> amazon.rds.aurora.tblUsers'),
+        relation('cloud.next.backend -> amazon.s3.bucket1'),
+        relation('cloud.next.events -> amazon.sqs'),
+        relation('cloud.next.events -> amazon.sqs.queue1'),
+        relation('cloud.next.events -> amazon.sqs.queue2'),
+        relation('cloud.ui.supportPanel -> amazon.rds.aurora.tblUsers'),
+        relation('cloud -> amazon'),
+      ]),
+      outgoers: new Set([
+        model.element('amazon'),
+        model.element('amazon.rds'),
+        model.element('amazon.s3'),
+        model.element('amazon.sqs'),
+        model.element('amazon.rds.pg'),
+        model.element('amazon.rds.aurora'),
+        model.element('amazon.rds.pg.tblUsers'),
+        model.element('amazon.rds.aurora.tblUsers'),
+        model.element('amazon.s3.bucket1'),
+        model.element('amazon.sqs.queue1'),
+        model.element('amazon.sqs.queue2'),
+      ]),
+    })
+    const nodesById = new Map(layouted.nodes.map(node => [node.id, node]))
+
+    for (const edge of layouted.edges) {
+      const source = nodesById.get(edge.source)
+      const target = nodesById.get(edge.target)
+      expect(source, `${edge.id} source node`).toBeDefined()
+      expect(target, `${edge.id} target node`).toBeDefined()
+
+      expect(containsPoint(source!, edge.points[0]), `${edge.id} starts inside ${edge.source}`).toBe(true)
+      expect(containsPoint(target!, edge.points.at(-1)!), `${edge.id} ends inside ${edge.target}`).toBe(true)
+    }
+
+    const subjectCloud = layouted.nodes.find(node => node.id === 'subject-cloud')!
+    const incomingToCompound = layouted.edges.find(edge => edge.id === 'in-customer->subject-cloud')!
+    const outgoingFromCompound = layouted.edges.find(edge => edge.id === 'subject-cloud->out-amazon')!
+
+    expect(
+      incomingToCompound.points.slice(-4).every(([, y]) => y >= subjectCloud.y),
+      `${incomingToCompound.id} connects at or below the visible compound top`,
+    ).toBe(true)
+    expect(
+      outgoingFromCompound.points.slice(0, 4).every(([, y]) => y >= subjectCloud.y),
+      `${outgoingFromCompound.id} connects at or below the visible compound top`,
+    ).toBe(true)
   })
 })

--- a/packages/core/src/compute-view/relationships-view/layout.ts
+++ b/packages/core/src/compute-view/relationships-view/layout.ts
@@ -6,10 +6,25 @@
 // Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
 
 import dagre, { type EdgeConfig, type GraphLabel } from '@dagrejs/dagre'
-import { concat, filter, find, forEachObj, groupBy, hasAtLeast, map, mapToObj, pipe, prop, reduce, tap } from 'remeda'
-import type { ElementModel } from '../../model/ElementModel'
+import {
+  concat,
+  filter,
+  find,
+  forEachObj,
+  groupBy,
+  hasAtLeast,
+  map,
+  mapToObj,
+  omit,
+  pipe,
+  prop,
+  reduce,
+  tap,
+} from 'remeda'
+import type { ElementModel, LikeC4ViewModel } from '../../model'
 import type { RelationshipModel } from '../../model/RelationModel'
 import {
+  type AnyAux,
   type DiagramEdge,
   type DiagramNode,
   type DiagramView,
@@ -20,7 +35,7 @@ import {
   type Point,
   exact,
 } from '../../types'
-import { invariant, sortParentsFirst } from '../../utils'
+import { ifind, invariant, sortParentsFirst } from '../../utils'
 import { toArray } from '../../utils/iterable'
 import { DefaultMap } from '../../utils/mnemonist'
 import type { RelationshipsViewData } from './_types'
@@ -194,8 +209,25 @@ function toStraightBezierSpline(points: Point[]): NonEmptyArray<Point> {
   return spline
 }
 
-export function layoutRelationshipsView(
-  data: RelationshipsViewData<any>,
+function inheritedScopedNodeStyle<M extends AnyAux>(
+  scope: LikeC4ViewModel<M> | null,
+  element: ElementModel<M>,
+) {
+  const inheritFromNode = scope?.findNodeWithElement(element.id) ?? null
+  const scopedAncestor = scope && !inheritFromNode
+    ? ifind(element.ancestors(), ancestor => !!scope.findNodeWithElement(ancestor.id))?.id ?? null
+    : null
+  const inheritFromAncestor = scopedAncestor ? scope?.findNodeWithElement(scopedAncestor) ?? null : null
+
+  return {
+    inheritFromNode,
+    inheritFromNodeOrAncestor: inheritFromNode ?? inheritFromAncestor,
+  }
+}
+
+export function layoutRelationshipsView<M extends AnyAux>(
+  data: RelationshipsViewData<M>,
+  scope: LikeC4ViewModel<M> | null = null,
 ): Pick<DiagramView, 'nodes' | 'edges' | 'bounds'> {
   const g = createGraph()
 
@@ -207,7 +239,7 @@ export function layoutRelationshipsView(
     name: string
     source: string // node id
     target: string // node id
-    relations: RelationshipModel[]
+    relations: RelationshipModel<M>[]
   }>
 
   pipe(
@@ -350,7 +382,10 @@ export function layoutRelationshipsView(
     // }
     const children = (g.children(id) as NodeId[] | undefined ?? []).filter(c => !c.endsWith(PortSuffix))
 
-    const { color, icon, shape, ...style } = element.style
+    const { inheritFromNode, inheritFromNodeOrAncestor } = inheritedScopedNodeStyle(scope, element)
+    const inheritedStyle = inheritFromNode
+      ? { ...element.style, ...inheritFromNode.style }
+      : { ...element.style, ...inheritFromNodeOrAncestor?.style, ...element.$element.style }
 
     return exact({
       id: id as NodeId,
@@ -362,9 +397,11 @@ export function layoutRelationshipsView(
       technology: element.technology,
       tags: [],
       links: null,
-      color,
-      icon,
-      shape,
+      color: inheritFromNode
+        ? inheritFromNode.color
+        : element.$element.style.color ?? inheritFromNodeOrAncestor?.color ?? element.color,
+      icon: inheritFromNode ? inheritFromNode.icon : element.icon,
+      shape: inheritFromNode?.shape ?? element.shape,
       modelRef: element.id,
       kind: element.kind,
       level: nodeLevel(id),
@@ -374,7 +411,7 @@ export function layoutRelationshipsView(
         width: width,
         height: height,
       },
-      style,
+      style: omit(inheritedStyle, ['color', 'shape', 'icon']),
       inEdges: [],
       outEdges: [],
       depth: children.length > 0 ? nodeDepth(id) : 0,

--- a/packages/core/src/compute-view/relationships-view/layout.ts
+++ b/packages/core/src/compute-view/relationships-view/layout.ts
@@ -479,7 +479,7 @@ export function layoutRelationshipsView<M extends AnyAux>(
     })
   })
 
-  const nodesById = new Map(nodes.map(node => [node.id, node]))
+  const nodesById = new Map<NodeId, DiagramNode>(nodes.map(node => [node.id, node]))
 
   const diagramEdges = g.edges().reduce((acc, e) => {
     const edge = g.edge(e)
@@ -491,21 +491,23 @@ export function layoutRelationshipsView<M extends AnyAux>(
     invariant(edgeData, `Edge ${ename} has no relationship data`)
     const onlyRelation = edgeData.relations.length === 1 ? edgeData.relations[0] : null
     const edgeId = edgeData.name as EdgeId
-    const source = nodesById.get(edgeData.source as NodeId)
-    const target = nodesById.get(edgeData.target as NodeId)
+    const sourceId = edgeData.source as NodeId
+    const targetId = edgeData.target as NodeId
+    const source = nodesById.get(sourceId)
+    const target = nodesById.get(targetId)
     invariant(source, `Edge ${ename} has no source node ${edgeData.source}`)
     invariant(target, `Edge ${ename} has no target node ${edgeData.target}`)
 
     // Keep exported geometry valid for direct LayoutedView consumers, even though current source generators ignore it.
-    const points = edge.points.map(p => [p.x, p.y] as Point)
+    const points = edge.points.map<Point>(p => [p.x, p.y])
     clampTerminalSegmentToBounds(points, source, 'start')
     clampTerminalSegmentToBounds(points, target, 'end')
 
     acc.push(exact({
       id: edgeId,
       parent: null,
-      source: edgeData.source as NodeId,
-      target: edgeData.target as NodeId,
+      source: sourceId,
+      target: targetId,
       label: onlyRelation ? onlyRelation.title ?? 'untitled' : `${edgeData.relations.length} relationships`,
       description: onlyRelation?.description.$source ?? null,
       technology: onlyRelation?.technology ?? null,

--- a/packages/core/src/compute-view/relationships-view/layout.ts
+++ b/packages/core/src/compute-view/relationships-view/layout.ts
@@ -15,7 +15,6 @@ import {
   hasAtLeast,
   map,
   mapToObj,
-  omit,
   pipe,
   prop,
   reduce,
@@ -35,10 +34,11 @@ import {
   type Point,
   exact,
 } from '../../types'
-import { ifind, invariant, sortParentsFirst } from '../../utils'
+import { invariant, sortParentsFirst } from '../../utils'
 import { toArray } from '../../utils/iterable'
 import { DefaultMap } from '../../utils/mnemonist'
 import type { RelationshipsViewData } from './_types'
+import { resolveRelationshipNodeStyle } from './resolve-node-style'
 import { treeFromElements } from './utils'
 
 /**
@@ -288,22 +288,6 @@ function clampTerminalSegmentToBounds(points: Point[], bounds: Bounds, terminal:
   }
 }
 
-function inheritedScopedNodeStyle<M extends AnyAux>(
-  scope: LikeC4ViewModel<M> | null,
-  element: ElementModel<M>,
-) {
-  const inheritFromNode = scope?.findNodeWithElement(element.id) ?? null
-  const scopedAncestor = scope && !inheritFromNode
-    ? ifind(element.ancestors(), ancestor => !!scope.findNodeWithElement(ancestor.id))?.id ?? null
-    : null
-  const inheritFromAncestor = scopedAncestor ? scope?.findNodeWithElement(scopedAncestor) ?? null : null
-
-  return {
-    inheritFromNode,
-    inheritFromNodeOrAncestor: inheritFromNode ?? inheritFromAncestor,
-  }
-}
-
 export function layoutRelationshipsView<M extends AnyAux>(
   data: RelationshipsViewData<M>,
   scope: LikeC4ViewModel<M> | null = null,
@@ -461,10 +445,7 @@ export function layoutRelationshipsView<M extends AnyAux>(
     // }
     const children = (g.children(id) as NodeId[] | undefined ?? []).filter(c => !c.endsWith(PortSuffix))
 
-    const { inheritFromNode, inheritFromNodeOrAncestor } = inheritedScopedNodeStyle(scope, element)
-    const inheritedStyle = inheritFromNode
-      ? { ...element.style, ...inheritFromNode.style }
-      : { ...element.style, ...inheritFromNodeOrAncestor?.style, ...element.$element.style }
+    const resolvedStyle = resolveRelationshipNodeStyle(scope, element)
 
     return exact({
       id: id as NodeId,
@@ -476,11 +457,9 @@ export function layoutRelationshipsView<M extends AnyAux>(
       technology: element.technology,
       tags: [],
       links: null,
-      color: inheritFromNode
-        ? inheritFromNode.color
-        : element.$element.style.color ?? inheritFromNodeOrAncestor?.color ?? element.color,
-      icon: inheritFromNode ? inheritFromNode.icon : element.icon,
-      shape: inheritFromNode?.shape ?? element.shape,
+      color: resolvedStyle.color,
+      icon: resolvedStyle.icon,
+      shape: resolvedStyle.shape,
       modelRef: element.id,
       kind: element.kind,
       level: nodeLevel(id),
@@ -490,7 +469,7 @@ export function layoutRelationshipsView<M extends AnyAux>(
         width: width,
         height: height,
       },
-      style: omit(inheritedStyle, ['color', 'shape', 'icon']),
+      style: resolvedStyle.style,
       inEdges: [],
       outEdges: [],
       depth: children.length > 0 ? nodeDepth(id) : 0,
@@ -517,6 +496,7 @@ export function layoutRelationshipsView<M extends AnyAux>(
     invariant(source, `Edge ${ename} has no source node ${edgeData.source}`)
     invariant(target, `Edge ${ename} has no target node ${edgeData.target}`)
 
+    // Keep exported geometry valid for direct LayoutedView consumers, even though current source generators ignore it.
     const points = edge.points.map(p => [p.x, p.y] as Point)
     clampTerminalSegmentToBounds(points, source, 'start')
     clampTerminalSegmentToBounds(points, target, 'end')

--- a/packages/core/src/compute-view/relationships-view/layout.ts
+++ b/packages/core/src/compute-view/relationships-view/layout.ts
@@ -209,6 +209,85 @@ function toStraightBezierSpline(points: Point[]): NonEmptyArray<Point> {
   return spline
 }
 
+type Bounds = Pick<DiagramNode, 'x' | 'y' | 'width' | 'height'>
+type BoundsSide = 'top' | 'bottom' | 'left' | 'right'
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max)
+}
+
+function clampPointToBounds([x, y]: Point, { x: minX, y: minY, width, height }: Bounds): Point {
+  return [
+    clamp(x, minX, minX + width),
+    clamp(y, minY, minY + height),
+  ]
+}
+
+function overflowSide([x, y]: Point, { x: minX, y: minY, width, height }: Bounds): BoundsSide | null {
+  const maxX = minX + width
+  const maxY = minY + height
+  switch (true) {
+    case y < minY:
+      return 'top'
+    case y > maxY:
+      return 'bottom'
+    case x < minX:
+      return 'left'
+    case x > maxX:
+      return 'right'
+    default:
+      return null
+  }
+}
+
+function overlapsSide([x, y]: Point, { x: minX, y: minY, width, height }: Bounds, side: BoundsSide) {
+  const maxX = minX + width
+  const maxY = minY + height
+  switch (side) {
+    case 'top':
+      return y < minY && x >= minX && x <= maxX
+    case 'bottom':
+      return y > maxY && x >= minX && x <= maxX
+    case 'left':
+      return x < minX && y >= minY && y <= maxY
+    case 'right':
+      return x > maxX && y >= minY && y <= maxY
+  }
+}
+
+function clampPointToSide([x, y]: Point, { x: minX, y: minY, width, height }: Bounds, side: BoundsSide): Point {
+  switch (side) {
+    case 'top':
+      return [x, minY]
+    case 'bottom':
+      return [x, minY + height]
+    case 'left':
+      return [minX, y]
+    case 'right':
+      return [minX + width, y]
+  }
+}
+
+function clampTerminalSegmentToBounds(points: Point[], bounds: Bounds, terminal: 'start' | 'end') {
+  const terminalIndex = terminal === 'start' ? 0 : points.length - 1
+  const side = overflowSide(points[terminalIndex]!, bounds)
+  points[terminalIndex] = clampPointToBounds(points[terminalIndex]!, bounds)
+  if (!side) {
+    return
+  }
+
+  if (terminal === 'start') {
+    for (let i = 1; i < points.length && overlapsSide(points[i]!, bounds, side); i++) {
+      points[i] = clampPointToSide(points[i]!, bounds, side)
+    }
+    return
+  }
+
+  for (let i = points.length - 2; i >= 0 && overlapsSide(points[i]!, bounds, side); i--) {
+    points[i] = clampPointToSide(points[i]!, bounds, side)
+  }
+}
+
 function inheritedScopedNodeStyle<M extends AnyAux>(
   scope: LikeC4ViewModel<M> | null,
   element: ElementModel<M>,
@@ -421,6 +500,8 @@ export function layoutRelationshipsView<M extends AnyAux>(
     })
   })
 
+  const nodesById = new Map(nodes.map(node => [node.id, node]))
+
   const diagramEdges = g.edges().reduce((acc, e) => {
     const edge = g.edge(e)
     const ename = e.name
@@ -431,6 +512,14 @@ export function layoutRelationshipsView<M extends AnyAux>(
     invariant(edgeData, `Edge ${ename} has no relationship data`)
     const onlyRelation = edgeData.relations.length === 1 ? edgeData.relations[0] : null
     const edgeId = edgeData.name as EdgeId
+    const source = nodesById.get(edgeData.source as NodeId)
+    const target = nodesById.get(edgeData.target as NodeId)
+    invariant(source, `Edge ${ename} has no source node ${edgeData.source}`)
+    invariant(target, `Edge ${ename} has no target node ${edgeData.target}`)
+
+    const points = edge.points.map(p => [p.x, p.y] as Point)
+    clampTerminalSegmentToBounds(points, source, 'start')
+    clampTerminalSegmentToBounds(points, target, 'end')
 
     acc.push(exact({
       id: edgeId,
@@ -447,7 +536,7 @@ export function layoutRelationshipsView<M extends AnyAux>(
       head: onlyRelation?.head,
       tail: onlyRelation?.tail,
       navigateTo: onlyRelation?.navigateTo?.id ?? null,
-      points: toStraightBezierSpline(edge.points.map(p => [p.x, p.y])),
+      points: toStraightBezierSpline(points),
       labelBBox: null,
     }))
     return acc

--- a/packages/core/src/compute-view/relationships-view/resolve-node-style.ts
+++ b/packages/core/src/compute-view/relationships-view/resolve-node-style.ts
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import { omit } from 'remeda'
+import type { ElementModel, LikeC4ViewModel } from '../../model'
+import type { AnyAux } from '../../types'
+import { ifind } from '../../utils'
+
+export function resolveRelationshipNodeStyle<M extends AnyAux>(
+  scope: LikeC4ViewModel<M> | null,
+  element: ElementModel<M>,
+) {
+  const scopedNode = scope?.findNodeWithElement(element.id) ?? null
+  const scopedAncestor = scope && !scopedNode
+    ? ifind(element.ancestors(), ancestor => !!scope.findNodeWithElement(ancestor.id)) ?? null
+    : null
+  const scopedAncestorNode = scopedAncestor ? scope?.findNodeWithElement(scopedAncestor.id) ?? null : null
+  const inheritedNode = scopedNode ?? scopedAncestorNode
+
+  const inheritedStyle = scopedNode
+    ? { ...element.style, ...scopedNode.style }
+    : { ...element.style, ...scopedAncestorNode?.style, ...element.$element.style }
+
+  return {
+    existsInCurrentView: !!scopedNode,
+    color: scopedNode
+      ? scopedNode.color
+      : element.$element.style.color ?? scopedAncestorNode?.color ?? element.color,
+    icon: scopedNode
+      ? scopedNode.icon
+      : element.$element.style.icon ?? scopedAncestorNode?.icon ?? element.icon,
+    shape: scopedNode
+      ? scopedNode.shape
+      : element.$element.style.shape ?? scopedAncestorNode?.shape ?? element.shape,
+    style: omit(inheritedStyle, ['color', 'shape', 'icon']),
+    inheritedNode,
+  }
+}

--- a/packages/core/src/compute-view/relationships-view/resolve-node-style.ts
+++ b/packages/core/src/compute-view/relationships-view/resolve-node-style.ts
@@ -4,13 +4,22 @@
 
 import { omit } from 'remeda'
 import type { ElementModel, LikeC4ViewModel } from '../../model'
-import type { AnyAux } from '../../types'
+import type { AnyAux, Color, ElementShape, ElementStyle, IconUrl } from '../../types'
 import { ifind } from '../../utils'
+
+export type ResolvedRelationshipNodeStyle<M extends AnyAux> = {
+  existsInCurrentView: boolean
+  color: Color
+  icon: IconUrl | null
+  shape: ElementShape
+  style: Omit<ElementStyle, 'color' | 'shape' | 'icon'>
+  inheritedNode: ReturnType<LikeC4ViewModel<M>['findNodeWithElement']>
+}
 
 export function resolveRelationshipNodeStyle<M extends AnyAux>(
   scope: LikeC4ViewModel<M> | null,
   element: ElementModel<M>,
-) {
+): ResolvedRelationshipNodeStyle<M> {
   const scopedNode = scope?.findNodeWithElement(element.id) ?? null
   const scopedAncestor = scope && !scopedNode
     ? ifind(element.ancestors(), ancestor => !!scope.findNodeWithElement(ancestor.id)) ?? null

--- a/packages/diagram/src/StaticRelationshipsBrowser.spec.ts
+++ b/packages/diagram/src/StaticRelationshipsBrowser.spec.ts
@@ -3,7 +3,7 @@
 // Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import { describe, it } from 'vitest'
-import { relationshipEdgeLabelMaxWidth } from './StaticRelationshipsBrowser'
+import { compoundPortTop, relationshipEdgeLabelMaxWidth } from './StaticRelationshipsBrowser'
 
 describe('relationshipEdgeLabelMaxWidth', () => {
   it('subtracts label padding from the absolute edge span', ({ expect }) => {
@@ -18,5 +18,20 @@ describe('relationshipEdgeLabelMaxWidth', () => {
 
   it('caps long relationship labels', ({ expect }) => {
     expect(relationshipEdgeLabelMaxWidth(100, 700)).toBe(250)
+  })
+})
+
+describe('compoundPortTop', () => {
+  it('spaces compound handles inside the node bounds', ({ expect }) => {
+    expect(compoundPortTop(0, 3)).toBe('25%')
+    expect(compoundPortTop(1, 3)).toBe('50%')
+    expect(compoundPortTop(2, 3)).toBe('75%')
+  })
+
+  it('keeps the last compound handle inside the node for dense ports', ({ expect }) => {
+    const top = compoundPortTop(9, 10)
+
+    expect(Number.parseFloat(top)).toBeCloseTo(90.909, 3)
+    expect(top).toMatch(/%$/)
   })
 })

--- a/packages/diagram/src/StaticRelationshipsBrowser.spec.ts
+++ b/packages/diagram/src/StaticRelationshipsBrowser.spec.ts
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import { describe, it } from 'vitest'
+import { relationshipEdgeLabelMaxWidth } from './StaticRelationshipsBrowser'
+
+describe('relationshipEdgeLabelMaxWidth', () => {
+  it('subtracts label padding from the absolute edge span', ({ expect }) => {
+    expect(relationshipEdgeLabelMaxWidth(100, 300)).toBe(130)
+    expect(relationshipEdgeLabelMaxWidth(300, 100)).toBe(130)
+  })
+
+  it('never returns a negative label width', ({ expect }) => {
+    expect(relationshipEdgeLabelMaxWidth(100, 130)).toBe(0)
+    expect(relationshipEdgeLabelMaxWidth(130, 100)).toBe(0)
+  })
+
+  it('caps long relationship labels', ({ expect }) => {
+    expect(relationshipEdgeLabelMaxWidth(100, 700)).toBe(250)
+  })
+})

--- a/packages/diagram/src/StaticRelationshipsBrowser.tsx
+++ b/packages/diagram/src/StaticRelationshipsBrowser.tsx
@@ -58,6 +58,10 @@ export function relationshipEdgeLabelMaxWidth(sourceX: number, targetX: number):
   )
 }
 
+export function compoundPortTop(index: number, count: number): string {
+  return `${((index + 1) / (count + 1)) * 100}%`
+}
+
 export type StaticRelationshipsBrowserView =
   & ReturnType<typeof useRelationshipsView>
   & ReturnType<typeof viewToNodesEdge>
@@ -232,7 +236,7 @@ function CompoundPorts({ data }: CompoundPortsProps) {
           position={Position.Left}
           style={{
             visibility: 'hidden',
-            top: `${20 * (i + 1)}px`,
+            top: compoundPortTop(i, data.ports.in.length),
           }} />
       ))}
       {data.ports.out.map((id, i) => (
@@ -243,7 +247,7 @@ function CompoundPorts({ data }: CompoundPortsProps) {
           position={Position.Right}
           style={{
             visibility: 'hidden',
-            top: `${20 * (i + 1)}px`,
+            top: compoundPortTop(i, data.ports.out.length),
           }} />
       ))}
     </>

--- a/packages/diagram/src/StaticRelationshipsBrowser.tsx
+++ b/packages/diagram/src/StaticRelationshipsBrowser.tsx
@@ -48,6 +48,16 @@ import {
 type StaticRelationshipsBrowserNode = RelationshipsBrowserTypes.AnyNode
 type StaticRelationshipsBrowserEdge = RelationshipsBrowserTypes.Edge
 
+const RELATIONSHIP_LABEL_HORIZONTAL_PADDING = 70
+const RELATIONSHIP_LABEL_MAX_WIDTH = 250
+
+export function relationshipEdgeLabelMaxWidth(sourceX: number, targetX: number): number {
+  return Math.min(
+    Math.max(Math.abs(targetX - sourceX) - RELATIONSHIP_LABEL_HORIZONTAL_PADDING, 0),
+    RELATIONSHIP_LABEL_MAX_WIDTH,
+  )
+}
+
 export type StaticRelationshipsBrowserView =
   & ReturnType<typeof useRelationshipsView>
   & ReturnType<typeof viewToNodesEdge>
@@ -276,7 +286,7 @@ const StaticRelationshipEdge = memoEdge<RelationshipsBrowserTypes.EdgeProps>((pr
           translate: 'translate(-50%, 0)',
         }}
         style={{
-          maxWidth: Math.min(Math.abs(props.targetX - props.sourceX - 70), 250),
+          maxWidth: relationshipEdgeLabelMaxWidth(props.sourceX, props.targetX),
         }}
       >
         <EdgeLabel

--- a/packages/diagram/src/StaticRelationshipsBrowser.tsx
+++ b/packages/diagram/src/StaticRelationshipsBrowser.tsx
@@ -1,0 +1,295 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import type { Fqn, ViewId } from '@likec4/core/types'
+import { css, cx } from '@likec4/styles/css'
+import {
+  type OnEdgesChange,
+  type OnNodesChange,
+  type ReactFlowInstance,
+  Handle,
+  Position,
+  ReactFlowProvider,
+} from '@xyflow/react'
+import { getBezierPath } from '@xyflow/system'
+import { useMemo } from 'react'
+import {
+  CompoundNodeContainer,
+  CompoundTitle,
+  EdgeContainer,
+  EdgeLabel,
+  EdgeLabelContainer,
+  EdgePath,
+  ElementData,
+  ElementNodeContainer,
+  ElementShape,
+  memoEdge,
+} from './base-primitives'
+import type { XYBackground } from './base/Background'
+import { BaseXYFlow } from './base/BaseXYFlow'
+import type { BaseNodePropsWithData } from './base/types'
+import { RootContainer } from './components/RootContainer'
+import {
+  EnsureMantine,
+  FramerMotionConfig,
+} from './context'
+import { TagStylesProvider } from './context/TagStylesContext'
+import { useId } from './hooks/useId'
+import { LikeC4Styles } from './LikeC4Styles'
+import type { RelationshipsBrowserTypes } from './overlays/relationships-browser/_types'
+import { EmptyNode } from './overlays/relationships-browser/custom/EmptyNode'
+import { useRelationshipsView } from './overlays/relationships-browser/layout'
+import {
+  useViewToNodesEdges,
+  viewToNodesEdge,
+} from './overlays/relationships-browser/useViewToNodesEdges'
+
+type StaticRelationshipsBrowserNode = RelationshipsBrowserTypes.AnyNode
+type StaticRelationshipsBrowserEdge = RelationshipsBrowserTypes.Edge
+
+export type StaticRelationshipsBrowserView =
+  & ReturnType<typeof useRelationshipsView>
+  & ReturnType<typeof viewToNodesEdge>
+
+export type StaticRelationshipsBrowserInstance = ReactFlowInstance<
+  StaticRelationshipsBrowserNode,
+  StaticRelationshipsBrowserEdge
+>
+
+export type StaticRelationshipsBrowserProps = {
+  view: StaticRelationshipsBrowserView
+  className?: string | undefined
+  background?: 'transparent' | 'solid' | XYBackground | undefined
+  initialViewport?: { x: number; y: number; zoom: number } | undefined
+  onInitialized?: ((instance: StaticRelationshipsBrowserInstance) => void) | undefined
+}
+
+/**
+ * Computes the same relationship-browser view model used by the interactive overlay.
+ */
+export function useStaticRelationshipsBrowserView(
+  subject: Fqn,
+  viewId: ViewId | null,
+  scope: 'global' | 'view',
+): StaticRelationshipsBrowserView {
+  const layouted = useRelationshipsView(subject, viewId, scope)
+  const {
+    xynodes,
+    xyedges,
+  } = useViewToNodesEdges(layouted)
+
+  return useMemo(
+    () => ({
+      ...layouted,
+      xynodes,
+      xyedges,
+    }),
+    [layouted, xynodes, xyedges],
+  )
+}
+
+const nodeTypes: RelationshipsBrowserTypes.NodeRenderers = {
+  element: StaticElementNode,
+  compound: StaticCompoundNode,
+  empty: EmptyNode,
+}
+
+const ignoreNodeChanges: OnNodesChange<StaticRelationshipsBrowserNode> = () => {}
+const ignoreEdgeChanges: OnEdgesChange<StaticRelationshipsBrowserEdge> = () => {}
+
+/**
+ * Renders relationship-browser visuals without interactive browser controls.
+ */
+export function StaticRelationshipsBrowser({
+  view,
+  className,
+  background = 'dots',
+  initialViewport,
+  onInitialized,
+}: StaticRelationshipsBrowserProps) {
+  const id = useId()
+  return (
+    <EnsureMantine>
+      <FramerMotionConfig>
+        <LikeC4Styles id={id} />
+        <TagStylesProvider rootSelector={`#${id}`}>
+          <RootContainer id={id} className={cx('likec4-static-view', className)}>
+            <ReactFlowProvider initialNodes={view.xynodes} initialEdges={view.xyedges}>
+              <BaseXYFlow<StaticRelationshipsBrowserNode, StaticRelationshipsBrowserEdge>
+                nodes={view.xynodes}
+                edges={view.xyedges}
+                className="initialized relationships-browser"
+                nodeTypes={nodeTypes}
+                edgeTypes={edgeTypes}
+                fitView={false}
+                {...initialViewport && {
+                  defaultViewport: initialViewport,
+                }}
+                {...onInitialized && {
+                  onInit: onInitialized,
+                }}
+                onNodesChange={ignoreNodeChanges}
+                onEdgesChange={ignoreEdgeChanges}
+                nodesDraggable={false}
+                nodesSelectable={false}
+                nodesFocusable={false}
+                edgesFocusable={false}
+                pannable={false}
+                zoomable={false}
+                background={background}
+                aria-label="Relationship export"
+              />
+            </ReactFlowProvider>
+          </RootContainer>
+        </TagStylesProvider>
+      </FramerMotionConfig>
+    </EnsureMantine>
+  )
+}
+
+function StaticElementNode(props: RelationshipsBrowserTypes.NodeProps<'element'>) {
+  return (
+    <ElementNodeContainer key={props.id} layoutId={props.id} nodeProps={props}>
+      <ElementShape {...props} />
+      <ElementData {...props} />
+      <ElementPorts {...props} />
+    </ElementNodeContainer>
+  )
+}
+
+function StaticCompoundNode(props: RelationshipsBrowserTypes.NodeProps<'compound'>) {
+  return (
+    <CompoundNodeContainer key={props.id} layoutId={props.id} nodeProps={props}>
+      <CompoundTitle {...props} />
+      <CompoundPorts {...props} />
+    </CompoundNodeContainer>
+  )
+}
+
+type ElementPortsProps = BaseNodePropsWithData<
+  Pick<
+    RelationshipsBrowserTypes.ElementNodeData,
+    | 'ports'
+    | 'height'
+  >
+>
+
+function ElementPorts({ data: { ports, height } }: ElementPortsProps) {
+  return (
+    <>
+      {ports.in.map((id, i) => (
+        <Handle
+          key={id}
+          id={id}
+          type="target"
+          position={Position.Left}
+          style={{
+            visibility: 'hidden',
+            top: `${15 + (i + 1) * ((height - 30) / (ports.in.length + 1))}px`,
+          }} />
+      ))}
+      {ports.out.map((id, i) => (
+        <Handle
+          key={id}
+          id={id}
+          type="source"
+          position={Position.Right}
+          style={{
+            visibility: 'hidden',
+            top: `${15 + (i + 1) * ((height - 30) / (ports.out.length + 1))}px`,
+          }} />
+      ))}
+    </>
+  )
+}
+
+type CompoundPortsProps = BaseNodePropsWithData<
+  Pick<
+    RelationshipsBrowserTypes.CompoundNodeData,
+    'ports'
+  >
+>
+
+function CompoundPorts({ data }: CompoundPortsProps) {
+  return (
+    <>
+      {data.ports.in.map((id, i) => (
+        <Handle
+          key={id}
+          id={id}
+          type="target"
+          position={Position.Left}
+          style={{
+            visibility: 'hidden',
+            top: `${20 * (i + 1)}px`,
+          }} />
+      ))}
+      {data.ports.out.map((id, i) => (
+        <Handle
+          key={id}
+          id={id}
+          type="source"
+          position={Position.Right}
+          style={{
+            visibility: 'hidden',
+            top: `${20 * (i + 1)}px`,
+          }} />
+      ))}
+    </>
+  )
+}
+
+const StaticRelationshipEdge = memoEdge<RelationshipsBrowserTypes.EdgeProps>((props) => {
+  const {
+    data: {
+      relations,
+      existsInCurrentView,
+    },
+  } = props
+  const [svgPath, labelX, labelY] = getBezierPath(props)
+  const markOrange = relations.length > 1 || !existsInCurrentView
+  const edgeProps: RelationshipsBrowserTypes.EdgeProps = markOrange
+    ? {
+      ...props,
+      data: {
+        ...props.data,
+        color: 'amber',
+      } satisfies RelationshipsBrowserTypes.EdgeData,
+    }
+    : props
+
+  return (
+    <EdgeContainer {...edgeProps}>
+      <EdgePath
+        edgeProps={edgeProps}
+        svgPath={svgPath}
+        {...markOrange && {
+          strokeWidth: 5,
+        }}
+      />
+      <EdgeLabelContainer
+        edgeProps={edgeProps}
+        labelPosition={{
+          x: labelX,
+          y: labelY,
+          translate: 'translate(-50%, 0)',
+        }}
+        style={{
+          maxWidth: Math.min(Math.abs(props.targetX - props.sourceX - 70), 250),
+        }}
+      >
+        <EdgeLabel
+          edgeProps={edgeProps}
+          className={css({
+            transition: 'fast',
+          })}
+        />
+      </EdgeLabelContainer>
+    </EdgeContainer>
+  )
+})
+
+const edgeTypes = {
+  relationship: StaticRelationshipEdge,
+}

--- a/packages/diagram/src/index.ts
+++ b/packages/diagram/src/index.ts
@@ -87,6 +87,14 @@ export type { Types } from './likec4diagram/types'
 
 export { StaticLikeC4Diagram } from './StaticLikeC4Diagram'
 
+export {
+  StaticRelationshipsBrowser,
+  type StaticRelationshipsBrowserInstance,
+  type StaticRelationshipsBrowserProps,
+  type StaticRelationshipsBrowserView,
+  useStaticRelationshipsBrowserView,
+} from './StaticRelationshipsBrowser'
+
 export { LikeC4View } from './LikeC4View'
 
 export type { LikeC4BrowserProps, LikeC4ViewProps } from './LikeC4View'

--- a/packages/diagram/src/overlays/relationships-browser/layout.spec.ts
+++ b/packages/diagram/src/overlays/relationships-browser/layout.spec.ts
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import { Builder } from '@likec4/core/builder'
+import { computeRelationshipsView, computeRelationshipViewExport } from '@likec4/core/compute-view'
+import { describe, it } from 'vitest'
+import { layoutRelationshipsView } from './layout'
+
+describe('relationship browser layout', () => {
+  it('resolves scoped ancestor styles like relationship source exports', ({ expect }) => {
+    const specs = Builder
+      .specification({
+        elements: {
+          el: {
+            style: {
+              opacity: 20,
+            },
+          },
+        },
+      })
+
+    const model = specs
+      .model(({ el, rel }, _) =>
+        _(
+          el('cloud', {
+            color: 'blue',
+            icon: 'tech:cloud',
+          }).with(
+            el('backend', {
+              color: 'red',
+              icon: 'tech:nestjs',
+              shape: 'queue',
+              style: {
+                opacity: 40,
+                size: 'xs',
+              },
+            }),
+          ),
+          el('amazon', {
+            icon: 'tech:aws',
+          }),
+          rel('cloud.backend', 'amazon', 'uses'),
+        )
+      )
+      .views(({ view, $include, $style }, _) =>
+        _(
+          view('index', 'Context').with(
+            $include('cloud'),
+            $include('amazon'),
+            $style('cloud', {
+              color: 'green',
+              icon: 'tech:aws',
+              opacity: 80,
+              shape: 'browser',
+              size: 'xl',
+            }),
+            $style('amazon', {
+              color: 'amber',
+              icon: 'none',
+              shape: 'queue',
+            }),
+          ),
+        )
+      )
+      .toLikeC4Model()
+
+    const sourceExport = computeRelationshipViewExport({
+      model,
+      baseViewId: 'index',
+      subjectId: 'cloud.backend',
+      scope: 'view',
+    })
+    const browserExport = layoutRelationshipsView(
+      computeRelationshipsView('cloud.backend', model, 'index', 'view'),
+      model.view('index'),
+    )
+
+    const sourceNode = (modelRef: string) => sourceExport.nodes.find(n => n.modelRef === modelRef)
+    const browserNode = (modelRef: string) => browserExport.nodes.find(n => n.modelRef === modelRef)
+
+    expect(browserNode('cloud.backend')).toMatchObject({
+      color: sourceNode('cloud.backend')?.color,
+      icon: sourceNode('cloud.backend')?.icon,
+      shape: sourceNode('cloud.backend')?.shape,
+      style: sourceNode('cloud.backend')?.style,
+    })
+    expect(browserNode('amazon')).toMatchObject({
+      color: sourceNode('amazon')?.color,
+      icon: sourceNode('amazon')?.icon,
+      shape: sourceNode('amazon')?.shape,
+      style: sourceNode('amazon')?.style,
+    })
+  })
+})

--- a/packages/diagram/src/overlays/relationships-browser/layout.ts
+++ b/packages/diagram/src/overlays/relationships-browser/layout.ts
@@ -1,6 +1,14 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import {
   type RelationshipsViewData,
   computeRelationshipsView,
+  resolveRelationshipNodeStyle,
   treeFromElements,
 } from '@likec4/core/compute-view'
 import type {
@@ -10,7 +18,6 @@ import type {
   EdgeId,
   ElementKind,
   Fqn,
-  IconUrl,
   MarkdownOrString,
   NodeId,
   NonEmptyArray,
@@ -37,7 +44,6 @@ import {
   groupBy,
   map,
   mapToObj,
-  omit,
   only,
   pipe,
   prop,
@@ -505,11 +511,7 @@ export function layoutRelationshipsView(
 
     const navigateTo = scope ? ifind(element.scopedViews(), v => v.id !== scope.id)?.id ?? null : null
 
-    const inheritFromNode = scope?.findNodeWithElement(element.id)
-    const scopedAncestor = scope && !inheritFromNode
-      ? ifind(element.ancestors(), a => !!scope.findNodeWithElement(a.id))?.id
-      : null
-    const inheritFromNodeOrAncestor = inheritFromNode ?? (scopedAncestor && scope?.findNodeWithElement(scopedAncestor))
+    const resolvedStyle = resolveRelationshipNodeStyle(scope, element)
 
     return {
       id: id as NodeId,
@@ -521,9 +523,9 @@ export function layoutRelationshipsView(
       technology: element.technology,
       tags: [...element.tags],
       links: null,
-      color: inheritFromNodeOrAncestor?.color ?? element.color,
-      shape: inheritFromNode?.shape ?? element.shape,
-      icon: inheritFromNode?.icon ?? element.icon ?? 'none' as IconUrl,
+      color: resolvedStyle.color,
+      shape: resolvedStyle.shape,
+      icon: resolvedStyle.icon,
       modelRef: element.id,
       kind: element.kind,
       level: nodeLevel(id),
@@ -533,10 +535,7 @@ export function layoutRelationshipsView(
         width: width,
         height: height,
       },
-      style: omit({
-        ...(inheritFromNode ?? inheritFromNodeOrAncestor)?.style,
-        ...element.$element.style,
-      }, ['color', 'shape', 'icon']),
+      style: resolvedStyle.style,
       navigateTo,
       ...(children.length > 0 && { depth: nodeDepth(id) }),
       children,
@@ -547,7 +546,7 @@ export function layoutRelationshipsView(
         in: sortedPorts(id, 'in', inPorts),
         out: sortedPorts(id, 'out', outPorts),
       },
-      existsInCurrentView: !!inheritFromNode,
+      existsInCurrentView: resolvedStyle.existsInCurrentView,
     }
   })
 

--- a/packages/likec4-spa/src/pages/ExportPage.spec.ts
+++ b/packages/likec4-spa/src/pages/ExportPage.spec.ts
@@ -22,7 +22,9 @@ const testState = vi.hoisted(() => ({
     relationships: undefined as string | undefined,
     relationshipScope: undefined as string | undefined,
   },
-  model: {},
+  model: {
+    findElement: (id: string) => id === 'missing' ? null : {},
+  },
 }))
 
 vi.mock('@likec4/diagram', () => ({

--- a/packages/likec4-spa/src/pages/ExportPage.tsx
+++ b/packages/likec4-spa/src/pages/ExportPage.tsx
@@ -6,18 +6,24 @@
 // Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
 
 import { type LayoutedView, type NodeNotation, type RichTextOrEmpty, RichText } from '@likec4/core'
-import { LikeC4Diagram, pickViewBounds, useLikeC4Styles } from '@likec4/diagram'
+import {
+  LikeC4Diagram,
+  pickViewBounds,
+  StaticRelationshipsBrowser,
+  useLikeC4Styles,
+  useStaticRelationshipsBrowserView,
+} from '@likec4/diagram'
 import { ElementShape, Markdown } from '@likec4/diagram/custom'
 import { Box } from '@likec4/styles/jsx'
 import { LoadingOverlay } from '@mantine/core'
 import { useStore } from '@nanostores/react'
 import { useSearch } from '@tanstack/react-router'
 import type { CSSProperties } from 'react'
-import { useMemo, useRef } from 'react'
+import { useRef } from 'react'
 import { NotFound } from '../components/NotFound'
 import { useLikeC4ModelAtom } from '../context/safeCtx'
 import { useCurrentView, useCurrentViewId, useTransparentBackground } from '../hooks'
-import { createRelationshipExportView, normalizeRelationshipScope } from '../relationship-export'
+import { normalizeRelationshipScope } from '../relationship-export'
 import {
   computeExportPageLayout,
   EXPORT_DESCRIPTION_BODY_TOP_GAP,
@@ -127,32 +133,137 @@ export function ExportPage() {
 
   useTransparentBackground(!isJpeg)
 
-  const exportDiagram = useMemo(() => {
-    if (!relationships) {
-      return diagram
+  if (relationships) {
+    if (!model.findElement(relationships as never)) {
+      return <NotFound />
     }
-    try {
-      return createRelationshipExportView({
-        model,
-        baseViewId: viewId,
-        subjectId: relationships,
-        scope: normalizeRelationshipScope(relationshipScope),
-      })
-    } catch (error) {
-      console.error(error)
-      return null
-    }
-  }, [diagram, model, relationshipScope, relationships, viewId])
-
-  if (relationships && !exportDiagram) {
-    return <NotFound />
+    return (
+      <RelationshipExportPage
+        subjectId={relationships}
+        viewId={viewId}
+        scope={normalizeRelationshipScope(relationshipScope)}
+        isJpeg={isJpeg}
+      />
+    )
   }
 
-  if (!exportDiagram) {
+  if (!diagram) {
     return <div>Loading...</div>
   }
 
-  return <GuardedExportPage diagram={exportDiagram} isJpeg={isJpeg} />
+  return <GuardedExportPage diagram={diagram} isJpeg={isJpeg} />
+}
+
+/**
+ * Renders relationship-browser image exports through the same visual path as the interactive relationship browser.
+ */
+function RelationshipExportPage({
+  subjectId,
+  viewId,
+  scope,
+  isJpeg,
+}: {
+  subjectId: Parameters<typeof useStaticRelationshipsBrowserView>[0]
+  viewId: Parameters<typeof useStaticRelationshipsBrowserView>[1]
+  scope: Parameters<typeof useStaticRelationshipsBrowserView>[2]
+  isJpeg: boolean
+}) {
+  const {
+    padding = 20,
+    download = false,
+    quality,
+  } = useSearch({
+    strict: false,
+  })
+  const viewportRef = useRef<HTMLDivElement>(null)
+  const loadingOverlayRef = useRef<HTMLDivElement>(null)
+  const downloadedRef = useRef(false)
+  const browserView = useStaticRelationshipsBrowserView(subjectId, viewId, scope)
+  const bounds = browserView.bounds
+  const layout = computeExportPageLayout({
+    bounds,
+    padding,
+    description: null,
+    notationEntries: 0,
+  })
+  const filename = `${viewId}-relationships-${subjectId}`
+
+  const downloadDiagram = () => {
+    const viewport = viewportRef.current
+    if (!download || !viewport || downloadedRef.current) {
+      return
+    }
+    const loadingOverlay = loadingOverlayRef.current
+    if (loadingOverlay) {
+      loadingOverlay.style.display = 'none'
+    }
+    downloadedRef.current = true
+    if (isJpeg) {
+      void downloadAsJpeg({
+        filename,
+        viewport,
+        quality: quality ?? 0.8,
+      })
+    } else {
+      void downloadAsPng({
+        pngFilename: filename,
+        viewport,
+      })
+    }
+  }
+
+  return (
+    <Box
+      ref={viewportRef}
+      data-testid="export-page"
+      css={{
+        position: 'fixed',
+        top: '0',
+        left: '0',
+        padding: '0',
+        margin: '0',
+        overflow: 'hidden',
+        zIndex: 2,
+      }}
+      style={{
+        marginRight: 'auto',
+        marginBottom: 'auto',
+        minWidth: layout.width,
+        width: layout.width,
+        minHeight: layout.height,
+        height: layout.height,
+        background: isJpeg ? 'var(--mantine-color-body)' : 'transparent',
+      }}>
+      {download && <LoadingOverlay ref={loadingOverlayRef} visible />}
+      <Box
+        data-testid="export-diagram-area"
+        css={{
+          position: 'absolute',
+          overflow: 'hidden',
+        }}
+        style={{
+          top: layout.diagram.top,
+          left: layout.diagram.left,
+          width: layout.diagram.width,
+          height: layout.height - layout.diagram.top,
+        }}>
+        <StaticRelationshipsBrowser
+          view={browserView}
+          background={isJpeg ? 'solid' : 'dots'}
+          initialViewport={{
+            x: Math.round(-bounds.x + padding),
+            y: Math.round(-bounds.y + padding),
+            zoom: 1,
+          }}
+          onInitialized={() => {
+            if (download) {
+              window.setTimeout(downloadDiagram, 500)
+            }
+          }}
+        />
+      </Box>
+    </Box>
+  )
 }
 
 /**

--- a/packages/likec4-spa/src/pages/ExportPage.tsx
+++ b/packages/likec4-spa/src/pages/ExportPage.tsx
@@ -5,7 +5,7 @@
 //
 // Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
 
-import { type LayoutedView, type NodeNotation, type RichTextOrEmpty, RichText } from '@likec4/core'
+import { type Fqn, type LayoutedView, type NodeNotation, type RichTextOrEmpty, RichText } from '@likec4/core'
 import {
   LikeC4Diagram,
   pickViewBounds,
@@ -41,6 +41,10 @@ type PaletteCssVars =
     '--likec4-palette-fill' | '--likec4-palette-stroke' | '--likec4-palette-hiContrast' | '--likec4-palette-loContrast',
     string
   >
+
+function isRelationshipSubject(value: unknown): value is Fqn {
+  return typeof value === 'string' && value.length > 0
+}
 
 /**
  * Downloads a generated object URL or data URL through a temporary browser link.
@@ -133,8 +137,8 @@ export function ExportPage() {
 
   useTransparentBackground(!isJpeg)
 
-  if (relationships) {
-    if (!model.findElement(relationships as never)) {
+  if (isRelationshipSubject(relationships)) {
+    if (!model.findElement(relationships)) {
       return <NotFound />
     }
     return (


### PR DESCRIPTION
## Summary

- Export relationship image views through the relationship-browser visual path, so scoped colors, shapes, icons, labels, and relationship edges match the in-app relationship view.
- Keep the detailed relationship graph in image exports instead of falling back to the base diagram view.
- Preserve the compound-edge correction so direct relationships attach to visible compound bounds.

Stacked on #3079.

## Screenshots

Browser relationship view reference for `cloud` with real relationships and labels:

![Browser relationship view reference](https://raw.githubusercontent.com/likec4/likec4/cgk/pr-assets-export-screenshots-20260629/relationship-export-visual-parity/browser-reference-full.png)

Before this PR, focused relationship image export styling fell back to the default blue palette:

![Before relationship export customer styling](https://raw.githubusercontent.com/likec4/likec4/cgk/pr-assets-export-screenshots-20260629/relationship-export-visual-parity/before-customer.png)

After this PR, the exported relationship viewport uses the same relationship-browser styling and edge labels:

![After relationship export viewport](https://raw.githubusercontent.com/likec4/likec4/cgk/pr-assets-export-screenshots-20260629/relationship-export-visual-parity/after-top-edge.png)

Full relationship image export after this PR:

![After relationship export full graph](https://raw.githubusercontent.com/likec4/likec4/cgk/pr-assets-export-screenshots-20260629/relationship-export-visual-parity/after-full.png)

Focused exported node after this PR:

![After relationship export customer styling](https://raw.githubusercontent.com/likec4/likec4/cgk/pr-assets-export-screenshots-20260629/relationship-export-visual-parity/after-customer.png)

## Validation

- `pnpm exec dprint check packages/diagram/src/StaticRelationshipsBrowser.tsx packages/diagram/src/index.ts packages/likec4-spa/src/pages/ExportPage.tsx e2e/tests/search-params.spec.ts`
- `pnpm --filter @likec4/diagram typecheck`
- `pnpm --filter @likec4/spa typecheck`
- `python3 /home/ckeller/src/agent-skills/skills/likec4-license-headers/scripts/apply_likec4_headers.py --check`
- `NODE_ENV=production pnpm --filter @likec4/diagram build && NODE_ENV=production pnpm --filter @likec4/spa build && NODE_ENV=production pnpm --filter likec4 build && NODE_ENV=production pnpm --filter likec4 pack`
- `cd e2e && pnpm install --no-lockfile`
- `cd e2e && pnpm exec playwright test search-params.spec.ts -g "image export keeps relationship browser node styling" --reporter=list --trace=off`
- `cd e2e && pnpm exec playwright test search-params.spec.ts -g "relationship" --reporter=list --trace=off`
