### PR TITLE
fix(lsp): normalize project exclude path matching

### DIFF
--- a/.changeset/twelve-mangos-yell.md
+++ b/.changeset/twelve-mangos-yell.md
@@ -1,0 +1,5 @@
+---
+"@likec4/language-server": patch
+---
+
+Project excludes now match Windows drive-letter URI paths, and workspace startup loads files from configured include paths.

--- a/packages/language-server/src/workspace/ProjectsManager.spec.ts
+++ b/packages/language-server/src/workspace/ProjectsManager.spec.ts
@@ -452,6 +452,93 @@ describe('ProjectsManager', () => {
         expect(pm.isExcluded(path), `path: ${path}`).toBe(expected)
       })
     })
+
+    it('should match project excludes against decoded Windows drive URI paths', async ({ expect }) => {
+      const { projectsManager, services } = await createMultiProjectTestServices({})
+
+      const projectA = await projectsManager.registerProject({
+        config: {
+          name: 'projectA',
+          include: { paths: ['../shared'] },
+          exclude: ['test.c4', '**/wrong.c4', 'node_modules', 'excluded.c4', 'bad file.c4'],
+        },
+        folderUri: URI.parse('file:///C%3A/repo/architecture'),
+      })
+
+      const addDocumentAt = (uri: string, input = 'model { component c }') => {
+        const document = services.shared.workspace.LangiumDocumentFactory.fromString(input, URI.parse(uri))
+        services.shared.workspace.LangiumDocuments.addDocument(document)
+        return document
+      }
+
+      const projectDoc = addDocumentAt(
+        'file:///C%3A/repo/architecture/model.c4',
+        'specification { element component }',
+      )
+      const sameFolderExcludedDoc = addDocumentAt('file:///C%3A/repo/architecture/test.c4')
+      const nestedExcludedDoc = addDocumentAt('file:///C%3A/repo/architecture/nested/wrong.c4')
+      const nodeModulesDoc = addDocumentAt('file:///C%3A/repo/architecture/node_modules/pkg/model.c4')
+      const includedExcludedDoc = addDocumentAt('file:///C%3A/repo/shared/excluded.c4')
+      const spacedExcludedDoc = addDocumentAt('file:///C%3A/repo/architecture/my%20workspace/bad%20file.c4')
+
+      expect(projectsManager.ownerProjectId(projectDoc)).toBe(projectA.id)
+      expect(projectsManager.isIncluded(projectA.id, projectDoc)).toBe(true)
+      expect(projectsManager.isExcluded(projectDoc)).toBe(false)
+
+      for (
+        const doc of [
+          sameFolderExcludedDoc,
+          nestedExcludedDoc,
+          nodeModulesDoc,
+          spacedExcludedDoc,
+        ]
+      ) {
+        expect(projectsManager.ownerProjectId(doc)).toBe(projectA.id)
+        expect(projectsManager.isExcluded(projectA.id, doc)).toBe(true)
+        expect(projectsManager.isExcluded(doc)).toBe(true)
+        expect(projectsManager.isIncluded(projectA.id, doc)).toBe(false)
+      }
+      expect(projectsManager.ownerProjectId(includedExcludedDoc)).toBe('default')
+      expect(projectsManager.isExcluded(projectA.id, includedExcludedDoc)).toBe(true)
+      expect(projectsManager.isExcluded(includedExcludedDoc)).toBe(true)
+      expect(projectsManager.isIncluded(projectA.id, includedExcludedDoc)).toBe(false)
+
+      const projectADocs = services.shared.workspace.LangiumDocuments.projectDocuments(projectA.id)
+        .toArray()
+        .map(d => d.uri.toString())
+
+      expect(projectADocs).toContain(projectDoc.uri.toString())
+      expect(projectADocs).not.toContain(sameFolderExcludedDoc.uri.toString())
+      expect(projectADocs).not.toContain(nestedExcludedDoc.uri.toString())
+      expect(projectADocs).not.toContain(nodeModulesDoc.uri.toString())
+      expect(projectADocs).not.toContain(includedExcludedDoc.uri.toString())
+      expect(projectADocs).not.toContain(spacedExcludedDoc.uri.toString())
+    })
+
+    it('should match workspace excludes against decoded Windows drive URI paths', async ({ expect }) => {
+      const { projectsManager: pm, services } = await createMultiProjectTestServices({})
+
+      pm.setWorkspaceExcludePatterns([
+        '/C:/repo/architecture/workspace-excluded.c4',
+        '**/dist/**',
+      ])
+      const projectA = await pm.registerProject({
+        config: { name: 'projectA' },
+        folderUri: URI.parse('file:///c%3A/repo/architecture'),
+      })
+      const workspaceExcludedDoc = services.shared.workspace.LangiumDocumentFactory.fromString(
+        'model { component c }',
+        URI.parse('file:///c%3A/repo/architecture/workspace-excluded.c4'),
+      )
+      services.shared.workspace.LangiumDocuments.addDocument(workspaceExcludedDoc)
+
+      expect(pm.ownerProjectId(workspaceExcludedDoc)).toBe(projectA.id)
+      expect(pm.isExcludedByWorkspace(workspaceExcludedDoc.uri)).toBe(true)
+      expect(pm.isExcluded(workspaceExcludedDoc)).toBe(true)
+      expect(pm.isIncluded(projectA.id, workspaceExcludedDoc)).toBe(false)
+      expect(pm.isExcludedByWorkspace(URI.parse('file:///c%3A/repo/architecture/dist/model.c4'))).toBe(true)
+      expect(pm.isExcludedByWorkspace(URI.parse('file:///c%3A/repo/architecture/src/model.c4'))).toBe(false)
+    })
   })
 
   describe('include paths', () => {

--- a/packages/language-server/src/workspace/ProjectsManager.spec.ts
+++ b/packages/language-server/src/workspace/ProjectsManager.spec.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import type { LikeC4ProjectJsonConfig } from '@likec4/config'
 import type { ProjectId } from '@likec4/core'
 import { UriUtils } from 'langium'

--- a/packages/language-server/src/workspace/ProjectsManager.spec.ts
+++ b/packages/language-server/src/workspace/ProjectsManager.spec.ts
@@ -1207,6 +1207,87 @@ describe('ProjectsManager', () => {
       )
     })
 
+    it.runIf(isWin)(
+      'should exclude same-directory files from project config on real Windows paths',
+      async ({ expect }) => {
+        const { projectsManager, services, validateAll, buildModel } = await createMultiProjectTestServices({})
+
+        const projectRoot = 'c:\\likec4-repro\\architecture'
+        const modelDocUri = URI.file(`${projectRoot}\\model.c4`)
+        const excludedDocUri = URI.file(`${projectRoot}\\test.c4`)
+
+        const project = await projectsManager.registerProject({
+          config: {
+            name: 'architecture-repository',
+            title: 'Repozytorium architektury',
+            exclude: ['test.c4'],
+            implicitViews: false,
+            landingPage: {
+              redirect: true,
+            },
+          },
+          folderUri: projectRoot,
+        })
+
+        const modelDoc = services.shared.workspace.LangiumDocumentFactory.fromString(
+          `
+        specification {
+          element component
+        }
+
+        model {
+          component app
+        }
+
+        views {
+          view included {
+            title 'Included'
+            include *
+          }
+        }
+        `,
+          modelDocUri,
+        )
+        const excludedDoc = services.shared.workspace.LangiumDocumentFactory.fromString(
+          `
+        views {
+          view test {
+            title '!TEST!'
+            include *
+          }
+        }
+        `,
+          excludedDocUri,
+        )
+
+        services.shared.workspace.LangiumDocuments.addDocument(modelDoc)
+        services.shared.workspace.LangiumDocuments.addDocument(excludedDoc)
+
+        expect(projectsManager.ownerProjectId(modelDoc)).toBe(project.id)
+        expect(projectsManager.ownerProjectId(excludedDoc)).toBe(project.id)
+        expect(projectsManager.isExcluded(project.id, excludedDoc)).toBe(true)
+        expect(projectsManager.isExcluded(excludedDoc)).toBe(true)
+        expect(projectsManager.isIncluded(project.id, excludedDoc)).toBe(false)
+
+        const projectDocs = services.shared.workspace.LangiumDocuments.projectDocuments(project.id)
+          .toArray()
+          .map(doc => doc.uri.toString())
+
+        expect(projectDocs).toContain(modelDocUri.toString())
+        expect(projectDocs).not.toContain(excludedDocUri.toString())
+
+        const { errors } = await validateAll()
+        expect(errors).toEqual([])
+
+        const model = await buildModel(project.id)
+        const viewTitles = Object.values(model.views).map(view => view.title)
+
+        expect(viewTitles).toContain('Included')
+        expect(viewTitles).not.toContain('!TEST!')
+        expect(model.views).not.toHaveProperty('test')
+      },
+    )
+
     it.todo('should exclude node_modules', async ({ expect }) => {
       const { projectsManager: pm } = await createMultiProjectTestServices({})
 

--- a/packages/language-server/src/workspace/ProjectsManager.ts
+++ b/packages/language-server/src/workspace/ProjectsManager.ts
@@ -32,7 +32,6 @@ import {
   isRelative,
   joinRelativeURL,
   joinURL,
-  withoutProtocol,
   withoutTrailingSlash,
   withTrailingSlash,
 } from 'ufo'
@@ -63,6 +62,19 @@ function normalizeUri(uri: DocOrUri): NormalizedUri {
     return URI.file(uri).toString() as NormalizedUri
   }
   return uri.toString() as NormalizedUri
+}
+
+const windowsDrivePath = /^\/?([A-Za-z]):(?=\/|$)/
+
+function normalizeWindowsDrivePath(path: string): string {
+  return path.replace(windowsDrivePath, (_, drive: string) => `/${drive.toLowerCase()}:`)
+}
+
+function uriPathForMatcher(uri: NormalizedUri | URI): string {
+  if (URI.isUri(uri)) {
+    return normalizeWindowsDrivePath(uri.path)
+  }
+  return normalizeWindowsDrivePath(URI.parse(uri).path)
 }
 
 /**
@@ -104,7 +116,7 @@ function _isInScope(project: ProjectData, docUri: NormalizedUri): boolean {
   return docUri.startsWith(project.folder) || (project.includePaths?.some(isParentFolderFor(docUri)) ?? false)
 }
 function _excludes(project: ProjectData, docUri: NormalizedUri): boolean {
-  return project.exclude?.(withoutProtocol(docUri)) ?? false
+  return project.exclude?.(uriPathForMatcher(docUri)) ?? false
 }
 
 /**
@@ -194,7 +206,7 @@ const DefaultProject = {
 }
 
 function isExcludedByDefault(uri: NormalizedUri): boolean {
-  return DefaultProject.exclude(withoutProtocol(uri))
+  return DefaultProject.exclude(uriPathForMatcher(uri))
 }
 
 type RegisterProjectOptions =
@@ -331,7 +343,7 @@ export class ProjectsManager extends ADisposable {
     if (URI.isUri(uri)) {
       uri = normalizeUri(uri)
     }
-    return this.#workspaceExclude(withoutProtocol(uri))
+    return this.#workspaceExclude(uriPathForMatcher(uri))
   }
 
   /**
@@ -348,6 +360,7 @@ export class ProjectsManager extends ADisposable {
         patterns,
         filter(isTruthy),
         map(p => {
+          p = normalizeWindowsDrivePath(p)
           if (!isAbsolute(p) && !p.startsWith('**')) {
             p = joinURL('**', p)
           }
@@ -912,7 +925,7 @@ export class ProjectsManager extends ADisposable {
           if (!isRelative(p) && !p.startsWith('**')) {
             p = joinURL('**', p)
           }
-          return cleanDoubleSlashes(joinRelativeURL(root.path, p))
+          return cleanDoubleSlashes(joinRelativeURL(uriPathForMatcher(root), p))
         })
       )
       project.exclude = picomatch(patterns, {

--- a/packages/language-server/src/workspace/ProjectsManager.ts
+++ b/packages/language-server/src/workspace/ProjectsManager.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import {
   type IncludeConfig,
   type LikeC4ProjectConfig,

--- a/packages/language-server/src/workspace/WorkspaceManager.spec.ts
+++ b/packages/language-server/src/workspace/WorkspaceManager.spec.ts
@@ -1,0 +1,147 @@
+import { LikeC4ProjectConfigOps } from '@likec4/config'
+import type { ProjectId } from '@likec4/core'
+import { describe, it, vi } from 'vitest'
+import type { WorkspaceFolder } from 'vscode-languageserver'
+import { URI } from 'vscode-uri'
+import type { FileNode } from '../filesystem'
+import { createTestServices } from '../test'
+
+const fileNode = (uri: URI): FileNode => ({
+  isFile: true,
+  isDirectory: false,
+  uri,
+})
+
+describe('WorkspaceManager', () => {
+  it('should load project include paths during workspace startup', async ({ expect }) => {
+    const testServices = createTestServices({ workspace: 'file:///test/workspace' })
+    try {
+      const { services } = testServices
+      const fs = services.shared.workspace.FileSystemProvider
+      const workspaceUri = URI.parse('file:///test/workspace')
+      const projectConfigUri = URI.parse('file:///test/workspace/project/.likec4rc')
+      const projectDocUri = URI.parse('file:///test/workspace/project/model.c4')
+      const sharedDirUri = URI.parse('file:///test/shared')
+      const sharedDocUri = URI.parse('file:///test/shared/shared.c4')
+      const workspaceFolder: WorkspaceFolder = {
+        name: 'workspace',
+        uri: workspaceUri.toString(),
+      }
+
+      vi.spyOn(fs, 'scanProjectFiles').mockResolvedValue([fileNode(projectConfigUri)])
+      vi.spyOn(fs, 'loadProjectConfig').mockResolvedValue(
+        LikeC4ProjectConfigOps.validate({
+          name: 'projectA',
+          include: { paths: ['../../shared'] },
+        }),
+      )
+      const readDirectory = vi.spyOn(fs, 'readDirectory').mockImplementation(async uri => {
+        switch (uri.toString()) {
+          case workspaceUri.toString():
+            return [fileNode(projectDocUri)]
+          case sharedDirUri.toString():
+            return [fileNode(sharedDocUri)]
+          default:
+            return []
+        }
+      })
+      vi.spyOn(fs, 'readFile').mockImplementation(async uri => {
+        switch (uri.toString()) {
+          case projectDocUri.toString():
+            return 'specification { element component }'
+          case sharedDocUri.toString():
+            return 'model { component shared }'
+          default:
+            return ''
+        }
+      })
+
+      services.shared.workspace.WorkspaceManager.initialize({
+        capabilities: {},
+        processId: null,
+        rootUri: workspaceFolder.uri,
+        workspaceFolders: [workspaceFolder],
+      })
+      await services.shared.workspace.WorkspaceManager.initializeWorkspace([workspaceFolder])
+
+      expect(readDirectory.mock.calls.some(([uri]) => uri.toString() === sharedDirUri.toString())).toBe(true)
+      expect(services.shared.workspace.LangiumDocuments.hasDocument(sharedDocUri)).toBe(true)
+      expect(services.shared.workspace.ProjectsManager.ownerProjectId(sharedDocUri)).toBe('projectA')
+
+      const projectDocs = services.shared.workspace.LangiumDocuments.projectDocuments('projectA' as ProjectId)
+        .toArray()
+        .map(doc => doc.uri.toString())
+
+      expect(projectDocs).toContain(projectDocUri.toString())
+      expect(projectDocs).toContain(sharedDocUri.toString())
+      expect(projectDocs.filter(uri => uri === sharedDocUri.toString())).toHaveLength(1)
+    } finally {
+      await testServices[Symbol.asyncDispose]()
+    }
+  })
+
+  it('should dedupe documents found by workspace and include-path startup scans', async ({ expect }) => {
+    const testServices = createTestServices({ workspace: 'file:///test/workspace' })
+    try {
+      const { services } = testServices
+      const fs = services.shared.workspace.FileSystemProvider
+      const workspaceUri = URI.parse('file:///test/workspace')
+      const projectConfigUri = URI.parse('file:///test/workspace/project/.likec4rc')
+      const projectDocUri = URI.parse('file:///test/workspace/project/model.c4')
+      const sharedDirUri = URI.parse('file:///test/workspace/shared')
+      const sharedDocUri = URI.parse('file:///test/workspace/shared/shared.c4')
+      const workspaceFolder: WorkspaceFolder = {
+        name: 'workspace',
+        uri: workspaceUri.toString(),
+      }
+
+      vi.spyOn(fs, 'scanProjectFiles').mockResolvedValue([fileNode(projectConfigUri)])
+      vi.spyOn(fs, 'loadProjectConfig').mockResolvedValue(
+        LikeC4ProjectConfigOps.validate({
+          name: 'projectA',
+          include: { paths: ['../shared'] },
+        }),
+      )
+      const readDirectory = vi.spyOn(fs, 'readDirectory').mockImplementation(async uri => {
+        switch (uri.toString()) {
+          case workspaceUri.toString():
+            return [fileNode(projectDocUri), fileNode(sharedDocUri)]
+          case sharedDirUri.toString():
+            return [fileNode(sharedDocUri)]
+          default:
+            return []
+        }
+      })
+      vi.spyOn(fs, 'readFile').mockImplementation(async uri => {
+        switch (uri.toString()) {
+          case projectDocUri.toString():
+            return 'specification { element component }'
+          case sharedDocUri.toString():
+            return 'model { component shared }'
+          default:
+            return ''
+        }
+      })
+
+      services.shared.workspace.WorkspaceManager.initialize({
+        capabilities: {},
+        processId: null,
+        rootUri: workspaceFolder.uri,
+        workspaceFolders: [workspaceFolder],
+      })
+      await services.shared.workspace.WorkspaceManager.initializeWorkspace([workspaceFolder])
+
+      expect(readDirectory.mock.calls.some(([uri]) => uri.toString() === sharedDirUri.toString())).toBe(true)
+
+      const allDocs = services.shared.workspace.LangiumDocuments.all.toArray().map(doc => doc.uri.toString())
+      const projectDocs = services.shared.workspace.LangiumDocuments.projectDocuments('projectA' as ProjectId)
+        .toArray()
+        .map(doc => doc.uri.toString())
+
+      expect(allDocs.filter(uri => uri === sharedDocUri.toString())).toHaveLength(1)
+      expect(projectDocs.filter(uri => uri === sharedDocUri.toString())).toHaveLength(1)
+    } finally {
+      await testServices[Symbol.asyncDispose]()
+    }
+  })
+})

--- a/packages/language-server/src/workspace/WorkspaceManager.spec.ts
+++ b/packages/language-server/src/workspace/WorkspaceManager.spec.ts
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
 import { LikeC4ProjectConfigOps } from '@likec4/config'
 import type { ProjectId } from '@likec4/core'
 import { describe, it, vi } from 'vitest'

--- a/packages/language-server/src/workspace/WorkspaceManager.ts
+++ b/packages/language-server/src/workspace/WorkspaceManager.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { invariant } from '@likec4/core'
 import type {
   BuildOptions,

--- a/packages/language-server/src/workspace/WorkspaceManager.ts
+++ b/packages/language-server/src/workspace/WorkspaceManager.ts
@@ -148,7 +148,7 @@ export class LikeC4WorkspaceManager extends DefaultWorkspaceManager {
   protected async scanProjectIncludePaths(): Promise<FileSystemNode[]> {
     // Load documents from project include paths
     const includePaths = this.services.workspace.ProjectsManager.getAllIncludePaths()
-    if (hasAtLeast(includePaths, 1)) {
+    if (!hasAtLeast(includePaths, 1)) {
       return []
     }
 


### PR DESCRIPTION
## Summary

Fixes #2546.

This fixes project exclude matching when LikeC4 receives Windows drive-letter file URIs, for example `file:///C%3A/repo/architecture/test.c4`. Exclude matching now uses decoded URI paths and normalizes only the leading Windows drive letter, so POSIX paths remain case-sensitive.

It also fixes workspace startup so configured `include.paths` are scanned when projects are discovered.

## Examples covered

- `exclude: ['test.c4']` excludes `file:///C%3A/repo/architecture/test.c4`
- `exclude: ['**/wrong.c4']` excludes nested Windows-drive URI paths
- `exclude: ['node_modules']` excludes directory matches under a Windows-drive project root
- excludes also apply to configured include paths
- workspace excludes still take precedence over project ownership/inclusion
- startup scans include-path directories and deduplicates overlapping workspace/include scans

## Validation

- `pnpm --filter @likec4/language-server generate`
- `pnpm --filter @likec4/language-server exec vitest run --no-isolate src/workspace/ProjectsManager.spec.ts src/workspace/WorkspaceManager.spec.ts`
- `pnpm --filter @likec4/language-server typecheck`
- `pnpm exec dprint check packages/language-server/src/workspace/ProjectsManager.ts packages/language-server/src/workspace/ProjectsManager.spec.ts packages/language-server/src/workspace/WorkspaceManager.ts packages/language-server/src/workspace/WorkspaceManager.spec.ts .changeset/twelve-mangos-yell.md`
- `git diff --check --cached`

## Checklist

- [x] I've thoroughly read the latest [contribution guidelines](https://github.com/likec4/likec4/blob/main/CONTRIBUTING.md).
- [x] I've rebased my branch onto `main` **before** creating this PR.
- [x] I've added tests to cover my changes (if applicable).
- [x] I've verified `pnpm typecheck` and `pnpm test`.
- [x] I've added [changesets](https://changesets-docs.vercel.app/) (you can use `/changeset-generator` SKILL).
- [ ] My change requires documentation updates.
- [ ] I've updated the documentation accordingly (or will do in follow-up PR).

Documentation updates are not applicable for this bug fix; behavior is covered by regression tests and a patch changeset.
