### PR TITLE
fix(mcp): stop stdio server on stdin EOF

### DIFF
--- a/.changeset/tidy-stdio-watchers.md
+++ b/.changeset/tidy-stdio-watchers.md
@@ -1,0 +1,6 @@
+---
+"@likec4/mcp": patch
+"likec4": patch
+---
+
+Stop stdio MCP servers when the client closes stdin so file watchers are cleaned up instead of leaving orphaned processes.

--- a/packages/mcp/src/__tests__/stdio-lifecycle.int.spec.ts
+++ b/packages/mcp/src/__tests__/stdio-lifecycle.int.spec.ts
@@ -1,0 +1,120 @@
+import { LikeC4 } from '@likec4/language-services/node'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { PassThrough, Writable } from 'node:stream'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { startLikeC4MCP } from '../index'
+import { StdioLikeC4MCPServer } from '../server/StdioLikeC4MCPServer'
+
+const tempDirs: string[] = []
+
+afterEach(async () => {
+  while (tempDirs.length > 0) {
+    await rm(tempDirs.pop()!, { recursive: true, force: true })
+  }
+})
+
+async function createWorkspace() {
+  const dir = await mkdtemp(path.join(tmpdir(), 'likec4-mcp-stdio-'))
+  tempDirs.push(dir)
+  await writeFile(
+    path.join(dir, 'model.c4'),
+    `
+      specification {
+        element system
+      }
+      model {
+        app = system 'App'
+      }
+      views {
+        view index {
+          include *
+        }
+      }
+    `,
+  )
+  return dir
+}
+
+function discardOutput() {
+  return new Writable({
+    write(_chunk, _encoding, callback) {
+      callback()
+    },
+  })
+}
+
+describe('MCP stdio lifecycle', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it.each([
+    ['EOF', (stdin: PassThrough) => stdin.end()],
+    ['close', (stdin: PassThrough) => stdin.destroy()],
+  ])('stops the server and disposes language services when stdin reaches %s', async (_event, closeStdin) => {
+    const workspacePath = await createWorkspace()
+    const stdin = new PassThrough()
+    const stdout = discardOutput()
+
+    const started = await startLikeC4MCP({
+      workspacePath,
+      mcp: 'stdio',
+      watch: true,
+      configureLogger: false,
+      stdio: { stdin, stdout },
+    })
+    const dispose = vi.spyOn(started.likec4, 'dispose')
+
+    closeStdin(stdin)
+
+    await vi.waitFor(() => {
+      expect(started.server.isStarted).toBe(false)
+      expect(dispose).toHaveBeenCalledOnce()
+    })
+  })
+
+  it('disposes language services when the stdio server fails to start', async () => {
+    const workspacePath = await createWorkspace()
+    const startError = new Error('stdio start failed')
+    vi.spyOn(StdioLikeC4MCPServer.prototype, 'start').mockRejectedValueOnce(startError)
+    const dispose = vi.spyOn(LikeC4.prototype, 'dispose')
+
+    await expect(startLikeC4MCP({
+      workspacePath,
+      mcp: 'stdio',
+      watch: true,
+      configureLogger: false,
+      stdio: {
+        stdin: new PassThrough(),
+        stdout: discardOutput(),
+      },
+    })).rejects.toThrow(startError)
+
+    expect(dispose).toHaveBeenCalledOnce()
+  })
+
+  it('does not start the stdio server when stdin is already closed', async () => {
+    const workspacePath = await createWorkspace()
+    const stdin = new PassThrough()
+    stdin.destroy()
+    const start = vi.spyOn(StdioLikeC4MCPServer.prototype, 'start')
+    const dispose = vi.spyOn(LikeC4.prototype, 'dispose')
+
+    const started = await startLikeC4MCP({
+      workspacePath,
+      mcp: 'stdio',
+      watch: true,
+      configureLogger: false,
+      stdio: {
+        stdin,
+        stdout: discardOutput(),
+      },
+    })
+
+    expect(start).not.toHaveBeenCalled()
+    expect(started.server.isStarted).toBe(false)
+    expect(dispose).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -4,6 +4,7 @@ import { configureLanguageServerLogger } from '@likec4/language-server'
 import { type LikeC4, fromWorkspace } from '@likec4/language-services/node'
 import { defu } from 'defu'
 import { resolve } from 'node:path'
+import type { Readable, Writable } from 'node:stream'
 import { isDevelopment } from 'std-env'
 import k from 'tinyrainbow'
 import { setLanguageServicesCtx } from './ctx'
@@ -38,6 +39,15 @@ export interface FromWorkspaceOptions {
    * @default 'wasm'
    */
   graphviz?: 'wasm' | 'binary'
+
+  /**
+   * Stdio streams used by the stdio transport.
+   * @default process.stdin/process.stdout
+   */
+  stdio?: {
+    stdin?: Readable
+    stdout?: Writable
+  }
 
   /**
    * Whether to throw an error if no LikeC4 sources are found in the workspace.
@@ -100,7 +110,7 @@ export async function initLikeC4MCP(
   const services = setLanguageServicesCtx(likec4.languageServices)
 
   let server = opts.mcp === 'stdio'
-    ? new StdioLikeC4MCPServer(services)
+    ? new StdioLikeC4MCPServer(services, opts.stdio)
     : new StreamableLikeC4MCPServer(services, opts.mcp.port)
 
   return {
@@ -113,7 +123,83 @@ export async function startLikeC4MCP(options?: FromWorkspaceOptions): Promise<{
   server: StdioLikeC4MCPServer | StreamableLikeC4MCPServer
   likec4: LikeC4
 }> {
-  const initiated = await initLikeC4MCP(options)
-  await initiated.server.start()
-  return initiated
+  const observeStdin = options?.mcp === undefined || options.mcp === 'stdio'
+  const stdin = observeStdin ? (options?.stdio?.stdin ?? process.stdin) : undefined
+  let initiated: Awaited<ReturnType<typeof initLikeC4MCP>> | undefined
+  let serverStarted = false
+  let stdinClosed = stdin ? stdin.readableEnded || stdin.destroyed : false
+  let shutdown: Promise<void> | undefined
+
+  const cleanup = async () => {
+    const current = initiated
+    if (!current) {
+      return
+    }
+    shutdown ??= (async () => {
+      try {
+        await current.server.stop()
+      } finally {
+        try {
+          await current.likec4.dispose()
+        } finally {
+          setLanguageServicesCtx(undefined)
+        }
+      }
+    })()
+    await shutdown
+  }
+
+  function stopObservingStdin() {
+    if (!stdin) {
+      return
+    }
+    stdin.off('end', onStdinClosed)
+    stdin.off('close', onStdinClosed)
+  }
+
+  function onStdinClosed() {
+    stdinClosed = true
+    stopObservingStdin()
+    if (serverStarted) {
+      cleanup().catch(err => {
+        logger.error('Failed to stop MCP stdio server after stdin closed', { err })
+      })
+    }
+  }
+
+  if (stdin && !stdinClosed) {
+    stdin.once('end', onStdinClosed)
+    stdin.once('close', onStdinClosed)
+    stdinClosed = stdin.readableEnded || stdin.destroyed
+  }
+
+  try {
+    initiated = await initLikeC4MCP(options)
+
+    if (initiated.server instanceof StdioLikeC4MCPServer) {
+      if (stdinClosed) {
+        stopObservingStdin()
+        await cleanup()
+        return initiated
+      }
+      await initiated.server.start()
+      serverStarted = true
+      if (stdinClosed) {
+        await cleanup()
+      }
+    } else {
+      await initiated.server.start()
+    }
+    return initiated
+  } catch (e) {
+    stopObservingStdin()
+    if (initiated) {
+      try {
+        await cleanup()
+      } catch (err) {
+        logger.error('Failed to clean up MCP stdio server after start error', { err })
+      }
+    }
+    throw e
+  }
 }

--- a/packages/mcp/src/server/StdioLikeC4MCPServer.ts
+++ b/packages/mcp/src/server/StdioLikeC4MCPServer.ts
@@ -2,6 +2,7 @@ import type { LikeC4LanguageServices } from '@likec4/language-server'
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import type { AsyncDisposable } from 'langium'
+import type { Readable, Writable } from 'node:stream'
 import { setMcpServerCtx } from '../ctx'
 import { logger } from '../utils'
 import { createMCPServer } from './createMCPServer'
@@ -14,11 +15,19 @@ export interface LikeC4MCPServer {
   stop(): Promise<void>
 }
 
+export interface StdioLikeC4MCPServerOptions {
+  stdin?: Readable
+  stdout?: Writable
+}
+
 export class StdioLikeC4MCPServer implements LikeC4MCPServer, AsyncDisposable {
   private transport: StdioServerTransport | undefined = undefined
   private _mcp: McpServer | undefined = undefined
 
-  constructor(private services: LikeC4LanguageServices) {
+  constructor(
+    private services: LikeC4LanguageServices,
+    private options: StdioLikeC4MCPServerOptions = {},
+  ) {
   }
 
   get mcp(): McpServer {
@@ -47,8 +56,13 @@ export class StdioLikeC4MCPServer implements LikeC4MCPServer, AsyncDisposable {
     logger.info('Starting MCP stdio server')
     this._mcp = createMCPServer(this.services)
     setMcpServerCtx(this._mcp)
-    this.transport = new StdioServerTransport()
-    await this._mcp.connect(this.transport)
+    this.transport = new StdioServerTransport(this.options.stdin, this.options.stdout)
+    try {
+      await this._mcp.connect(this.transport)
+    } catch (e) {
+      await this.stop()
+      throw e
+    }
     logger.info('LikeC4 MCP Server running on stdio')
   }
 


### PR DESCRIPTION
Fixes #3092

## Summary
- observe stdio before workspace initialization so early stdin EOF/close cannot orphan watch-mode services
- stop stdio MCP servers when stdin reaches EOF or closes
- dispose LikeC4 language services so default watch mode releases file watchers
- clean up language services if stdio server startup fails after workspace initialization
- add regression coverage for EOF, close-only, already-closed stdin, and startup-failure lifecycle paths

## Verification
- pnpm generate
- pnpm --filter @likec4/mcp exec vitest run --no-isolate src/__tests__/stdio-lifecycle.int.spec.ts
- pnpm --filter @likec4/mcp typecheck
- pnpm --filter @likec4/mcp build
- pnpm --filter @likec4/mcp test
- timeout 8s node packages/mcp/bin/likec4-mcp.mjs --stdio examples < /dev/null
