### PR TITLE
fix: keep direct parent of leaf when flattening relationships view

### DIFF
--- a/.changeset/fix-relationships-flatten-keep-parent.md
+++ b/.changeset/fix-relationships-flatten-keep-parent.md
@@ -1,0 +1,5 @@
+---
+'@likec4/core': patch
+---
+
+Relationships browser: keep the direct parent of leaf elements when flattening hierarchy. Previously a single-child chain was collapsed to "root + leaf", so a nested component was rendered as a direct child of a distant ancestor and its owner was not visible.

--- a/packages/core/src/compute-view/relationships-view/compute.spec.ts
+++ b/packages/core/src/compute-view/relationships-view/compute.spec.ts
@@ -100,10 +100,11 @@ describe('computeRelationshipsView', () => {
         .toLikeC4Model(),
       result = computeRelationships('cloud', m, null)
 
-    expect(result.incomers.size).toBe(2)
+    expect(result.incomers.size).toBe(3)
     expect([...result.incomers]).toEqual([
       m.element('external'),
-      // Must skip the external.some
+      // Must keep the external.some, as the direct parent of the leaf
+      m.element('external.some'),
       m.element('external.some.service'),
     ])
 
@@ -131,9 +132,11 @@ describe('computeRelationshipsView', () => {
 
     m.findElement('clour')
 
-    expect(result.outgoers.size).toBe(2)
+    expect(result.outgoers.size).toBe(3)
     expect([...result.outgoers].map(e => e.id)).toEqual([
       'external',
+      // Must keep the external.some, as the direct parent of the leaf
+      'external.some',
       'external.some.service',
     ])
     expect(result.subjects.size).toBe(2)
@@ -192,6 +195,7 @@ describe('computeRelationshipsView', () => {
     )
     expect([...result1.subjects].map(prop('id'))).toEqual([
       'cloud',
+      'cloud.backend',
       'cloud.backend.service1',
       'cloud.backend.service2',
       'cloud.backend.service1.api',
@@ -248,7 +252,9 @@ describe('computeRelationshipsView', () => {
       'cloud',
       'cloud.backend1',
       'cloud.backend2',
+      'cloud.backend1.service1',
       'cloud.backend1.service1.api',
+      'cloud.backend2.service2',
       'cloud.backend2.service2.api',
     ])
 
@@ -272,6 +278,7 @@ describe('computeRelationshipsView', () => {
     expect([...result4.subjects].map(prop('id'))).toEqual([
       'cloud',
       'cloud.backend',
+      'cloud.backend.service1',
       'cloud.backend.service1.api',
     ])
   })
@@ -297,6 +304,7 @@ describe('computeRelationshipsView', () => {
     )
     expect([...result1.incomers].map(prop('id'))).toEqual([
       'cloud',
+      'cloud.backend',
       'cloud.backend.service1',
       'cloud.backend.service2',
       'cloud.backend.service1.api',
@@ -322,6 +330,7 @@ describe('computeRelationshipsView', () => {
     expect([...result2.incomers].map(prop('id'))).toEqual([
       'cloud',
       'cloud.backend',
+      'cloud.backend.service1',
       'cloud.backend.service1.api',
     ])
 
@@ -349,7 +358,9 @@ describe('computeRelationshipsView', () => {
       'cloud',
       'cloud.backend1',
       'cloud.backend2',
+      'cloud.backend1.service1',
       'cloud.backend1.service1.api',
+      'cloud.backend2.service2',
       'cloud.backend2.service2.api',
     ])
   })
@@ -375,6 +386,7 @@ describe('computeRelationshipsView', () => {
     )
     expect([...result1.outgoers].map(prop('id'))).toEqual([
       'cloud',
+      'cloud.backend',
       'cloud.backend.service1',
       'cloud.backend.service2',
       'cloud.backend.service1.api',
@@ -400,6 +412,7 @@ describe('computeRelationshipsView', () => {
     expect([...result2.outgoers].map(prop('id'))).toEqual([
       'cloud',
       'cloud.backend',
+      'cloud.backend.service1',
       'cloud.backend.service1.api',
     ])
 
@@ -427,7 +440,9 @@ describe('computeRelationshipsView', () => {
       'cloud',
       'cloud.backend1',
       'cloud.backend2',
+      'cloud.backend1.service1',
       'cloud.backend1.service1.api',
+      'cloud.backend2.service2',
       'cloud.backend2.service2.api',
     ])
   })

--- a/packages/core/src/compute-view/relationships-view/utils.spec.ts
+++ b/packages/core/src/compute-view/relationships-view/utils.spec.ts
@@ -130,6 +130,7 @@ describe('treeFromElements', () => {
       'cloud.backend.service1',
       'cloud.backend.service2',
       'cloud.backend.service1.api',
+      'cloud.backend',
     ])
 
     const result2 = treeFromElements(
@@ -177,7 +178,9 @@ describe('treeFromElements', () => {
       'cloud.backend1',
       'cloud.backend2',
       'cloud.backend1.service1.api',
+      'cloud.backend1.service1',
       'cloud.backend2.service2.api',
+      'cloud.backend2.service2',
     ])
 
     const result4 = treeFromElements(
@@ -212,12 +215,15 @@ describe('treeFromElements', () => {
       'cloud.backend1',
       'cloud.backend2',
       'cloud.backend1.service1.api',
+      'cloud.backend1.service1',
       'cloud.backend2.service2.api',
+      'cloud.backend2.service2',
       'amazon.rds',
       'amazon.sqs',
       'amazon.rds.pg1',
       'amazon.rds.pg2',
       'amazon.rds.pg2.db.db1',
+      'amazon.rds.pg2.db',
       'amazon.sqs.q1',
       'amazon.sqs.q2',
     ])

--- a/packages/core/src/compute-view/relationships-view/utils.ts
+++ b/packages/core/src/compute-view/relationships-view/utils.ts
@@ -53,7 +53,8 @@ export function treeFromElements<M extends AnyAux>(elements: Iterable<ElementMod
    */
   children(el: aux.ElementId<M> | ElementModel<M>): ReadonlyArray<ElementModel<M>>
   /**
-   * Flattens the tree structure by removing redundant hierarchy levels.
+   * Flattens the tree structure by removing redundant hierarchy levels,
+   * while always keeping the direct parent of every leaf (the leaf owner).
    * @example
    *   A
    *   └── B
@@ -65,7 +66,8 @@ export function treeFromElements<M extends AnyAux>(elements: Iterable<ElementMod
    * becomes
    *   A
    *   ├── C
-   *   │   └── E
+   *   │   └── D
+   *   │       └── E
    *   └── F
    *       └── G
    */
@@ -115,6 +117,11 @@ export function treeFromElements<M extends AnyAux>(elements: Iterable<ElementMod
           const _children = children.get(el.id)
           if (_children.length === 0) {
             acc.push(el)
+            // Keep the direct parent of a leaf, otherwise its owner is lost
+            const parent = parents.get(el.id)
+            if (parent) {
+              acc.push(parent)
+            }
             return acc
           }
           if (_children.length > 1) {


### PR DESCRIPTION
## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask, and propose improvements. We're here to help. -->

- [x] I've thoroughly read the latest [contribution guidelines](https://github.com/likec4/likec4/blob/main/CONTRIBUTING.md).
- [x] I've rebased my branch onto `main` **before** creating this PR.
- [x] I've added tests to cover my changes (if applicable).
- [x] I've verified `pnpm typecheck` and `pnpm test`.
- [x] I've added [changesets](https://changesets-docs.vercel.app/) (you can use `/changeset-generator` SKILL).
- [ ] My change requires documentation updates.
- [ ] I've updated the documentation accordingly (or will do in follow-up PR).
