### PR TITLE
 fix(likec4-spa): render view leaf nodes without empty children in sidebar tree

### DIFF
--- a/.changeset/fix-sidebar-tree-empty-children.md
+++ b/.changeset/fix-sidebar-tree-empty-children.md
@@ -1,0 +1,5 @@
+---
+'@likec4/spa': patch
+---
+
+Fixed sidebar navigation drawer rendering every view as an empty expandable folder: view leaf nodes carried an empty `children` array, which Mantine Tree treats as "has children", so views got a folder icon and lost click navigation

--- a/packages/likec4-spa/src/components/sidebar/data.ts
+++ b/packages/likec4-spa/src/components/sidebar/data.ts
@@ -9,7 +9,9 @@ interface DiagramTreeNodeData {
   label: string
   value: string
   type: 'file' | 'folder' | 'view' | 'deployment-view'
-  children: DiagramTreeNodeData[]
+  // Mantine Tree treats any node with a `children` array (even an empty one) as expandable,
+  // so leaf nodes (views) must not have this property
+  children?: DiagramTreeNodeData[]
 }
 
 export type GroupBy = 'by-files' | 'by-folders' | 'none'
@@ -25,10 +27,12 @@ function dropFilename(relativePath: string) {
 }
 
 function compareTreeNodes(a: DiagramTreeNodeData, b: DiagramTreeNodeData) {
-  if (a.children.length === 0 && b.children.length > 0) {
+  const aChildren = a.children?.length ?? 0
+  const bChildren = b.children?.length ?? 0
+  if (aChildren === 0 && bChildren > 0) {
     return 1
   }
-  if (a.children.length > 0 && b.children.length === 0) {
+  if (aChildren > 0 && bChildren === 0) {
     return -1
   }
   return compareNatural(a.label, b.label)
@@ -56,7 +60,7 @@ function buildDiagramTreeData(views: readonly LikeC4ViewModel[], groupBy: GroupB
       let node = find(parent.children!, n => n.value === value)
       if (!node) {
         node = { label, value, type: 'folder', children: [] }
-        parent.children.push(node)
+        parent.children!.push(node)
       }
       parent = node
     }
@@ -79,21 +83,20 @@ function buildDiagramTreeData(views: readonly LikeC4ViewModel[], groupBy: GroupB
         nonexhaustive(groupBy)
     }
     const parent = findParent(relativePath)
-    parent.children.push({
+    parent.children!.push({
       value: view.id,
       label: view.title ?? view.id,
       type: view.isDeploymentView() ? 'deployment-view' : 'view',
-      children: [],
     })
     if (parent !== root) {
-      parent.children.sort(compareTreeNodes)
+      parent.children!.sort(compareTreeNodes)
       if (groupBy === 'by-files' && parent.type !== 'file') {
         parent.type = 'file'
       }
     }
   }
 
-  return root.children.sort(compareTreeNodes)
+  return root.children!.sort(compareTreeNodes)
 }
 
 export function useDiagramsTreeData(groupBy: GroupBy = 'by-files') {


### PR DESCRIPTION
 ## What                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                    
  Fixes the sidebar navigation drawer (overview page) rendering every view as an empty expandable folder.                                                                                                                                           
                                                                                                                                                                                                                                                    
  **Before:** every view in the drawer gets a folder icon, expands into nothing, and clicking it does not navigate. All three grouping modes ("By files" / "By folders" / "List") look broken the same way.                                         
                                                                                                                                                                                                                                                    
  **After:** views render as leaves with the proper view icon and navigate on click; folders and file nodes keep their behavior.                                                                                                                    
                                                                                                                                                                                                                                                    
  ## Why                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                    
  `buildDiagramTreeData` (`packages/likec4-spa/src/components/sidebar/data.ts`) created view leaf nodes with `children: []`. Mantine `Tree` treats any node whose `children` is an array as expandable, even an empty one (see `TreeNode`:          
  `hasChildren = Array.isArray(node.children) || !!node.hasChildren`). So `renderNode` in `DiagramsTree.tsx` received `hasChildren: true` for every view, which switched it to the folder branch: `FolderIcon` instead of the view icon and no      
  `onClick` navigation handler.                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                    
  ## How                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                    
  View leaf nodes no longer carry the `children` property (Mantine's convention for leaves). `compareTreeNodes` guards `children?.length` accordingly. Folder and file nodes are unchanged.                                                         
                                                                                                                                                                                                                                                    
  ## Repro                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                    
  Any project reproduces it: run `likec4 serve`, open the overview page, toggle the navigation drawer. Every view shows up as an empty folder. Verified the fix against our production model (46 views in a single `.c4` file): icons, hover        
  previews, click navigation and all three grouping modes work.                                                                                                                                                                                     
                                                                                                                                                                                                                                                    
  ## Checklist                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                    
  - [x] I've thoroughly read the latest [contribution guidelines](https://github.com/likec4/likec4/blob/main/CONTRIBUTING.md).                                                                                                                      
  - [x] I've rebased my branch onto `main` **before** creating this PR.                                                                                                                                                                             
  - [ ] I've added tests to cover my changes (if applicable).                                                                                                                                                                                       
  - [x] I've verified `pnpm typecheck` and `pnpm test`.                                                                                                                                                                                             
  - [x] I've added [changesets](https://changesets-docs.vercel.app/).                                                                                                                                                                               
  - [ ] My change requires documentation updates.                                                                                                                                                                                                   
  - [ ] I've updated the documentation accordingly (or will do in follow-up PR).                                                                                                                                                                    
                                                                                                                                                                                                                                                    
  🤖 Generated with [Claude Code](https://claude.com/claude-code)