### PR TITLE
fix: keep codegen output inside outdir

### DIFF
--- a/.changeset/fix-codegen-outdir-include-paths.md
+++ b/.changeset/fix-codegen-outdir-include-paths.md
@@ -1,0 +1,5 @@
+---
+'likec4': patch
+---
+
+Keep generated `dot`, `d2`, `mermaid`, and `plantuml` files inside the requested output directory when views come from external include paths.

--- a/packages/likec4/src/cli/codegen/handler.spec.ts
+++ b/packages/likec4/src/cli/codegen/handler.spec.ts
@@ -1,0 +1,133 @@
+import { existsSync } from 'node:fs'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, win32 } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { legacyHandler, relativeOutputDir } from './handler'
+
+type MockView = {
+  id: string
+  sourcePath?: string
+}
+
+type MockModel = {
+  $styles: Record<string, never>
+  $data: {
+    views: Record<string, MockView>
+  }
+}
+
+type MockViewModel = {
+  $view: MockView
+}
+
+type MockLayoutedModel = {
+  views: () => MockViewModel[]
+}
+
+type MockLanguageServices = {
+  computedModel: () => Promise<MockModel>
+  layoutedModel: () => Promise<MockLayoutedModel>
+  ensureSingleProject: () => void
+  viewsService: {
+    computedViews: () => Promise<Array<{ id: string }>>
+    layouter: {
+      dot: () => Promise<string>
+    }
+  }
+}
+
+const fromWorkspace = vi.hoisted(() => vi.fn<() => Promise<MockLanguageServices>>())
+
+vi.mock('@likec4/generators', () => ({
+  generateD2: (vm: MockViewModel) => `d2 ${vm.$view.id}`,
+  generateMermaid: (vm: MockViewModel) => `mermaid ${vm.$view.id}`,
+  generatePuml: (vm: MockViewModel) => `plantuml ${vm.$view.id}`,
+  generateViewsDataTs: () => 'views',
+}))
+
+vi.mock('@likec4/language-services/node', () => ({
+  fromWorkspace,
+}))
+
+const codegenFormats = [
+  { format: 'dot', ext: '.dot' },
+  { format: 'd2', ext: '.d2' },
+  { format: 'mermaid', ext: '.mmd' },
+  { format: 'plantuml', ext: '.puml' },
+] as const
+
+describe('legacy codegen handler', () => {
+  let tmp: string
+  let outdir: string
+
+  beforeEach(async () => {
+    tmp = await mkdtemp(join(tmpdir(), 'likec4-codegen-'))
+    outdir = join(tmp, 'out')
+    const views = {
+      a_view: {
+        id: 'a_view',
+        sourcePath: '../project-a/projects/model.c4',
+      },
+      b_view: {
+        id: 'b_view',
+        sourcePath: 'model.c4',
+      },
+      drive_view: {
+        id: 'drive_view',
+        sourcePath: 'D:/repo/project-a/projects/model.c4',
+      },
+      drive_backslash_view: {
+        id: 'drive_backslash_view',
+        sourcePath: 'D:\\repo\\project-a\\projects\\model.c4',
+      },
+    }
+    const viewModels = Object.values(views).map(view => ({ $view: view }))
+    fromWorkspace.mockResolvedValue({
+      computedModel: vi.fn<() => Promise<MockModel>>().mockResolvedValue({
+        $styles: {},
+        $data: {
+          views,
+        },
+      }),
+      layoutedModel: vi.fn<() => Promise<MockLayoutedModel>>().mockResolvedValue({
+        views: () => viewModels,
+      }),
+      ensureSingleProject: vi.fn<() => void>(),
+      viewsService: {
+        computedViews: vi.fn<() => Promise<Array<{ id: string }>>>().mockResolvedValue(Object.values(views)),
+        layouter: {
+          dot: vi.fn<() => Promise<string>>().mockResolvedValue('digraph {}'),
+        },
+      },
+    })
+  })
+
+  afterEach(async () => {
+    await rm(tmp, { recursive: true, force: true })
+    vi.clearAllMocks()
+  })
+
+  it.each(codegenFormats)('keeps generated $format files inside the requested outdir', async ({ ext, format }) => {
+    await legacyHandler({
+      path: join(tmp, 'project-b'),
+      useDotBin: false,
+      format,
+      outdir,
+    })
+
+    expect(existsSync(join(outdir, 'project-a', 'projects', `a_view${ext}`))).toBe(true)
+    expect(existsSync(join(outdir, 'b_view' + ext))).toBe(true)
+    expect(existsSync(join(outdir, 'repo', 'project-a', 'projects', `drive_view${ext}`))).toBe(true)
+    expect(existsSync(join(outdir, 'repo', 'project-a', 'projects', `drive_backslash_view${ext}`))).toBe(true)
+    expect(existsSync(join(tmp, 'project-a', 'projects', `a_view${ext}`))).toBe(false)
+  })
+
+  it('returns relative output dirs for Windows drive-qualified source paths', () => {
+    expect(relativeOutputDir('D:/repo/project-a/projects/model.c4')).toBe(join('repo', 'project-a', 'projects'))
+    const outputDir = relativeOutputDir('D:\\repo\\project-a\\projects\\model.c4')
+
+    expect(outputDir).toBe(join('repo', 'project-a', 'projects'))
+    expect(win32.resolve('C:\\out', outputDir)).toBe(win32.join('C:\\out', 'repo', 'project-a', 'projects'))
+  })
+})

--- a/packages/likec4/src/cli/codegen/handler.ts
+++ b/packages/likec4/src/cli/codegen/handler.ts
@@ -2,7 +2,7 @@ import { nonexhaustive } from '@likec4/core'
 import { generateD2, generateMermaid, generatePuml, generateViewsDataTs } from '@likec4/generators'
 import { type LikeC4, fromWorkspace } from '@likec4/language-services/node'
 import { mkdir, writeFile } from 'node:fs/promises'
-import { dirname, extname, relative, resolve } from 'node:path'
+import { dirname, extname, join, relative, resolve } from 'node:path'
 import { values } from 'remeda'
 import k from 'tinyrainbow'
 import type { Logger } from 'vite'
@@ -26,6 +26,29 @@ type HandlerParams =
       outdir: string | undefined
     }
   )
+
+export function relativeOutputDir(sourcePath: string | undefined): string {
+  if (!sourcePath) {
+    return '.'
+  }
+  const pathSegments = sourcePath.split(/[\\/]+/)
+  pathSegments.pop()
+  const segments: string[] = []
+  for (const segment of pathSegments) {
+    const withoutDrivePrefix = segment.replace(/^[a-zA-Z]:/, '')
+    switch (withoutDrivePrefix) {
+      case '':
+      case '.':
+        break
+      case '..':
+        segments.pop()
+        break
+      default:
+        segments.push(withoutDrivePrefix)
+    }
+  }
+  return segments.length > 0 ? join(...segments) : '.'
+}
 
 async function singleFileCodegenAction(
   languageServices: LikeC4,
@@ -68,11 +91,7 @@ async function dotCodegenAction(
         view,
         styles: model.$styles,
       })
-      let relativePath = '.'
-      if (view.sourcePath) {
-        relativePath = dirname(view.sourcePath)
-      }
-      relativePath = resolve(outdir, relativePath)
+      const relativePath = resolve(outdir, relativeOutputDir(view.sourcePath))
 
       if (!createdDirs.has(relativePath)) {
         await mkdir(relativePath, { recursive: true })
@@ -129,11 +148,7 @@ async function multipleFilesCodegenAction(
   for (const vm of model.views()) {
     const view = vm.$view
     try {
-      let relativePath = '.'
-      if (view.sourcePath) {
-        relativePath = dirname(view.sourcePath)
-      }
-      relativePath = resolve(outdir, relativePath)
+      const relativePath = resolve(outdir, relativeOutputDir(view.sourcePath))
 
       if (!createdDirs.has(relativePath)) {
         await mkdir(relativePath, { recursive: true })

--- a/packages/likec4/src/cli/codegen/handler.ts
+++ b/packages/likec4/src/cli/codegen/handler.ts
@@ -27,6 +27,11 @@ type HandlerParams =
     }
   )
 
+/**
+ * Computes the output subdirectory for a view from its source path.
+ * Normalizes path separators, strips Windows drive prefixes, and removes `..`
+ * segments so generated files stay under the requested output directory.
+ */
 export function relativeOutputDir(sourcePath: string | undefined): string {
   if (!sourcePath) {
     return '.'


### PR DESCRIPTION
Follow-up to #3093. The scenario was found during integration review for #2546, but #3093 contains the closing `Fixes #2546` reference. This PR stays scoped to the separate codegen outdir escape.

## Summary

- Keeps multi-file codegen outputs inside `--outdir` for views loaded through external include paths.
- Applies to `dot`, `d2`, `mermaid`, and `plantuml` generation.
- Parses source-derived output directories separator-independently before resolving them under `--outdir`.
- Strips Windows drive prefixes from both `D:/...` and `D:\...` style source paths.
- Adds regression coverage for all affected formats and Windows drive-qualified source path cases.
- Documents `relativeOutputDir`, addressing the CodeRabbit nitpick.

## Validation

- `npx -y pnpm@11.5.1 generate`
- `npx -y pnpm@11.5.1 --filter likec4 exec vitest run src/cli/codegen/handler.spec.ts`
- `npx -y pnpm@11.5.1 --filter likec4 typecheck`
- `npx -y pnpm@11.5.1 exec oxlint --type-aware packages/likec4/src/cli/codegen/handler.ts packages/likec4/src/cli/codegen/handler.spec.ts`
- `npx -y pnpm@11.5.1 exec dprint check packages/likec4/src/cli/codegen/handler.ts packages/likec4/src/cli/codegen/handler.spec.ts .changeset/fix-codegen-outdir-include-paths.md`
- `git diff --check`
- Real source CLI smoke: `likec4 gen dot ... -o <tmp-outdir>` kept `a_view.dot` under `<tmp-outdir>/project-a/projects/` and did not create `/tmp/project-a`.
- Real source CLI smoke: `likec4 gen mermaid ... -o <tmp-outdir>` kept `a_view.mmd` under `<tmp-outdir>/project-a/projects/` and did not create `/tmp/project-a`.

## Checklist

- [x] I've thoroughly read the latest [contribution guidelines](https://github.com/likec4/likec4/blob/main/CONTRIBUTING.md).
- [x] I've rebased my branch onto `main` **before** creating this PR.
- [x] I've added tests to cover my changes (if applicable).
- [x] I've verified `pnpm typecheck` and `pnpm test`.
- [x] I've added [changesets](https://changesets-docs.vercel.app/) (you can use `/changeset-generator` SKILL).
- [ ] My change requires documentation updates.
- [ ] I've updated the documentation accordingly (or will do in follow-up PR).
