### PR TITLE
fix: allow dynamic keywords as metadata keys

### DIFF
--- a/.changeset/quiet-masks-allow.md
+++ b/.changeset/quiet-masks-allow.md
@@ -1,0 +1,5 @@
+---
+"@likec4/language-server": patch
+---
+
+Allow dynamic view flow keywords such as `alt` to be used as metadata keys again.

--- a/.changeset/quiet-masks-allow.md
+++ b/.changeset/quiet-masks-allow.md
@@ -3,3 +3,5 @@
 ---
 
 Allow dynamic view flow keywords such as `alt` to be used as metadata keys again.
+
+Fixes [#3110](https://github.com/likec4/likec4/issues/3110)

--- a/packages/language-server/src/__tests__/model.spec.ts
+++ b/packages/language-server/src/__tests__/model.spec.ts
@@ -398,4 +398,28 @@ describe('model', () => {
         }
       }
     }`
+
+  // https://github.com/likec4/likec4/issues/3110
+  test('element metadata keys can use dynamic view flow keywords').valid`
+    specification {
+      element component
+    }
+    model {
+      component system1 {
+        metadata {
+          alt 'alternative'
+          opt 'optional'
+          par 'parallel group'
+          parallel 'parallel group'
+          loop 'loop'
+          when 'condition'
+          if 'condition'
+          else 'fallback'
+          break 'break'
+          try 'try'
+          catch 'catch'
+          finally 'finally'
+        }
+      }
+    }`
 })

--- a/packages/language-server/src/like-c4.langium
+++ b/packages/language-server/src/like-c4.langium
@@ -667,15 +667,22 @@ fragment StepsBlockFragment:
 // -----------------------------------------------
 // Semantic group of dynamic view steps (flow branch)
 
+type SubflowKind =
+  'opt' | 'par' | 'parallel' | 'loop' | 'when' | 'if' | 'else' | 'break'
+;
+SubflowKind returns SubflowKind:
+  'opt' | 'par' | 'parallel' | 'loop' | 'when' | 'if' | 'else' | 'break'
+;
+
 interface SubflowStep extends StepsBlock {
-  kind: 'opt' | 'par' | 'parallel' | 'loop' | 'when' | 'if' | 'else' | 'break'
+  kind: SubflowKind
   /// Optional title for the branch
   title?: string
 }
 
 // Must be defined before "StepsBlock"
 SubflowStep returns SubflowStep:
-  kind=('opt' | 'par' | 'parallel' | 'loop' | 'when' | 'if' | 'else' | 'break')
+  kind=SubflowKind
   title=String? StepsBlockFragment
 ;
 
@@ -1094,15 +1101,7 @@ DynamicViewDisplayVariantValue returns string:
   'diagram' | 'sequence';
 
 DynamicViewFlowKeyword returns string:
-  'alt' |
-  'opt' |
-  'par' |
-  'parallel' |
-  'loop' |
-  'when' |
-  'if' |
-  'else' |
-  'break' |
+  SubflowKind |
   'try' |
   'catch' |
   'finally';

--- a/packages/language-server/src/like-c4.langium
+++ b/packages/language-server/src/like-c4.langium
@@ -1093,6 +1093,20 @@ ArrowType returns string:
 DynamicViewDisplayVariantValue returns string:
   'diagram' | 'sequence';
 
+DynamicViewFlowKeyword returns string:
+  'alt' |
+  'opt' |
+  'par' |
+  'parallel' |
+  'loop' |
+  'when' |
+  'if' |
+  'else' |
+  'break' |
+  'try' |
+  'catch' |
+  'finally';
+
 ThemeColor returns string:
   'primary' |
   'secondary' |
@@ -1160,6 +1174,7 @@ Id returns string:
   Participant |
   SizeValue |
   DynamicViewDisplayVariantValue |
+  DynamicViewFlowKeyword |
   IconPositionValue |
   RankValue |
   // Allow reserved keywords as Id

--- a/packages/language-server/src/lsp/CompletionProvider.spec.ts
+++ b/packages/language-server/src/lsp/CompletionProvider.spec.ts
@@ -171,8 +171,9 @@ describe('LikeC4CompletionProvider', () => {
         'title',
         'technology',
         'this',
-        // target and top are reserved keywords and suggested as id new element
+        // target,try and top are reserved keywords and suggested as id new element
         'target',
+        'try',
         'top',
       ],
     })


### PR DESCRIPTION
Fixes #3110.

## What changed

- Adds the dynamic view flow keywords (`alt`, `opt`, `par`, `parallel`, `loop`, `when`, `if`, `else`, `break`, `try`, `catch`, `finally`) to the grammar's general `Id` rule.
- Adds a parser regression test showing those keywords can be used as element metadata keys.
- Adds a patch changeset for the language-server parser fix.

## Root cause

LikeC4 intentionally allows several keyword tokens to be reused where an `Id` is expected, including metadata keys. The dynamic-view flow keywords added in 1.59.0 became parser keywords, but they were not added back into the `Id` rule. As a result, `metadata { alt "..." }` was parsed as an unexpected keyword instead of a metadata key.

## Validation

- Reproduced the reported case locally before the fix: `metadata { alt 'Batch alt' }` failed with `Expecting token of type '}' but found \`alt\`.`
- Confirmed the same reproduction validates with no errors after the fix.
- `pnpm generate`
- `pnpm --filter @likec4/language-server exec vitest run src/__tests__/model.spec.ts --no-isolate -t "dynamic view flow keywords"`
- `pnpm --filter @likec4/language-server exec vitest run src/__tests__/model.spec.ts src/__tests__/views-dynamic-blocks.spec.ts --no-isolate`
- `pnpm --filter @likec4/language-server typecheck`
- `pnpm exec dprint check packages/language-server/src/like-c4.langium packages/language-server/src/__tests__/model.spec.ts .changeset/quiet-masks-allow.md`
- `git diff --check`
