### PR TITLE
docs: add LikeC4 developer workflow skills

### DIFF
--- a/.agents/skills/likec4-cli-codegen-regression/SKILL.md
+++ b/.agents/skills/likec4-cli-codegen-regression/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: likec4-cli-codegen-regression
+description: Use when changing or reviewing LikeC4 CLI code generation, exporters, output file naming, include-path codegen behavior, or `likec4 gen` commands. Trigger for bugs around `--outdir`, generated files escaping output folders, dot/d2/mermaid/plantuml output, or external include-path views.
+---
+
+# LikeC4 CLI Codegen Regression
+
+Protect `likec4 gen` output contracts with focused tests. The most important invariant is that multi-file generators write every emitted view under the requested output directory.
+
+## Ground rules
+
+- Start in `packages/likec4/src/cli/codegen`.
+- Add a regression test before implementation when fixing a bug.
+- Test every affected multi-file format, not only the format that exposed the issue.
+- Treat external include-path views and Windows paths as first-class edge cases.
+
+## Output-path invariants
+
+For `likec4 gen dot`, `d2`, `mermaid` or `mmd`, and `plantuml`:
+
+- `--outdir` or `-o` defines the containment root for all generated files.
+- Source-relative view paths must never escape the output root.
+- Absolute source paths, parent-relative paths, and Windows drive-root paths must not create files outside `--outdir`.
+- A view coming from an external include path should still be emitted under `--outdir`.
+- Define and assert the resulting output naming contract for escaped or external source paths; containment-only checks are not enough.
+- Single-file generators such as model, react, or webcomponent should keep their existing `--outfile` behavior.
+
+## Regression matrix
+
+Cover the smallest matrix that proves the contract:
+
+| Case                                      | Expected result                                             |
+| ----------------------------------------- | ----------------------------------------------------------- |
+| view in project folder                    | file under `--outdir`                                       |
+| view in nested project folder             | nested file under `--outdir`                                |
+| view from external include path           | file under `--outdir`, not beside the included source       |
+| source path with `..` relation to project | sanitized or re-rooted under `--outdir`                     |
+| Windows drive-style source path           | no drive-root escape such as `C:` output outside `--outdir` |
+| absolute source path                      | no absolute-root escape outside `--outdir`                  |
+
+Formats to consider:
+
+- `.dot`
+- `.d2`
+- `.mmd`
+- `.puml`
+
+## Test shape
+
+Use a temp workspace fixture:
+
+```text
+workspace/
+  project-a/
+    likec4.config.ts
+    project-view.c4
+  shared/
+    included-view.c4
+  out/
+```
+
+Configure `project-a` to include `../shared`. Run each generator with `--outdir workspace/out`.
+
+Assert:
+
+- expected files exist inside `workspace/out`
+- escaped or external source paths use the explicitly chosen output naming contract
+- no generated file exists under `project-a`, `shared`, or the temp workspace root outside `out`
+- all generated paths pass an `isInside(outdir, filepath)` style check
+
+If the real fixture cannot produce absolute or Windows drive-style `sourcePath` values, extract a small path-resolution helper and cover those cases with pure unit tests.
+
+## Focused commands
+
+```bash
+pnpm --filter likec4 test -- codegen
+pnpm --filter likec4 typecheck
+pnpm exec dprint check packages/likec4/src/cli/codegen
+git diff --check
+```
+
+If touching shared path utilities, also run the package tests that own those utilities.

--- a/.agents/skills/likec4-gh-pr-triage/SKILL.md
+++ b/.agents/skills/likec4-gh-pr-triage/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: likec4-gh-pr-triage
+description: Use when checking LikeC4 GitHub issues, mentions, PR status, review comments, CodeRabbit feedback, reviewer requests, or terse status follow-ups with `gh`.
+---
+
+# LikeC4 GitHub PR Triage
+
+Use `gh` and local git as the source of truth. Browser automation is a fallback only when explicitly requested or `gh` cannot answer.
+
+## Ground rules
+
+- Re-check live state before reporting readiness, mergeability, reviews, or comments.
+- Keep `status` replies compact: PR number, checks, review state, blocker.
+- Do not post comments, mark ready, request reviewers, close issues, or merge unless the user explicitly asks.
+- Preserve unrelated local files. In mixed worktrees, stage explicit paths only.
+
+## Identify the active PR
+
+```bash
+git status -sb
+git branch --show-current
+gh pr view "$(git branch --show-current)" --repo likec4/likec4 \
+  --json number,title,url,headRefName,baseRefName,state,isDraft,reviewDecision,mergeStateStatus,reviewRequests
+```
+
+If the current branch has no PR, ask whether to inspect a specific PR number or create one.
+
+## Check assigned issues and mentions
+
+Set the target login from the request or live GitHub context. Do not hard-code personal usernames.
+
+```bash
+GITHUB_LOGIN=<github-login>
+REPO=likec4/likec4
+
+gh api -X GET search/issues --paginate \
+  --raw-field q="repo:${REPO} is:issue assignee:${GITHUB_LOGIN}" \
+  --raw-field per_page=100
+gh api -X GET search/issues --paginate \
+  --raw-field q="repo:${REPO} is:issue mentions:${GITHUB_LOGIN}" \
+  --raw-field per_page=100
+gh api -X GET search/issues --paginate \
+  --raw-field q="repo:${REPO} is:issue is:open mentions:${GITHUB_LOGIN}" \
+  --raw-field per_page=100
+```
+
+Use `gh api 'notifications?...'` only for the authenticated user; notifications do not answer arbitrary-login mention searches.
+
+For exact context:
+
+```bash
+gh issue view ISSUE --repo likec4/likec4 --comments
+gh api repos/likec4/likec4/issues/ISSUE/timeline --paginate
+```
+
+Search issue bodies, comments, and timeline entries for exact mention locations.
+
+## Check PR health
+
+```bash
+gh pr view PR --repo likec4/likec4 \
+  --json number,title,url,isDraft,reviewDecision,mergeStateStatus,reviewRequests,statusCheckRollup,latestReviews
+gh pr checks PR --repo likec4/likec4 --watch=false
+```
+
+`REVIEW_REQUIRED` means human review still blocks. `BLOCKED` with green checks usually means required review or branch protection.
+
+## Check review comments
+
+```bash
+gh pr view PR --repo likec4/likec4 --comments
+gh api repos/likec4/likec4/pulls/PR/comments --paginate
+```
+
+Filter by reviewer or bot only after resolving the current login from PR comments or review metadata.
+
+If counts disagree with GitHub UI, inspect review threads with GraphQL; resolved/outdated line comments may not show in simple comment views.
+
+## Common requested actions
+
+- Trigger CodeRabbit only when requested by posting a PR comment such as `@coderabbitai review`.
+- Mark ready only when requested and after checking branch state and validation.
+- Add reviewers only when requested, for example:
+
+```bash
+gh pr edit PR --repo likec4/likec4 --add-reviewer REVIEWER_LOGIN
+```
+
+## Reporting format
+
+For status:
+
+```text
+PR #NNNN: checks pass/fail, review state, merge state. Open blocker: ...
+```
+
+For comment triage:
+
+```text
+Open comments:
+- reviewer: actionable summary, file/path if known
+No action needed:
+- reviewer: reason
+```
+
+For mention triage:
+
+```text
+LOGIN is mentioned in <total> issue(s); <open_count> remain open.
+- #NNNN <title> — mentioned in <body/comment/timeline>; current action/blocker; URL
+```

--- a/.agents/skills/likec4-gh-pr-triage/SKILL.md
+++ b/.agents/skills/likec4-gh-pr-triage/SKILL.md
@@ -30,7 +30,7 @@ If the current branch has no PR, ask whether to inspect a specific PR number or 
 Set the target login from the request or live GitHub context. Do not hard-code personal usernames.
 
 ```bash
-GITHUB_LOGIN=<github-login>
+GITHUB_LOGIN='REPLACE_WITH_GITHUB_LOGIN'
 REPO=likec4/likec4
 
 gh api -X GET search/issues --paginate \

--- a/.agents/skills/likec4-issue-repro/SKILL.md
+++ b/.agents/skills/likec4-issue-repro/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: likec4-issue-repro
+description: Use when reproducing, diagnosing, or verifying a reported LikeC4 bug from a GitHub issue or user report. Trigger for tasks asking whether an issue can be reproduced, requesting a minimal repro, checking bug reports, or turning a reproduction into a focused regression test.
+---
+
+# LikeC4 Issue Reproduction
+
+Reproduce with the smallest fixture that exercises the reported behavior, then give a direct yes/no with evidence.
+
+## Ground rules
+
+- Prefer live GitHub issue data from `gh issue view ISSUE --repo likec4/likec4 --comments`.
+- Keep fixtures outside unrelated source changes, usually in a temp directory or a focused test fixture.
+- Do not churn dependencies. If `pnpm` fails unexpectedly, check disk space before reinstalling.
+- If reproduction is blocked, report the exact blocker and the next command that would prove it.
+
+## Route the issue
+
+Use the report symptoms to choose the likely code area:
+
+| Symptom                                                     | Start here                                                        |
+| ----------------------------------------------------------- | ----------------------------------------------------------------- |
+| `likec4 gen`, exporters, `--outdir`, generated files        | `packages/likec4/src/cli/codegen`                                 |
+| `likec4.config`, project discovery, include paths, excludes | `packages/language-server/src/workspace`                          |
+| DSL parsing, validation, completions, imports               | `packages/language-server`                                        |
+| computed views, predicates, relationships                   | `packages/core`                                                   |
+| diagram rendering, browser behavior, embedded UI            | `packages/diagram`, `packages/likec4-spa`, `packages/vite-plugin` |
+
+If the route is codegen or project config, also use the corresponding LikeC4 repo skill.
+
+## Reproduction workflow
+
+1. Capture the exact report:
+
+```bash
+gh issue view ISSUE --repo likec4/likec4 --comments
+```
+
+2. Build a minimal fixture:
+
+- one `likec4.config.*` if project scope matters
+- one `specification` block with only required kinds
+- one `model` block with the smallest failing element or relationship shape
+- one `views` block only if rendering or codegen needs it
+
+3. Run the narrowest command that exercises the failure.
+
+Examples:
+
+```bash
+pnpm --filter @likec4/language-server test -- ProjectsManager.spec.ts
+pnpm --filter likec4 test -- codegen
+pnpm --filter @likec4/core test -- relationship
+pnpm --filter @likec4/diagram test -- path/to/spec
+```
+
+4. If reproducible, add or update a focused regression test before changing implementation.
+
+5. Re-run the focused test, then expand only as risk requires:
+
+```bash
+pnpm --filter PACKAGE test -- SPEC_OR_PATTERN
+pnpm --filter PACKAGE typecheck
+pnpm exec dprint check CHANGED_FILES
+git diff --check
+```
+
+## Evidence to report
+
+Use this format:
+
+```text
+Reproduced: yes/no.
+Fixture: path or short description.
+Failing command: exact command and relevant failure.
+Fix verification: exact command that passed.
+Remaining risk: anything not covered.
+```

--- a/.agents/skills/likec4-project-config-workflow/SKILL.md
+++ b/.agents/skills/likec4-project-config-workflow/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: likec4-project-config-workflow
+description: Use when changing or reviewing LikeC4 project discovery, `likec4.config` handling, include paths, excludes, workspace folders, document ownership, or `ProjectsManager` behavior. Trigger for bugs about multi-project workflows, excluded files, included external folders, default project ownership, or Windows path matching.
+---
+
+# LikeC4 Project Config Workflow
+
+Project ownership and exclusion rules are subtle. Preserve the distinction between "which project owns this document" and "is this document included for this project".
+
+## Ground rules
+
+- Start in `packages/language-server/src/workspace/ProjectsManager.ts`.
+- Check callers in `WorkspaceManager.ts`, `LangiumDocuments.ts`, and model parsing before changing semantics.
+- Prefer focused `ProjectsManager.spec.ts` coverage before implementation.
+- Keep Windows path behavior covered when touching path normalization or folder matching.
+
+## Concepts to preserve
+
+- A LikeC4 project is defined by config files such as `.likec4rc` or `likec4.config.*`.
+- The nearest config normally determines project ownership.
+- `include.paths` adds source roots for a project; paths are resolved relative to the project folder.
+- Project-level `exclude` affects that project, but another project may still include the same physical file.
+- Workspace-level excludes take precedence over project-level inclusion.
+- Default excludes such as `node_modules` still apply where no explicit project rule overrides them.
+
+Important distinction:
+
+- `ownerProjectId(document)` answers ownership.
+- `isExcluded(projectId, document)` answers exclusion for a specific project.
+- `isExcluded(document)` answers whether the document should be skipped in the effective owner context.
+
+## Regression matrix
+
+Add or update tests for the relevant rows:
+
+| Case                                                     | What to assert                                                 |
+| -------------------------------------------------------- | -------------------------------------------------------------- |
+| nested projects                                          | nearest config wins                                            |
+| sibling projects with similar prefixes                   | `qwe` does not own `qwe-qwe`                                   |
+| include path outside project folder                      | included document participates in the including project        |
+| document excluded by project A but included by project B | project-specific exclusion differs by project                  |
+| shared include path                                      | deterministic owner and no duplicate document processing       |
+| include path removed on reload                           | stale include ownership disappears                             |
+| workspace startup scanning                               | include-path documents are loaded before project docs use them |
+| workspace exclude                                        | excluded even if project config includes it                    |
+| Windows paths                                            | drive and backslash paths match expected project               |
+
+## Focused commands
+
+```bash
+pnpm --filter @likec4/language-server test -- ProjectsManager.spec.ts
+pnpm --filter @likec4/language-server test -- WorkspaceManager.spec.ts
+pnpm --filter @likec4/language-server typecheck
+pnpm exec dprint check packages/language-server/src/workspace
+git diff --check
+```
+
+If a unit test manually adds the document, also test the workspace-startup path. Manual document injection can pass while real include-path scanning still drops the file.
+
+## PR evidence
+
+Report:
+
+- the reproduced project/include/exclude scenario
+- the focused test name
+- whether Windows path behavior was covered
+- any intentionally unchanged behavior

--- a/.agents/skills/likec4-project-config-workflow/SKILL.md
+++ b/.agents/skills/likec4-project-config-workflow/SKILL.md
@@ -49,7 +49,6 @@ Add or update tests for the relevant rows:
 
 ```bash
 pnpm --filter @likec4/language-server test -- ProjectsManager.spec.ts
-pnpm --filter @likec4/language-server test -- WorkspaceManager.spec.ts
 pnpm --filter @likec4/language-server typecheck
 pnpm exec dprint check packages/language-server/src/workspace
 git diff --check

--- a/.claude/skills/likec4-cli-codegen-regression
+++ b/.claude/skills/likec4-cli-codegen-regression
@@ -1,0 +1,1 @@
+../../.agents/skills/likec4-cli-codegen-regression

--- a/.claude/skills/likec4-gh-pr-triage
+++ b/.claude/skills/likec4-gh-pr-triage
@@ -1,0 +1,1 @@
+../../.agents/skills/likec4-gh-pr-triage

--- a/.claude/skills/likec4-issue-repro
+++ b/.claude/skills/likec4-issue-repro
@@ -1,0 +1,1 @@
+../../.agents/skills/likec4-issue-repro

--- a/.claude/skills/likec4-project-config-workflow
+++ b/.claude/skills/likec4-project-config-workflow
@@ -1,0 +1,1 @@
+../../.agents/skills/likec4-project-config-workflow

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,7 +106,7 @@ Treat round trips such as `fromWorkspace → toDSL → fromSource` as one-way ge
 - `pnpm lint:fix` applies oxlint fixes.
 - `pnpm fmt` formats with dprint.
 - `pnpm test:e2e` runs Playwright tests from the isolated `e2e` workspace and takes longer than unit tests.
-- `pnpm check:agent-instructions` validates that this file remains canonical and adapters do not drift.
+- `pnpm check:agent-instructions` validates that this file remains canonical and that instruction and skill adapters do not drift.
 
 ## Generated Files
 
@@ -160,6 +160,7 @@ Always run `pnpm generate` after checkout, when generated files are missing, aft
 
 - AGENTS.md is the canonical shared repository instruction file.
 - The root `CLAUDE.md` file is the Claude Code adapter and must contain exactly `@AGENTS.md`.
+- Nested `CLAUDE.md` files are not shared adapters. Keep one only when Claude Code's lazy-loaded subtree memory adds materially local context that would be noisy globally. Currently `packages/diagram/src/likec4diagram/xyflow-sequence/CLAUDE.md` is allowed for the sequence layouter workbench.
 - Tools with native `AGENTS.md` support should read `AGENTS.md` directly.
 - Tool-specific files with import support should import `AGENTS.md`.
 - Tools without import support may use generated plain-text adapters derived from `AGENTS.md`, but those adapters must be generated and checked for drift.
@@ -169,6 +170,10 @@ Always run `pnpm generate` after checkout, when generated files are missing, aft
 - `.github/agents/*.agent.md` files may remain only as task-specific wrappers. Shared repository policy must live here in `AGENTS.md`.
 - VS Code and GitHub Copilot coding-agent/code-review surfaces can consume `AGENTS.md`. Do not add `.github/copilot-instructions.md`; any future adapter must be generated from `AGENTS.md` and added together with drift validation.
 - The `.cursor/` directory is gitignored. Contributors may add local `.cursor/rules/` files for personal use, but do not commit them.
+- Repo-local developer workflow skills live in `.agents/skills/`.
+- The public LikeC4 DSL skill lives in `skills/likec4-dsl/`.
+- Claude Code discovers project skills from `.claude/skills/`; keep each tracked `.claude/skills/*` entry as a per-skill symlink to one canonical skill directory.
+- Do not duplicate skill bodies into `.claude/skills/`; add or update the symlink adapter and `devops/check-agent-skills.mjs` together.
 - Use `.tool-versions` for expected Node and pnpm versions.
 - Pre-commit hooks use `nano-staged` to run dprint on staged files.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,7 +160,7 @@ Always run `pnpm generate` after checkout, when generated files are missing, aft
 
 - AGENTS.md is the canonical shared repository instruction file.
 - The root `CLAUDE.md` file is the Claude Code adapter and must contain exactly `@AGENTS.md`.
-- Nested `CLAUDE.md` files are not shared adapters. Keep one only when Claude Code's lazy-loaded subtree memory adds materially local context that would be noisy globally. Currently `packages/diagram/src/likec4diagram/xyflow-sequence/CLAUDE.md` is allowed for the sequence layouter workbench.
+- Nested `CLAUDE.md` files are not shared adapters. Keep one only when Claude Code's lazy-loaded subtree memory should point agents at a materially local section of AGENTS.md; it must import AGENTS.md and contain only a short pointer, not copied rules. Currently `packages/diagram/src/likec4diagram/xyflow-sequence/CLAUDE.md` is allowed for the sequence layouter workbench.
 - Tools with native `AGENTS.md` support should read `AGENTS.md` directly.
 - Tool-specific files with import support should import `AGENTS.md`.
 - Tools without import support may use generated plain-text adapters derived from `AGENTS.md`, but those adapters must be generated and checked for drift.

--- a/devops/check-agent-instructions.mjs
+++ b/devops/check-agent-instructions.mjs
@@ -73,10 +73,19 @@ if (existsSync(absolute('AGENT.md'))) {
   fail('Do not create root AGENT.md; use AGENTS.md')
 }
 
+const allowedNestedClaudeFiles = new Set([
+  'packages/diagram/src/likec4diagram/xyflow-sequence/CLAUDE.md',
+])
 const trackedClaudeFiles = tracked.filter(file => path.basename(file) === 'CLAUDE.md')
-const unexpectedClaudeFiles = trackedClaudeFiles.filter(file => file !== 'CLAUDE.md')
+const unexpectedClaudeFiles = trackedClaudeFiles.filter(file =>
+  file !== 'CLAUDE.md' && !allowedNestedClaudeFiles.has(file)
+)
 if (unexpectedClaudeFiles.length > 0) {
-  fail(`Only root CLAUDE.md is allowed; remove package adapters: ${unexpectedClaudeFiles.join(', ')}`)
+  fail(
+    `Only root CLAUDE.md and explicitly allowed localized Claude memories are allowed; remove package adapters: ${
+      unexpectedClaudeFiles.join(', ')
+    }`,
+  )
 }
 
 if (isTracked('.github/copilot-instructions.md')) {
@@ -119,6 +128,7 @@ if (existsSync(absolute('AGENTS.md'))) {
   const requiredPhrases = [
     'AGENTS.md is the canonical shared repository instruction file.',
     'The root `CLAUDE.md` file is the Claude Code adapter and must contain exactly `@AGENTS.md`.',
+    'Nested `CLAUDE.md` files are not shared adapters. Keep one only when Claude Code\'s lazy-loaded subtree memory adds materially local context that would be noisy globally.',
     'Do not create `AGENT.md`.',
     'Do not use symlink adapters for shared repository instructions; this repository has Windows CI and Windows contributors.',
     'Always use `patch` changesets; versioning is handled manually by maintainers.',

--- a/devops/check-agent-instructions.mjs
+++ b/devops/check-agent-instructions.mjs
@@ -73,8 +73,11 @@ if (existsSync(absolute('AGENT.md'))) {
   fail('Do not create root AGENT.md; use AGENTS.md')
 }
 
-const allowedNestedClaudeFiles = new Set([
-  'packages/diagram/src/likec4diagram/xyflow-sequence/CLAUDE.md',
+const allowedNestedClaudeFiles = new Map([
+  [
+    'packages/diagram/src/likec4diagram/xyflow-sequence/CLAUDE.md',
+    '@../../../../../AGENTS.md\n\nClaude Code local memory: use the `### packages/diagram/src/likec4diagram/xyflow-sequence` section in the imported root `AGENTS.md`; do not duplicate the sequence-layouter rules here.\n',
+  ],
 ])
 const trackedClaudeFiles = tracked.filter(file => path.basename(file) === 'CLAUDE.md')
 const unexpectedClaudeFiles = trackedClaudeFiles.filter(file =>
@@ -86,6 +89,17 @@ if (unexpectedClaudeFiles.length > 0) {
       unexpectedClaudeFiles.join(', ')
     }`,
   )
+}
+
+for (const [relativePath, expectedContent] of allowedNestedClaudeFiles) {
+  if (!isTracked(relativePath)) {
+    continue
+  }
+
+  const content = stripCarriageReturns(read(relativePath))
+  if (content !== expectedContent) {
+    fail(`${relativePath} must import AGENTS.md and contain only the approved local pointer`)
+  }
 }
 
 if (isTracked('.github/copilot-instructions.md')) {
@@ -128,7 +142,7 @@ if (existsSync(absolute('AGENTS.md'))) {
   const requiredPhrases = [
     'AGENTS.md is the canonical shared repository instruction file.',
     'The root `CLAUDE.md` file is the Claude Code adapter and must contain exactly `@AGENTS.md`.',
-    'Nested `CLAUDE.md` files are not shared adapters. Keep one only when Claude Code\'s lazy-loaded subtree memory adds materially local context that would be noisy globally.',
+    'Nested `CLAUDE.md` files are not shared adapters. Keep one only when Claude Code\'s lazy-loaded subtree memory should point agents at a materially local section of AGENTS.md; it must import AGENTS.md and contain only a short pointer, not copied rules.',
     'Do not create `AGENT.md`.',
     'Do not use symlink adapters for shared repository instructions; this repository has Windows CI and Windows contributors.',
     'Always use `patch` changesets; versioning is handled manually by maintainers.',

--- a/devops/check-agent-instructions.spec.mjs
+++ b/devops/check-agent-instructions.spec.mjs
@@ -104,12 +104,18 @@ describe('check-agent-instructions', () => {
     )
   })
 
-  it('rejects nested Claude adapters', () => {
+  it('accepts the localized sequence layouter Claude memory', () => {
+    expectPass(createFixture({
+      'packages/diagram/src/likec4diagram/xyflow-sequence/CLAUDE.md': '# Sequence Layouter\n',
+    }))
+  })
+
+  it('rejects unexpected nested Claude adapters', () => {
     expectFail(
       createFixture({
         'packages/core/CLAUDE.md': '@../../AGENTS.md\n',
       }),
-      /Only root CLAUDE\.md is allowed/,
+      /Only root CLAUDE\.md and explicitly allowed localized Claude memories are allowed/,
     )
   })
 

--- a/devops/check-agent-instructions.spec.mjs
+++ b/devops/check-agent-instructions.spec.mjs
@@ -8,6 +8,8 @@ import { afterEach, describe, it } from 'node:test'
 const repoRoot = path.resolve(import.meta.dirname, '..')
 const checker = path.join(repoRoot, 'devops/check-agent-instructions.mjs')
 const canonicalAgents = readFileSync(path.join(repoRoot, 'AGENTS.md'), 'utf8')
+const sequenceLayouterClaude =
+  '@../../../../../AGENTS.md\n\nClaude Code local memory: use the `### packages/diagram/src/likec4diagram/xyflow-sequence` section in the imported root `AGENTS.md`; do not duplicate the sequence-layouter rules here.\n'
 
 const tempRoots = []
 
@@ -106,8 +108,28 @@ describe('check-agent-instructions', () => {
 
   it('accepts the localized sequence layouter Claude memory', () => {
     expectPass(createFixture({
-      'packages/diagram/src/likec4diagram/xyflow-sequence/CLAUDE.md': '# Sequence Layouter\n',
+      'packages/diagram/src/likec4diagram/xyflow-sequence/CLAUDE.md': sequenceLayouterClaude,
     }))
+  })
+
+  it('rejects duplicated localized Claude memory content', () => {
+    expectFail(
+      createFixture({
+        'packages/diagram/src/likec4diagram/xyflow-sequence/CLAUDE.md':
+          '# Sequence Layouter\n\nThis directory is a development copy of the sequence layouter from `@likec4/layouts`.\n',
+      }),
+      /must import AGENTS\.md and contain only the approved local pointer/,
+    )
+  })
+
+  it('rejects missing AGENTS import in localized Claude memory', () => {
+    expectFail(
+      createFixture({
+        'packages/diagram/src/likec4diagram/xyflow-sequence/CLAUDE.md':
+          'Claude Code local memory: use the sequence layouter section in AGENTS.md.\n',
+      }),
+      /must import AGENTS\.md and contain only the approved local pointer/,
+    )
   })
 
   it('rejects unexpected nested Claude adapters', () => {

--- a/devops/check-agent-skills.mjs
+++ b/devops/check-agent-skills.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+import { execFileSync } from 'node:child_process'
+import { existsSync, lstatSync, readlinkSync } from 'node:fs'
+import path from 'node:path'
+
+const root = execFileSync('git', ['rev-parse', '--show-toplevel'], {
+  encoding: 'utf8',
+}).trim()
+
+const trackedEntries = execFileSync('git', ['ls-files', '-s'], {
+  cwd: root,
+  encoding: 'utf8',
+}).split('\n').filter(Boolean).map(line => {
+  const match = line.match(/^(\d{6}) [0-9a-f]+ \d\t(.+)$/)
+  if (!match) {
+    throw new Error(`Unexpected git ls-files output: ${line}`)
+  }
+  return {
+    mode: match[1],
+    file: match[2],
+  }
+})
+
+const tracked = new Map(trackedEntries.map(entry => [entry.file, entry]))
+const failures = []
+
+const expectedClaudeSkillLinks = new Map([
+  ['.claude/skills/add-new-element-shape', '../../.agents/skills/add-new-element-shape'],
+  ['.claude/skills/changeset-generator', '../../.agents/skills/changeset-generator'],
+  ['.claude/skills/dispatching-parallel-agents', '../../.agents/skills/dispatching-parallel-agents'],
+  ['.claude/skills/likec4-cli-codegen-regression', '../../.agents/skills/likec4-cli-codegen-regression'],
+  ['.claude/skills/likec4-dsl', '../../skills/likec4-dsl'],
+  ['.claude/skills/likec4-gh-pr-triage', '../../.agents/skills/likec4-gh-pr-triage'],
+  ['.claude/skills/likec4-issue-repro', '../../.agents/skills/likec4-issue-repro'],
+  ['.claude/skills/likec4-project-config-workflow', '../../.agents/skills/likec4-project-config-workflow'],
+  ['.claude/skills/refactor', '../../.agents/skills/refactor'],
+])
+
+const fail = message => failures.push(message)
+const absolute = relativePath => path.join(root, relativePath)
+const gitPathJoin = (...segments) => path.posix.normalize(path.posix.join(...segments))
+
+const trackedClaudeSkillEntries = [...tracked.keys()].filter(file => file.startsWith('.claude/skills/'))
+const unexpectedClaudeSkillEntries = trackedClaudeSkillEntries.filter(file => !expectedClaudeSkillLinks.has(file))
+
+if (unexpectedClaudeSkillEntries.length > 0) {
+  for (const file of unexpectedClaudeSkillEntries) {
+    const adapterPath = file.split('/').slice(0, 3).join('/')
+    if (expectedClaudeSkillLinks.has(adapterPath)) {
+      fail(`${adapterPath} must be tracked as a symlink; do not track nested files under it: ${file}`)
+    } else {
+      fail(`Unexpected tracked Claude skill adapter: ${file}`)
+    }
+  }
+}
+
+for (const [linkPath, expectedTarget] of expectedClaudeSkillLinks) {
+  const entry = tracked.get(linkPath)
+  if (!entry) {
+    fail(`${linkPath} must be tracked as a Claude skill symlink adapter`)
+    continue
+  }
+
+  if (entry.mode !== '120000') {
+    fail(`${linkPath} must be tracked as a symlink, but git mode is ${entry.mode}`)
+    continue
+  }
+
+  const absoluteLinkPath = absolute(linkPath)
+  if (!existsSync(absoluteLinkPath)) {
+    fail(`${linkPath} must exist`)
+    continue
+  }
+
+  if (!lstatSync(absoluteLinkPath).isSymbolicLink()) {
+    fail(`${linkPath} must be a filesystem symlink`)
+    continue
+  }
+
+  const actualTarget = readlinkSync(absoluteLinkPath)
+  if (actualTarget !== expectedTarget) {
+    fail(`${linkPath} must point to ${expectedTarget}, but points to ${actualTarget}`)
+    continue
+  }
+
+  const targetDir = gitPathJoin(path.posix.dirname(linkPath), actualTarget)
+  const targetSkillFile = gitPathJoin(targetDir, 'SKILL.md')
+  if (!tracked.has(targetSkillFile)) {
+    fail(`${linkPath} target must contain tracked ${targetSkillFile}`)
+  }
+  if (!existsSync(absolute(targetSkillFile))) {
+    fail(`${linkPath} target must contain existing ${targetSkillFile}`)
+  }
+}
+
+const trackedAgentSkillDirs = new Set(
+  [...tracked.keys()]
+    .filter(file => file.startsWith('.agents/skills/') && file.endsWith('/SKILL.md'))
+    .map(file => file.split('/').slice(0, 3).join('/')),
+)
+
+for (const skillDir of trackedAgentSkillDirs) {
+  const alias = `.claude/skills/${path.posix.basename(skillDir)}`
+  if (!expectedClaudeSkillLinks.has(alias)) {
+    fail(`${skillDir} is tracked but missing an explicit Claude skill symlink adapter`)
+  }
+}
+
+if (failures.length > 0) {
+  console.error('Agent skill validation failed:')
+  for (const failure of failures) {
+    console.error(`- ${failure}`)
+  }
+  process.exit(1)
+}
+
+console.log('Agent skill validation passed')

--- a/devops/check-agent-skills.mjs
+++ b/devops/check-agent-skills.mjs
@@ -2,6 +2,7 @@
 import { execFileSync } from 'node:child_process'
 import { existsSync, lstatSync, readFileSync, readlinkSync } from 'node:fs'
 import path from 'node:path'
+import { parseFrontmatter, validateMetadata } from 'skills-ref'
 
 const root = execFileSync('git', ['rev-parse', '--show-toplevel'], {
   encoding: 'utf8',
@@ -40,55 +41,9 @@ const fail = message => failures.push(message)
 const absolute = relativePath => path.join(root, relativePath)
 const read = relativePath => readFileSync(absolute(relativePath), 'utf8').replace(/\r/g, '')
 const gitPathJoin = (...segments) => path.posix.normalize(path.posix.join(...segments))
-const stripOuterQuotes = value => value.replace(/^['"]|['"]$/g, '')
-
-const parseSkillMetadata = (relativePath, content) => {
-  if (!content.startsWith('---\n')) {
-    fail(`${relativePath} must start with YAML frontmatter`)
-    return undefined
-  }
-
-  const frontmatterEnd = content.indexOf('\n---\n', 4)
-  if (frontmatterEnd === -1) {
-    fail(`${relativePath} must close YAML frontmatter with ---`)
-    return undefined
-  }
-
-  const frontmatter = content.slice(4, frontmatterEnd)
-  const body = content.slice(frontmatterEnd + '\n---\n'.length)
-  const lines = frontmatter.split('\n')
-  const metadata = new Map()
-
-  for (let index = 0; index < lines.length; index++) {
-    const line = lines[index]
-    const match = line.match(/^([A-Za-z0-9_-]+):(?:\s*(.*))?$/)
-    if (!match) {
-      continue
-    }
-
-    const key = match[1]
-    const inlineValue = match[2]?.trim() ?? ''
-    if (inlineValue) {
-      metadata.set(key, stripOuterQuotes(inlineValue))
-      continue
-    }
-
-    const blockLines = []
-    for (let blockIndex = index + 1; blockIndex < lines.length; blockIndex++) {
-      const blockLine = lines[blockIndex]
-      if (/^[A-Za-z0-9_-]+:/.test(blockLine)) {
-        break
-      }
-      if (blockLine.trim()) {
-        blockLines.push(blockLine.trim())
-      }
-      index = blockIndex
-    }
-    metadata.set(key, blockLines.join(' '))
-  }
-
-  return { body, metadata }
-}
+const legacyLikeC4SkillMetadataFields = new Set([
+  'disable-model-invocation',
+])
 
 const validateSkillFile = relativePath => {
   if (!existsSync(absolute(relativePath))) {
@@ -96,27 +51,39 @@ const validateSkillFile = relativePath => {
     return
   }
 
-  const parsed = parseSkillMetadata(relativePath, read(relativePath))
-  if (!parsed) {
+  let metadata
+  let body
+  try {
+    const parsed = parseFrontmatter(read(relativePath))
+    metadata = parsed[0]
+    body = parsed[1]
+  } catch (error) {
+    fail(`${relativePath}: ${error.message}`)
     return
   }
 
   const skillDir = path.posix.dirname(relativePath)
-  const expectedName = path.posix.basename(skillDir)
-  const name = parsed.metadata.get('name')?.trim()
-  const description = parsed.metadata.get('description')?.trim()
-
-  if (!name) {
-    fail(`${relativePath} must define a non-empty name`)
-  } else if (name !== expectedName) {
-    fail(`${relativePath} name must match directory "${expectedName}", but found "${name}"`)
+  const metadataForReferenceValidation = { ...metadata }
+  for (const field of legacyLikeC4SkillMetadataFields) {
+    delete metadataForReferenceValidation[field]
   }
 
-  if (!description) {
-    fail(`${relativePath} must define a non-empty description`)
+  for (const error of validateMetadata(metadataForReferenceValidation, absolute(skillDir))) {
+    fail(`${relativePath}: ${error}`)
   }
 
-  if (!parsed.body.trim()) {
+  if ('name' in metadata && (typeof metadata.name !== 'string' || !metadata.name.trim())) {
+    fail(`${relativePath}: Field 'name' must be a non-empty string`)
+  }
+
+  if (
+    'description' in metadata
+    && (typeof metadata.description !== 'string' || !metadata.description.trim())
+  ) {
+    fail(`${relativePath}: Field 'description' must be a non-empty string`)
+  }
+
+  if (!body.trim()) {
     fail(`${relativePath} must contain a non-empty skill body after frontmatter`)
   }
 }

--- a/devops/check-agent-skills.mjs
+++ b/devops/check-agent-skills.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { execFileSync } from 'node:child_process'
-import { existsSync, lstatSync, readlinkSync } from 'node:fs'
+import { existsSync, lstatSync, readFileSync, readlinkSync } from 'node:fs'
 import path from 'node:path'
 
 const root = execFileSync('git', ['rev-parse', '--show-toplevel'], {
@@ -38,7 +38,88 @@ const expectedClaudeSkillLinks = new Map([
 
 const fail = message => failures.push(message)
 const absolute = relativePath => path.join(root, relativePath)
+const read = relativePath => readFileSync(absolute(relativePath), 'utf8').replace(/\r/g, '')
 const gitPathJoin = (...segments) => path.posix.normalize(path.posix.join(...segments))
+const stripOuterQuotes = value => value.replace(/^['"]|['"]$/g, '')
+
+const parseSkillMetadata = (relativePath, content) => {
+  if (!content.startsWith('---\n')) {
+    fail(`${relativePath} must start with YAML frontmatter`)
+    return undefined
+  }
+
+  const frontmatterEnd = content.indexOf('\n---\n', 4)
+  if (frontmatterEnd === -1) {
+    fail(`${relativePath} must close YAML frontmatter with ---`)
+    return undefined
+  }
+
+  const frontmatter = content.slice(4, frontmatterEnd)
+  const body = content.slice(frontmatterEnd + '\n---\n'.length)
+  const lines = frontmatter.split('\n')
+  const metadata = new Map()
+
+  for (let index = 0; index < lines.length; index++) {
+    const line = lines[index]
+    const match = line.match(/^([A-Za-z0-9_-]+):(?:\s*(.*))?$/)
+    if (!match) {
+      continue
+    }
+
+    const key = match[1]
+    const inlineValue = match[2]?.trim() ?? ''
+    if (inlineValue) {
+      metadata.set(key, stripOuterQuotes(inlineValue))
+      continue
+    }
+
+    const blockLines = []
+    for (let blockIndex = index + 1; blockIndex < lines.length; blockIndex++) {
+      const blockLine = lines[blockIndex]
+      if (/^[A-Za-z0-9_-]+:/.test(blockLine)) {
+        break
+      }
+      if (blockLine.trim()) {
+        blockLines.push(blockLine.trim())
+      }
+      index = blockIndex
+    }
+    metadata.set(key, blockLines.join(' '))
+  }
+
+  return { body, metadata }
+}
+
+const validateSkillFile = relativePath => {
+  if (!existsSync(absolute(relativePath))) {
+    fail(`${relativePath} must exist`)
+    return
+  }
+
+  const parsed = parseSkillMetadata(relativePath, read(relativePath))
+  if (!parsed) {
+    return
+  }
+
+  const skillDir = path.posix.dirname(relativePath)
+  const expectedName = path.posix.basename(skillDir)
+  const name = parsed.metadata.get('name')?.trim()
+  const description = parsed.metadata.get('description')?.trim()
+
+  if (!name) {
+    fail(`${relativePath} must define a non-empty name`)
+  } else if (name !== expectedName) {
+    fail(`${relativePath} name must match directory "${expectedName}", but found "${name}"`)
+  }
+
+  if (!description) {
+    fail(`${relativePath} must define a non-empty description`)
+  }
+
+  if (!parsed.body.trim()) {
+    fail(`${relativePath} must contain a non-empty skill body after frontmatter`)
+  }
+}
 
 const trackedClaudeSkillEntries = [...tracked.keys()].filter(file => file.startsWith('.claude/skills/'))
 const unexpectedClaudeSkillEntries = trackedClaudeSkillEntries.filter(file => !expectedClaudeSkillLinks.has(file))
@@ -99,9 +180,28 @@ const trackedAgentSkillDirs = new Set(
     .map(file => file.split('/').slice(0, 3).join('/')),
 )
 
+const trackedSkillFiles = [...tracked.keys()].filter(file =>
+  (file.startsWith('.agents/skills/') || file.startsWith('skills/')) && file.endsWith('/SKILL.md')
+)
+
+const expectedClaudeSkillTargets = new Set(
+  [...expectedClaudeSkillLinks.entries()].map(([linkPath, expectedTarget]) =>
+    gitPathJoin(path.posix.dirname(linkPath), expectedTarget)
+  ),
+)
+
 for (const skillDir of trackedAgentSkillDirs) {
   const alias = `.claude/skills/${path.posix.basename(skillDir)}`
   if (!expectedClaudeSkillLinks.has(alias)) {
+    fail(`${skillDir} is tracked but missing an explicit Claude skill symlink adapter`)
+  }
+}
+
+for (const skillFile of trackedSkillFiles) {
+  validateSkillFile(skillFile)
+
+  const skillDir = path.posix.dirname(skillFile)
+  if (!expectedClaudeSkillTargets.has(skillDir)) {
     fail(`${skillDir} is tracked but missing an explicit Claude skill symlink adapter`)
   }
 }

--- a/devops/check-agent-skills.spec.mjs
+++ b/devops/check-agent-skills.spec.mjs
@@ -53,9 +53,14 @@ function validSkill(name) {
     ? 'description:\n  Use when testing generated changeset skill metadata'
     : `description: Use when testing ${name} skill metadata`
 
-  const extraMetadata = name === 'refactor' ? 'license: MIT\n' : ''
+  const extraMetadata = [
+    name === 'add-new-element-shape' ? 'disable-model-invocation: true' : '',
+    name === 'refactor' ? 'license: MIT' : '',
+  ].filter(Boolean).join('\n')
 
-  return `---\nname: ${name}\n${description}\n${extraMetadata}---\n\n# ${name}\n\nUse this skill in tests.\n`
+  return `---\nname: ${name}\n${description}\n${
+    extraMetadata ? `${extraMetadata}\n` : ''
+  }---\n\n# ${name}\n\nUse this skill in tests.\n`
 }
 
 function createFixture(customize) {
@@ -146,7 +151,7 @@ describe('check-agent-skills', () => {
       createFixture(root => {
         writeFixtureFile(root, '.agents/skills/likec4-gh-pr-triage/SKILL.md', '# LikeC4 PR triage\n')
       }),
-      /\.agents\/skills\/likec4-gh-pr-triage\/SKILL\.md must start with YAML frontmatter/,
+      /\.agents\/skills\/likec4-gh-pr-triage\/SKILL\.md: SKILL\.md must start with YAML frontmatter/,
     )
   })
 
@@ -159,7 +164,7 @@ describe('check-agent-skills', () => {
           `---\nname: issue-repro\ndescription: Use when testing issue repro metadata\n---\n\n# Issue Repro\n`,
         )
       }),
-      /name must match directory "likec4-issue-repro", but found "issue-repro"/,
+      /Directory name 'likec4-issue-repro' must match skill name 'issue-repro'/,
     )
   })
 
@@ -172,7 +177,20 @@ describe('check-agent-skills', () => {
           `---\nname: likec4-project-config-workflow\ndescription:\n---\n\n# Project Config Workflow\n`,
         )
       }),
-      /\.agents\/skills\/likec4-project-config-workflow\/SKILL\.md must define a non-empty description/,
+      /\.agents\/skills\/likec4-project-config-workflow\/SKILL\.md: Field 'description' must be a non-empty string/,
+    )
+  })
+
+  it('rejects unexpected skill metadata fields', () => {
+    expectFail(
+      createFixture(root => {
+        writeFixtureFile(
+          root,
+          '.agents/skills/likec4-gh-pr-triage/SKILL.md',
+          `---\nname: likec4-gh-pr-triage\ndescription: Use when testing PR triage metadata\nunsupported-field: true\n---\n\n# PR Triage\n`,
+        )
+      }),
+      /Unexpected fields in frontmatter: unsupported-field/,
     )
   })
 

--- a/devops/check-agent-skills.spec.mjs
+++ b/devops/check-agent-skills.spec.mjs
@@ -1,0 +1,133 @@
+import assert from 'node:assert/strict'
+import { execFileSync, spawnSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, it } from 'node:test'
+
+const repoRoot = path.resolve(import.meta.dirname, '..')
+const checker = path.join(repoRoot, 'devops/check-agent-skills.mjs')
+
+const tempRoots = []
+
+const expectedClaudeSkillLinks = new Map([
+  ['.claude/skills/add-new-element-shape', '../../.agents/skills/add-new-element-shape'],
+  ['.claude/skills/changeset-generator', '../../.agents/skills/changeset-generator'],
+  ['.claude/skills/dispatching-parallel-agents', '../../.agents/skills/dispatching-parallel-agents'],
+  ['.claude/skills/likec4-cli-codegen-regression', '../../.agents/skills/likec4-cli-codegen-regression'],
+  ['.claude/skills/likec4-dsl', '../../skills/likec4-dsl'],
+  ['.claude/skills/likec4-gh-pr-triage', '../../.agents/skills/likec4-gh-pr-triage'],
+  ['.claude/skills/likec4-issue-repro', '../../.agents/skills/likec4-issue-repro'],
+  ['.claude/skills/likec4-project-config-workflow', '../../.agents/skills/likec4-project-config-workflow'],
+  ['.claude/skills/refactor', '../../.agents/skills/refactor'],
+])
+
+afterEach(() => {
+  while (tempRoots.length > 0) {
+    rmSync(tempRoots.pop(), { recursive: true, force: true })
+  }
+})
+
+function writeFixtureFile(root, relativePath, content) {
+  const file = path.join(root, relativePath)
+  mkdirSync(path.dirname(file), { recursive: true })
+  writeFileSync(file, content)
+}
+
+function createSymlink(root, relativePath, target) {
+  const link = path.join(root, relativePath)
+  mkdirSync(path.dirname(link), { recursive: true })
+  symlinkSync(target, link, 'dir')
+}
+
+function removeFixturePath(root, relativePath) {
+  rmSync(path.join(root, relativePath), { recursive: true, force: true })
+}
+
+function targetSkillPath(linkPath, target) {
+  return path.posix.join(path.posix.dirname(linkPath), target, 'SKILL.md')
+}
+
+function createFixture(customize) {
+  const root = mkdtempSync(path.join(tmpdir(), 'likec4-agent-skills-check-'))
+  tempRoots.push(root)
+
+  execFileSync('git', ['init', '--initial-branch=main'], { cwd: root, stdio: 'ignore' })
+
+  for (const [linkPath, target] of expectedClaudeSkillLinks) {
+    writeFixtureFile(root, targetSkillPath(linkPath, target), `---\nname: ${path.posix.basename(linkPath)}\n---\n`)
+    createSymlink(root, linkPath, target)
+  }
+
+  customize?.(root)
+
+  execFileSync('git', ['add', '-A'], { cwd: root, stdio: 'ignore' })
+  return root
+}
+
+function runChecker(root) {
+  return spawnSync(process.execPath, [checker], {
+    cwd: root,
+    encoding: 'utf8',
+  })
+}
+
+function expectPass(root) {
+  const result = runChecker(root)
+  assert.equal(result.status, 0, result.stderr)
+  assert.match(result.stdout, /Agent skill validation passed/)
+}
+
+function expectFail(root, message) {
+  const result = runChecker(root)
+  assert.notEqual(result.status, 0, result.stdout)
+  assert.match(result.stderr, message)
+}
+
+describe('check-agent-skills', () => {
+  it('accepts canonical Claude skill symlink adapters', () => {
+    expectPass(createFixture())
+  })
+
+  it('rejects missing Claude skill adapters', () => {
+    expectFail(
+      createFixture(root => {
+        removeFixturePath(root, '.claude/skills/likec4-gh-pr-triage')
+      }),
+      /likec4-gh-pr-triage must be tracked as a Claude skill symlink adapter/,
+    )
+  })
+
+  it('rejects non-symlink Claude skill adapters', () => {
+    expectFail(
+      createFixture(root => {
+        removeFixturePath(root, '.claude/skills/likec4-issue-repro')
+        writeFixtureFile(root, '.claude/skills/likec4-issue-repro/SKILL.md', 'duplicated skill body\n')
+      }),
+      /likec4-issue-repro must be tracked as a symlink/,
+    )
+  })
+
+  it('rejects Claude skill adapters pointing to the wrong target', () => {
+    expectFail(
+      createFixture(root => {
+        removeFixturePath(root, '.claude/skills/likec4-project-config-workflow')
+        createSymlink(
+          root,
+          '.claude/skills/likec4-project-config-workflow',
+          '../../.agents/skills/refactor',
+        )
+      }),
+      /likec4-project-config-workflow must point to \.\.\/\.\.\/\.agents\/skills\/likec4-project-config-workflow/,
+    )
+  })
+
+  it('rejects repo-local skills without explicit Claude adapters', () => {
+    expectFail(
+      createFixture(root => {
+        writeFixtureFile(root, '.agents/skills/local-only/SKILL.md', '---\nname: local-only\n---\n')
+      }),
+      /\.agents\/skills\/local-only is tracked but missing an explicit Claude skill symlink adapter/,
+    )
+  })
+})

--- a/devops/check-agent-skills.spec.mjs
+++ b/devops/check-agent-skills.spec.mjs
@@ -48,6 +48,16 @@ function targetSkillPath(linkPath, target) {
   return path.posix.join(path.posix.dirname(linkPath), target, 'SKILL.md')
 }
 
+function validSkill(name) {
+  const description = name === 'changeset-generator'
+    ? 'description:\n  Use when testing generated changeset skill metadata'
+    : `description: Use when testing ${name} skill metadata`
+
+  const extraMetadata = name === 'refactor' ? 'license: MIT\n' : ''
+
+  return `---\nname: ${name}\n${description}\n${extraMetadata}---\n\n# ${name}\n\nUse this skill in tests.\n`
+}
+
 function createFixture(customize) {
   const root = mkdtempSync(path.join(tmpdir(), 'likec4-agent-skills-check-'))
   tempRoots.push(root)
@@ -55,7 +65,7 @@ function createFixture(customize) {
   execFileSync('git', ['init', '--initial-branch=main'], { cwd: root, stdio: 'ignore' })
 
   for (const [linkPath, target] of expectedClaudeSkillLinks) {
-    writeFixtureFile(root, targetSkillPath(linkPath, target), `---\nname: ${path.posix.basename(linkPath)}\n---\n`)
+    writeFixtureFile(root, targetSkillPath(linkPath, target), validSkill(path.posix.basename(linkPath)))
     createSymlink(root, linkPath, target)
   }
 
@@ -125,9 +135,57 @@ describe('check-agent-skills', () => {
   it('rejects repo-local skills without explicit Claude adapters', () => {
     expectFail(
       createFixture(root => {
-        writeFixtureFile(root, '.agents/skills/local-only/SKILL.md', '---\nname: local-only\n---\n')
+        writeFixtureFile(root, '.agents/skills/local-only/SKILL.md', validSkill('local-only'))
       }),
       /\.agents\/skills\/local-only is tracked but missing an explicit Claude skill symlink adapter/,
+    )
+  })
+
+  it('rejects skill files without frontmatter', () => {
+    expectFail(
+      createFixture(root => {
+        writeFixtureFile(root, '.agents/skills/likec4-gh-pr-triage/SKILL.md', '# LikeC4 PR triage\n')
+      }),
+      /\.agents\/skills\/likec4-gh-pr-triage\/SKILL\.md must start with YAML frontmatter/,
+    )
+  })
+
+  it('rejects skill names that drift from their directory', () => {
+    expectFail(
+      createFixture(root => {
+        writeFixtureFile(
+          root,
+          '.agents/skills/likec4-issue-repro/SKILL.md',
+          `---\nname: issue-repro\ndescription: Use when testing issue repro metadata\n---\n\n# Issue Repro\n`,
+        )
+      }),
+      /name must match directory "likec4-issue-repro", but found "issue-repro"/,
+    )
+  })
+
+  it('rejects skills without descriptions', () => {
+    expectFail(
+      createFixture(root => {
+        writeFixtureFile(
+          root,
+          '.agents/skills/likec4-project-config-workflow/SKILL.md',
+          `---\nname: likec4-project-config-workflow\ndescription:\n---\n\n# Project Config Workflow\n`,
+        )
+      }),
+      /\.agents\/skills\/likec4-project-config-workflow\/SKILL\.md must define a non-empty description/,
+    )
+  })
+
+  it('rejects skills without body content', () => {
+    expectFail(
+      createFixture(root => {
+        writeFixtureFile(
+          root,
+          '.agents/skills/likec4-cli-codegen-regression/SKILL.md',
+          `---\nname: likec4-cli-codegen-regression\ndescription: Use when testing codegen metadata\n---\n`,
+        )
+      }),
+      /\.agents\/skills\/likec4-cli-codegen-regression\/SKILL\.md must contain a non-empty skill body after frontmatter/,
     )
   })
 })

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "oxlint": "catalog:",
     "oxlint-tsgolint": "catalog:",
     "rimraf": "^6.1.3",
+    "skills-ref": "catalog:",
     "tsx": "catalog:",
     "turbo": "catalog:",
     "typescript": "catalog:",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "prepare": "node .husky/install.mjs",
     "fmt": "dprint fmt",
-    "check:agent-instructions": "node --test devops/check-agent-instructions.spec.mjs && node devops/check-agent-instructions.mjs",
+    "check:agent-instructions": "node --test devops/check-agent-instructions.spec.mjs devops/check-agent-skills.spec.mjs && node devops/check-agent-instructions.mjs && node devops/check-agent-skills.mjs",
     "changeset:empty": "changeset --empty",
     "lint": "oxlint",
     "lint:errors-only": "oxlint --quiet",

--- a/packages/diagram/src/likec4diagram/xyflow-sequence/CLAUDE.md
+++ b/packages/diagram/src/likec4diagram/xyflow-sequence/CLAUDE.md
@@ -1,0 +1,36 @@
+# Sequence Layouter — dev workbench
+
+This file is an intentional localized Claude Code memory. Root `AGENTS.md` remains the canonical shared repository instruction file; keep this file focused on the sequence layouter workbench.
+
+This directory is a **development copy** of the sequence layouter from `@likec4/layouts`.
+It lives here only to get Vite HMR while iterating on the layouter in the dev app.
+The canonical, production implementation is `packages/layouts/src/sequence/`.
+
+## How the two copies are used at runtime
+
+- **Production** (`likec4 build`, exports): `GraphvizLayoter` (`packages/layouts/src/graphviz/GraphvizLayoter.ts`) calls `calcSequenceLayout(diagram)` and stores the result in `view.sequenceLayout`. The diagram package only reads it.
+- **Dev**: `sequence-layout.ts` here detects `hasProp(view, 'flow')` and recomputes the layout on the fly via the local `calcSequenceLayout(view, flow)` — that's what makes HMR iteration possible.
+
+If the copies drift, the dev preview silently differs from the production render.
+
+## File map
+
+Mirrored with `packages/layouts/src/sequence/` (keep in sync):
+
+- `_types.ts`, `const.ts`, `layouter.ts`, `sequence-view.ts`, `utils.ts`, `utils.spec.ts`
+
+Local to this directory — do **not** copy to layouts:
+
+- `sequence-layout.ts` — `sequenceLayoutToXY()`, converts the computed layout into XYFlow nodes/edges (consumed by `../convert-to-xyflow.ts`). This is diagram-package glue, not layouter logic.
+- `CLAUDE.md` (this file)
+
+Local to the layouts side: `packages/layouts/src/sequence/index.ts` (public exports).
+
+## Syncing rules
+
+- Direction: iterate **here first**, then port stable changes to `packages/layouts/src/sequence/`.
+- Syncing is **not a blind file copy**. The entry signature intentionally differs: here `calcSequenceLayout(view, flow)` (flow provided by the caller in `sequence-layout.ts`); in layouts `calcSequenceLayout(view)` (computes flow internally, matching the `GraphvizLayoter` call sites). Adapt the signature when porting.
+- `const.ts` exports (`SeqZIndex`, `SeqParallelAreaColor`) are consumed only by the local `sequence-layout.ts`, but the file is mirrored — keep values consistent when syncing.
+- Always `diff` the two directories before syncing — do not assume they are currently identical; work-in-progress changes may exist on either side.
+- After porting, run tests in **both** packages (`utils.spec.ts` exists in each) and typecheck `packages/layouts`.
+- Never import `@likec4/layouts` from `packages/diagram` — the duplication exists precisely to avoid that dependency.

--- a/packages/diagram/src/likec4diagram/xyflow-sequence/CLAUDE.md
+++ b/packages/diagram/src/likec4diagram/xyflow-sequence/CLAUDE.md
@@ -1,36 +1,3 @@
-# Sequence Layouter — dev workbench
+@../../../../../AGENTS.md
 
-This file is an intentional localized Claude Code memory. Root `AGENTS.md` remains the canonical shared repository instruction file; keep this file focused on the sequence layouter workbench.
-
-This directory is a **development copy** of the sequence layouter from `@likec4/layouts`.
-It lives here only to get Vite HMR while iterating on the layouter in the dev app.
-The canonical, production implementation is `packages/layouts/src/sequence/`.
-
-## How the two copies are used at runtime
-
-- **Production** (`likec4 build`, exports): `GraphvizLayoter` (`packages/layouts/src/graphviz/GraphvizLayoter.ts`) calls `calcSequenceLayout(diagram)` and stores the result in `view.sequenceLayout`. The diagram package only reads it.
-- **Dev**: `sequence-layout.ts` here detects `hasProp(view, 'flow')` and recomputes the layout on the fly via the local `calcSequenceLayout(view, flow)` — that's what makes HMR iteration possible.
-
-If the copies drift, the dev preview silently differs from the production render.
-
-## File map
-
-Mirrored with `packages/layouts/src/sequence/` (keep in sync):
-
-- `_types.ts`, `const.ts`, `layouter.ts`, `sequence-view.ts`, `utils.ts`, `utils.spec.ts`
-
-Local to this directory — do **not** copy to layouts:
-
-- `sequence-layout.ts` — `sequenceLayoutToXY()`, converts the computed layout into XYFlow nodes/edges (consumed by `../convert-to-xyflow.ts`). This is diagram-package glue, not layouter logic.
-- `CLAUDE.md` (this file)
-
-Local to the layouts side: `packages/layouts/src/sequence/index.ts` (public exports).
-
-## Syncing rules
-
-- Direction: iterate **here first**, then port stable changes to `packages/layouts/src/sequence/`.
-- Syncing is **not a blind file copy**. The entry signature intentionally differs: here `calcSequenceLayout(view, flow)` (flow provided by the caller in `sequence-layout.ts`); in layouts `calcSequenceLayout(view)` (computes flow internally, matching the `GraphvizLayoter` call sites). Adapt the signature when porting.
-- `const.ts` exports (`SeqZIndex`, `SeqParallelAreaColor`) are consumed only by the local `sequence-layout.ts`, but the file is mirrored — keep values consistent when syncing.
-- Always `diff` the two directories before syncing — do not assume they are currently identical; work-in-progress changes may exist on either side.
-- After porting, run tests in **both** packages (`utils.spec.ts` exists in each) and typecheck `packages/layouts`.
-- Never import `@likec4/layouts` from `packages/diagram` — the duplication exists precisely to avoid that dependency.
+Claude Code local memory: use the `### packages/diagram/src/likec4diagram/xyflow-sequence` section in the imported root `AGENTS.md`; do not duplicate the sequence-layouter rules here.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,6 +154,9 @@ catalogs:
     playwright:
       specifier: 1.60.0
       version: 1.60.0
+    skills-ref:
+      specifier: 0.1.5
+      version: 0.1.5
     tsx:
       specifier: 4.22.5
       version: 4.22.5
@@ -540,6 +543,9 @@ importers:
       rimraf:
         specifier: ^6.1.3
         version: 6.1.3
+      skills-ref:
+        specifier: 'catalog:'
+        version: 0.1.5
       tsx:
         specifier: 'catalog:'
         version: 4.22.5
@@ -7303,6 +7309,10 @@ packages:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
     engines: {node: '>=16'}
 
+  commander@12.1.0:
+    resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
+    engines: {node: '>=18'}
+
   commenting@1.1.0:
     resolution: {integrity: sha512-YeNK4tavZwtH7jEgK1ZINXzLKm6DZdEMfsaaieOsCAN0S8vsY7UeuO3Q7d/M018EFgE+IeUAuBOKkFccBZsUZA==}
 
@@ -10204,6 +10214,11 @@ packages:
   sitemap@9.0.1:
     resolution: {integrity: sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ==}
     engines: {node: '>=20.19.5', npm: '>=10.8.2'}
+    hasBin: true
+
+  skills-ref@0.1.5:
+    resolution: {integrity: sha512-C2vyZbUQqt3PXA9vcdUmJ0lwbH9jK19C9fwQjl/ICPy2e5bzV3CaropViakJCv+HLt/9zsgjZ/NLJ5xEri0jSA==}
+    engines: {node: '>=18.0.0'}
     hasBin: true
 
   slash@3.0.0:
@@ -16218,6 +16233,8 @@ snapshots:
 
   commander@11.1.0: {}
 
+  commander@12.1.0: {}
+
   commenting@1.1.0: {}
 
   common-ancestor-path@2.0.0: {}
@@ -19801,6 +19818,11 @@ snapshots:
       '@types/sax': 1.2.7
       arg: 5.0.2
       sax: 1.6.0
+
+  skills-ref@0.1.5:
+    dependencies:
+      commander: 12.1.0
+      js-yaml: 4.1.1
 
   slash@3.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -53,6 +53,7 @@ catalog:
   oxlint-tsgolint: 0.24.0
   pako: ^2.1.0
   playwright: 1.60.0
+  skills-ref: 0.1.5
   tsx: 4.22.5
   turbo: 2.10.5
   typescript: 6.0.3

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,6 +1,8 @@
 # LikeC4 Agent Skills
 
-This directory contains [Agent Skills](https://www.skillsdk.dev/) for AI coding assistants (Claude Code, Cursor, Windsurf, etc.) that help with LikeC4 development.
+This directory contains public [Agent Skills](https://www.skillsdk.dev/) for AI coding assistants (Claude Code, Cursor, Windsurf, etc.) that help with LikeC4 development.
+
+Repo-local developer workflow skills live in `.agents/skills/`. Claude Code discovers those through per-skill symlink adapters in `.claude/skills/`.
 
 Skills are auto-discovered by agents when working in this repository. They provide DSL syntax references, coding patterns, and workflow guidance — enabling AI agents to write correct LikeC4 code without hallucinating syntax.
 


### PR DESCRIPTION
Follow-up to #3095.

## Summary

- Add repo-local skills for GitHub PR triage, issue reproduction, CLI codegen regressions, and project config workflows.
- Capture repeated LikeC4 workflow edge cases so agents can use repeatable repo-specific guidance instead of rediscovering the same commands and validation matrix.
- Keep the AGENTS instruction policy in AGENTS.md and the existing validator rather than adding a separate skill for mechanical adapter rules.

## Review notes

- Replaced hard-coded user examples with login placeholders.
- Added pagination/open filtering and exact-location guidance for issue mention triage.
- Added codegen edge cases for stable output naming and synthetic absolute/Windows path coverage.
- Added project-config guidance for workspace startup scanning, where manual document injection can miss dropped include-path files.

## Validation

- quick_validate.py passed for all four new skills
- pnpm exec dprint check on all four new SKILL.md files
- pnpm check:agent-instructions
- git diff --check