### PR TITLE
fix: honor excludes for include paths

### DIFF
--- a/.changeset/fix-include-path-excludes.md
+++ b/.changeset/fix-include-path-excludes.md
@@ -1,0 +1,5 @@
+---
+'@likec4/language-server': patch
+---
+
+Fix project `exclude` patterns so they also filter matching files loaded through `include.paths`.

--- a/packages/language-server/src/validation/property-checks.ts
+++ b/packages/language-server/src/validation/property-checks.ts
@@ -1,5 +1,5 @@
 import { nonexhaustive } from '@likec4/core'
-import { type ValidationCheck } from 'langium'
+import type { ValidationCheck } from 'langium'
 import { isNumber, isString } from 'remeda'
 import { ast } from '../ast'
 import type { LikeC4Services } from '../module'

--- a/packages/language-server/src/workspace/ProjectsManager.spec.ts
+++ b/packages/language-server/src/workspace/ProjectsManager.spec.ts
@@ -773,6 +773,106 @@ describe('ProjectsManager', () => {
         '/test/workspace/src/projectB/specification.c4',
       ])
     })
+
+    it('should apply exclude patterns to documents from include paths', async ({ expect }) => {
+      const { projectsManager, services, addDocument } = await createMultiProjectTestServices({})
+
+      const projectA = await projectsManager.registerProject({
+        config: {
+          name: 'projectA',
+          exclude: ['**/proj-template.c4**'],
+        },
+        folderUri: URI.parse('file:///test/workspace/src/projectA'),
+      })
+
+      const projectB = await projectsManager.registerProject({
+        config: {
+          name: 'projectB',
+          include: { paths: ['../projectA/projects'] },
+          exclude: ['**/proj-template.c4**'],
+        },
+        folderUri: URI.parse('file:///test/workspace/src/projectB'),
+      })
+
+      const projectADoc = await addDocument('projectA/projects/model.c4', 'specification { element component }')
+      const templateDoc = await addDocument('projectA/projects/proj-template.c4', 'model { component template }')
+      const projectBDoc = await addDocument('projectB/model.c4', 'model { component b }')
+
+      expect(projectsManager.isIncluded(projectA.id, projectADoc)).toBe(true)
+      expect(projectsManager.isIncluded(projectA.id, templateDoc)).toBe(false)
+      expect(projectsManager.isIncluded(projectB.id, projectBDoc)).toBe(true)
+      expect(projectsManager.isIncluded(projectB.id, templateDoc)).toBe(false)
+
+      const documents = services.shared.workspace.LangiumDocuments
+      const projectBDocs = documents.projectDocuments(projectB.id).toArray().map(d => d.uri.path)
+
+      expect(projectBDocs).toEqual([
+        '/test/workspace/src/projectA/projects/model.c4',
+        '/test/workspace/src/projectB/model.c4',
+      ])
+    })
+
+    it('should globally exclude include path documents excluded by all matching projects', async ({ expect }) => {
+      const { projectsManager, services, addDocument } = await createMultiProjectTestServices({})
+
+      const projectB = await projectsManager.registerProject({
+        config: {
+          name: 'projectB',
+          include: { paths: ['../projectA/projects'] },
+          exclude: ['**/proj-template.c4**'],
+        },
+        folderUri: URI.parse('file:///test/workspace/src/projectB'),
+      })
+
+      const projectADoc = await addDocument('projectA/projects/model.c4', 'specification { element component }')
+      const templateDoc = await addDocument('projectA/projects/proj-template.c4', 'model { component template }')
+      const projectBDoc = await addDocument('projectB/model.c4', 'model { component b }')
+
+      expect(projectsManager.isIncluded(projectB.id, projectADoc)).toBe(true)
+      expect(projectsManager.isIncluded(projectB.id, templateDoc)).toBe(false)
+      expect(projectsManager.isIncluded(projectB.id, projectBDoc)).toBe(true)
+      expect(projectsManager.isExcluded(templateDoc)).toBe(true)
+      expect(projectsManager.isIncluded('default' as ProjectId, templateDoc)).toBe(false)
+
+      const documents = services.shared.workspace.LangiumDocuments
+      const userDocs = documents.userDocuments.toArray().map(d => d.uri.path)
+
+      expect(userDocs).toEqual([
+        '/test/workspace/src/projectA/projects/model.c4',
+        '/test/workspace/src/projectB/model.c4',
+      ])
+    })
+
+    it('should anchor globstar exclude patterns to project and include roots', async ({ expect }) => {
+      const { projectsManager, addDocument } = await createMultiProjectTestServices({})
+
+      const projectA = await projectsManager.registerProject({
+        config: {
+          name: 'projectA',
+          exclude: ['**/test/**'],
+        },
+        folderUri: URI.parse('file:///test/workspace/src/projectA'),
+      })
+
+      const projectB = await projectsManager.registerProject({
+        config: {
+          name: 'projectB',
+          include: { paths: ['../shared'] },
+          exclude: ['**/test/**'],
+        },
+        folderUri: URI.parse('file:///test/workspace/src/projectB'),
+      })
+
+      const projectDoc = await addDocument('projectA/model.c4', 'specification { element component }')
+      const projectTestDoc = await addDocument('projectA/nested/test/model.c4', 'model { component ignored }')
+      const includedDoc = await addDocument('shared/model.c4', 'model { component shared }')
+      const includedTestDoc = await addDocument('shared/nested/test/model.c4', 'model { component ignored }')
+
+      expect(projectsManager.isIncluded(projectA.id, projectDoc)).toBe(true)
+      expect(projectsManager.isIncluded(projectA.id, projectTestDoc)).toBe(false)
+      expect(projectsManager.isIncluded(projectB.id, includedDoc)).toBe(true)
+      expect(projectsManager.isIncluded(projectB.id, includedTestDoc)).toBe(false)
+    })
   })
 
   it('should correctly return project for documents', async ({ expect }) => {

--- a/packages/language-server/src/workspace/ProjectsManager.ts
+++ b/packages/language-server/src/workspace/ProjectsManager.ts
@@ -100,6 +100,9 @@ function _includes(project: ProjectData, docUri: NormalizedUri): boolean {
   }
   return false
 }
+function _isInScope(project: ProjectData, docUri: NormalizedUri): boolean {
+  return docUri.startsWith(project.folder) || (project.includePaths?.some(isParentFolderFor(docUri)) ?? false)
+}
 function _excludes(project: ProjectData, docUri: NormalizedUri): boolean {
   return project.exclude?.(withoutProtocol(docUri)) ?? false
 }
@@ -111,6 +114,12 @@ function includes(project: ProjectData, doc: NormalizedUri): boolean
 function includes(doc: NormalizedUri): (project: ProjectData) => boolean
 function includes(...args: unknown[]) {
   return purry(_includes, args)
+}
+
+function isInScope(project: ProjectData, doc: NormalizedUri): boolean
+function isInScope(doc: NormalizedUri): (project: ProjectData) => boolean
+function isInScope(...args: unknown[]) {
+  return purry(_isInScope, args)
 }
 
 /**
@@ -283,6 +292,9 @@ export class ProjectsManager extends ADisposable {
     }
     const owner = this.#ownerOf.get(docuri)
     if (!owner) {
+      if (this.#projects.some(isInScope(docuri))) {
+        return !this.#projects.some(includes(docuri))
+      }
       return isExcludedByDefault(docuri)
     }
     // if the document is excluded by the owner project
@@ -515,7 +527,7 @@ export class ProjectsManager extends ADisposable {
     // - document is not excluded
     if (projectId === ProjectsManager.DefaultProjectId) {
       const owner = this.#ownerOf.get(uri)
-      return !owner && !isExcludedByDefault(uri)
+      return !owner && !this.#excludedDocuments.get(uri)
     }
     const project = this.#projectById.get(projectId)
     return includes(project, uri)
@@ -869,43 +881,45 @@ export class ProjectsManager extends ADisposable {
     delete project.includePaths
     delete project.exclude
 
+    const paths = project.includeConfig.paths
+    if (hasAtLeast(paths, 1)) {
+      // Resolve include paths relative to project folder
+      project.includePaths = map(
+        paths,
+        includePath => {
+          const uri = UriUtils.resolvePath(project.folderUri, includePath)
+          return {
+            uri,
+            folder: ProjectFolder(uri),
+          }
+        },
+      )
+      logger.debug`project ${project.id} include paths: ${project.includePaths.map(p => p.uri.fsPath).join(', ')}`
+    }
+
     // Update exclude patterns
-    switch (true) {
-      case isNullish(config.exclude):
-        project.exclude = DefaultProject.exclude
-        break
-      case config.exclude && hasAtLeast(config.exclude, 1): {
-        const patterns = map(config.exclude, p => {
+    const exclude = config.exclude
+    if (isNullish(exclude)) {
+      project.exclude = DefaultProject.exclude
+    } else if (hasAtLeast(exclude, 1)) {
+      const roots = [project.folderUri, ...map(project.includePaths ?? [], prop('uri'))]
+      const patterns = roots.flatMap(root =>
+        map(exclude, p => {
           if (!isRelative(p) && !p.startsWith('**')) {
             p = joinURL('**', p)
           }
-          return cleanDoubleSlashes(joinRelativeURL(project.folderUri.path, p))
+          return cleanDoubleSlashes(joinRelativeURL(root.path, p))
         })
-        project.exclude = picomatch(patterns, {
-          contains: true,
-          dot: true,
-        })
-        break
-      }
+      )
+      project.exclude = picomatch(patterns, {
+        contains: true,
+        dot: true,
+      })
     }
 
-    const paths = project.includeConfig.paths
-    if (!hasAtLeast(paths, 1)) {
+    if (!project.includePaths) {
       return project
     }
-
-    // Resolve include paths relative to project folder
-    project.includePaths = map(
-      paths,
-      includePath => {
-        const uri = UriUtils.resolvePath(project.folderUri, includePath)
-        return {
-          uri,
-          folder: ProjectFolder(uri),
-        }
-      },
-    )
-    logger.debug`project ${project.id} include paths: ${project.includePaths.map(p => p.uri.fsPath).join(', ')}`
 
     // Check for overlapping include paths with other projects
     for (const includePath of project.includePaths) {


### PR DESCRIPTION
Fixes #2546.

## Summary

- Apply project `exclude` patterns to files loaded through `include.paths`
- Keep globstar excludes scoped to project/include roots
- Prevent excluded external include-path files from leaking into the default project

## Validation

- `npx -y pnpm@11.5.1 --filter @likec4/language-server test`
- `npx -y pnpm@11.5.1 --filter @likec4/language-server typecheck`
- `npx -y pnpm@11.5.1 --filter @likec4/language-server lint`
- `npx -y pnpm@11.5.1 exec dprint check packages/language-server/src/workspace/ProjectsManager.ts packages/language-server/src/workspace/ProjectsManager.spec.ts packages/language-server/src/validation/property-checks.ts`

## Checklist

- [x] I've thoroughly read the latest [contribution guidelines](https://github.com/likec4/likec4/blob/main/CONTRIBUTING.md).
- [x] I've rebased my branch onto `main` **before** creating this PR.
- [x] I've added tests to cover my changes (if applicable).
- [x] I've verified `pnpm typecheck` and `pnpm test`.
- [x] I've added [changesets](https://changesets-docs.vercel.app/) (you can use `/changeset-generator` SKILL).
- [ ] My change requires documentation updates.
- [ ] I've updated the documentation accordingly (or will do in follow-up PR).
