### PR TITLE
test: add MCP package boundary smoke checks

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -60,6 +60,9 @@ jobs:
         run: |
           pnpm lint:package
 
+      - name: ⚙️ MCP packed install smoke
+        run: pnpm --filter @likec4/mcp run smoke:pack
+
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -50,6 +50,7 @@
     "preinspector": "tsdown",
     "inspector": "DANGEROUSLY_OMIT_AUTH=1 LIKEC4_WORKSPACE=../../examples pnpx @modelcontextprotocol/inspector node bin/likec4-mcp.mjs",
     "pack": "pnpm pack",
+    "smoke:pack": "node scripts/smoke-packed-install.mjs",
     "postpack": "likec4ops postpack",
     "clean": "likec4ops clean",
     "test": "vitest run --no-isolate",

--- a/packages/mcp/scripts/smoke-packed-install.mjs
+++ b/packages/mcp/scripts/smoke-packed-install.mjs
@@ -5,15 +5,22 @@
 // Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import { spawnSync } from 'node:child_process'
-import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import process from 'node:process'
-import { fileURLToPath } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 
 const packageDir = resolve(fileURLToPath(new URL('..', import.meta.url)))
 const repoRoot = resolve(packageDir, '../..')
 const runOnWindowsShell = process.platform === 'win32'
+
+/**
+ * @typedef {object} WorkspacePackage
+ * @property {string} dir
+ * @property {string} name
+ * @property {boolean} private
+ */
 
 function run(command, args, options = {}) {
   const cwd = options.cwd ?? repoRoot
@@ -39,7 +46,8 @@ function run(command, args, options = {}) {
   return result
 }
 
-function workspacePackageDirs() {
+/** @returns {Array<WorkspacePackage>} */
+export function workspacePackages() {
   const result = run('pnpm', ['--filter', '@likec4/mcp...', 'list', '--depth', '-1', '--json'], { capture: true })
   if (result.status !== 0) {
     process.stdout.write(result.stdout ?? '')
@@ -53,50 +61,105 @@ function workspacePackageDirs() {
   }
 
   return packageInfos.flatMap(packageInfo => {
-    return typeof packageInfo.path === 'string' ? [packageInfo.path] : []
+    if (typeof packageInfo.path !== 'string') {
+      return []
+    }
+    const manifest = JSON.parse(readFileSync(join(packageInfo.path, 'package.json'), 'utf8'))
+    return [{
+      dir: packageInfo.path,
+      name: typeof manifest.name === 'string' ? manifest.name : packageInfo.path,
+      private: manifest.private === true,
+    }]
   })
 }
 
-function packageTarballs(packageDirs) {
-  return packageDirs
-    .map(packageDir => join(packageDir, 'package.tgz'))
-    .filter(existsSync)
+function tarballPath(workspacePackage) {
+  return join(workspacePackage.dir, 'package.tgz')
 }
 
-const tempRoot = mkdtempSync(join(tmpdir(), 'likec4-mcp-pack-smoke-'))
-const installDir = join(tempRoot, 'install')
-const installLog = join(tempRoot, 'npm-install.log')
-
-mkdirSync(installDir)
-
-console.log(`Smoke workspace: ${tempRoot}`)
-const packageDirs = workspacePackageDirs()
-run('pnpm', ['turbo', 'run', 'pack', '--filter=@likec4/mcp...'])
-
-const tarballs = packageTarballs(packageDirs)
-const mcpTarball = join(packageDir, 'package.tgz')
-
-if (!existsSync(mcpTarball)) {
-  throw new Error(`Expected MCP tarball was not created: ${mcpTarball}`)
-}
-if (!tarballs.includes(mcpTarball)) {
-  tarballs.push(mcpTarball)
+export function removePackedTarballs(packages) {
+  for (const workspacePackage of packages) {
+    if (!workspacePackage.private) {
+      rmSync(tarballPath(workspacePackage), { force: true })
+    }
+  }
 }
 
-writeFileSync(
-  join(installDir, 'package.json'),
-  `${JSON.stringify({ private: true, type: 'module' }, null, 2)}\n`,
-)
+export function expectedPackedTarballs(packages) {
+  const missing = []
+  const tarballs = []
 
-const install = run('npm', ['install', ...tarballs], { cwd: installDir, capture: true })
-writeFileSync(installLog, `${install.stdout ?? ''}${install.stderr ?? ''}`)
+  for (const workspacePackage of packages) {
+    if (workspacePackage.private) {
+      continue
+    }
+    const tarball = tarballPath(workspacePackage)
+    if (existsSync(tarball)) {
+      tarballs.push(tarball)
+    } else {
+      missing.push(`${workspacePackage.name}: ${tarball}`)
+    }
+  }
 
-if (install.status !== 0) {
-  console.error(`npm install failed. Log: ${installLog}`)
-  process.stdout.write(install.stdout ?? '')
-  process.stderr.write(install.stderr ?? '')
-  throw new Error(`npm install failed with exit ${install.status ?? install.signal}`)
+  if (missing.length > 0) {
+    throw new Error(`Expected packed tarballs are missing:\n${missing.map(item => `- ${item}`).join('\n')}`)
+  }
+
+  return tarballs
 }
 
-run('npx', ['likec4-mcp', '--help'], { cwd: installDir })
-console.log(`MCP packed install smoke passed. Tarball: ${mcpTarball}`)
+export function localMcpBin(installDir, platform = process.platform) {
+  return join(installDir, 'node_modules', '.bin', platform === 'win32' ? 'likec4-mcp.cmd' : 'likec4-mcp')
+}
+
+export function main() {
+  const tempRoot = mkdtempSync(join(tmpdir(), 'likec4-mcp-pack-smoke-'))
+  const installDir = join(tempRoot, 'install')
+  const installLog = join(tempRoot, 'npm-install.log')
+
+  try {
+    mkdirSync(installDir)
+
+    console.log(`Smoke workspace: ${tempRoot}`)
+    const packages = workspacePackages()
+    removePackedTarballs(packages)
+    run('pnpm', ['turbo', 'run', 'pack', '--filter=@likec4/mcp...'])
+
+    const tarballs = expectedPackedTarballs(packages)
+    const mcpTarball = join(packageDir, 'package.tgz')
+
+    if (!tarballs.includes(mcpTarball)) {
+      throw new Error(`Expected MCP tarball was not created: ${mcpTarball}`)
+    }
+
+    writeFileSync(
+      join(installDir, 'package.json'),
+      `${JSON.stringify({ private: true, type: 'module' }, null, 2)}\n`,
+    )
+
+    const install = run('npm', ['install', ...tarballs], { cwd: installDir, capture: true })
+    writeFileSync(installLog, `${install.stdout ?? ''}${install.stderr ?? ''}`)
+
+    if (install.status !== 0) {
+      console.error(`npm install failed. Log: ${installLog}`)
+      process.stdout.write(install.stdout ?? '')
+      process.stderr.write(install.stderr ?? '')
+      throw new Error(`npm install failed with exit ${install.status ?? install.signal}`)
+    }
+
+    const mcpBin = localMcpBin(installDir)
+    if (!existsSync(mcpBin)) {
+      throw new Error(`Expected local MCP binary was not installed: ${mcpBin}`)
+    }
+    run(mcpBin, ['--help'], { cwd: installDir })
+    console.log(`MCP packed install smoke passed. Tarball: ${mcpTarball}`)
+    rmSync(tempRoot, { recursive: true, force: true })
+  } catch (error) {
+    console.error(`Smoke workspace preserved for debugging: ${tempRoot}`)
+    throw error
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  main()
+}

--- a/packages/mcp/scripts/smoke-packed-install.mjs
+++ b/packages/mcp/scripts/smoke-packed-install.mjs
@@ -7,7 +7,7 @@
 import { spawnSync } from 'node:child_process'
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join, resolve } from 'node:path'
+import { join, posix, resolve, win32 } from 'node:path'
 import process from 'node:process'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 
@@ -109,7 +109,8 @@ export function expectedPackedTarballs(packages) {
 }
 
 export function localMcpBin(installDir, platform = process.platform) {
-  return join(installDir, 'node_modules', '.bin', platform === 'win32' ? 'likec4-mcp.cmd' : 'likec4-mcp')
+  const path = platform === 'win32' ? win32 : posix
+  return path.join(installDir, 'node_modules', '.bin', platform === 'win32' ? 'likec4-mcp.cmd' : 'likec4-mcp')
 }
 
 export function main() {

--- a/packages/mcp/scripts/smoke-packed-install.mjs
+++ b/packages/mcp/scripts/smoke-packed-install.mjs
@@ -5,7 +5,7 @@
 // Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import { spawnSync } from 'node:child_process'
-import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import process from 'node:process'
@@ -39,18 +39,28 @@ function run(command, args, options = {}) {
   return result
 }
 
-function packageTarballs() {
-  const packagesDir = join(repoRoot, 'packages')
-  return readdirSync(packagesDir, { withFileTypes: true })
-    .filter(entry => entry.isDirectory())
-    .map(entry => join(packagesDir, entry.name, 'package.tgz'))
-    .filter(existsSync)
+function workspacePackageDirs() {
+  const result = run('pnpm', ['--filter', '@likec4/mcp...', 'list', '--depth', '-1', '--json'], { capture: true })
+  if (result.status !== 0) {
+    process.stdout.write(result.stdout ?? '')
+    process.stderr.write(result.stderr ?? '')
+    throw new Error(`Unable to list MCP workspace package closure: ${result.status ?? result.signal}`)
+  }
+
+  const packageInfos = JSON.parse(result.stdout ?? '[]')
+  if (!Array.isArray(packageInfos)) {
+    throw new Error('Unexpected pnpm workspace package list output')
+  }
+
+  return packageInfos.flatMap(packageInfo => {
+    return typeof packageInfo.path === 'string' ? [packageInfo.path] : []
+  })
 }
 
-function cleanPackageTarballs() {
-  for (const tarball of packageTarballs()) {
-    rmSync(tarball)
-  }
+function packageTarballs(packageDirs) {
+  return packageDirs
+    .map(packageDir => join(packageDir, 'package.tgz'))
+    .filter(existsSync)
 }
 
 const tempRoot = mkdtempSync(join(tmpdir(), 'likec4-mcp-pack-smoke-'))
@@ -60,10 +70,10 @@ const installLog = join(tempRoot, 'npm-install.log')
 mkdirSync(installDir)
 
 console.log(`Smoke workspace: ${tempRoot}`)
-cleanPackageTarballs()
+const packageDirs = workspacePackageDirs()
 run('pnpm', ['turbo', 'run', 'pack', '--filter=@likec4/mcp...'])
 
-const tarballs = packageTarballs()
+const tarballs = packageTarballs(packageDirs)
 const mcpTarball = join(packageDir, 'package.tgz')
 
 if (!existsSync(mcpTarball)) {

--- a/packages/mcp/scripts/smoke-packed-install.mjs
+++ b/packages/mcp/scripts/smoke-packed-install.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import { spawnSync } from 'node:child_process'
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+
+const packageDir = resolve(fileURLToPath(new URL('..', import.meta.url)))
+const repoRoot = resolve(packageDir, '../..')
+const runOnWindowsShell = process.platform === 'win32'
+
+function run(command, args, options = {}) {
+  const cwd = options.cwd ?? repoRoot
+  console.log(`$ ${command} ${args.join(' ')}`)
+  const result = spawnSync(command, args, {
+    cwd,
+    env: {
+      ...process.env,
+      CI: 'true',
+    },
+    encoding: 'utf8',
+    shell: runOnWindowsShell,
+    stdio: options.capture ? 'pipe' : 'inherit',
+  })
+
+  if (options.capture) {
+    return result
+  }
+
+  if (result.status !== 0) {
+    throw new Error(`Command failed with exit ${result.status ?? result.signal}: ${command} ${args.join(' ')}`)
+  }
+  return result
+}
+
+function packageTarballs() {
+  const packagesDir = join(repoRoot, 'packages')
+  return readdirSync(packagesDir, { withFileTypes: true })
+    .filter(entry => entry.isDirectory())
+    .map(entry => join(packagesDir, entry.name, 'package.tgz'))
+    .filter(existsSync)
+}
+
+function cleanPackageTarballs() {
+  for (const tarball of packageTarballs()) {
+    rmSync(tarball)
+  }
+}
+
+const tempRoot = mkdtempSync(join(tmpdir(), 'likec4-mcp-pack-smoke-'))
+const installDir = join(tempRoot, 'install')
+const installLog = join(tempRoot, 'npm-install.log')
+
+mkdirSync(installDir)
+
+console.log(`Smoke workspace: ${tempRoot}`)
+cleanPackageTarballs()
+run('pnpm', ['turbo', 'run', 'pack', '--filter=@likec4/mcp...'])
+
+const tarballs = packageTarballs()
+const mcpTarball = join(packageDir, 'package.tgz')
+
+if (!existsSync(mcpTarball)) {
+  throw new Error(`Expected MCP tarball was not created: ${mcpTarball}`)
+}
+if (!tarballs.includes(mcpTarball)) {
+  tarballs.push(mcpTarball)
+}
+
+writeFileSync(
+  join(installDir, 'package.json'),
+  `${JSON.stringify({ private: true, type: 'module' }, null, 2)}\n`,
+)
+
+const install = run('npm', ['install', ...tarballs], { cwd: installDir, capture: true })
+writeFileSync(installLog, `${install.stdout ?? ''}${install.stderr ?? ''}`)
+
+if (install.status !== 0) {
+  console.error(`npm install failed. Log: ${installLog}`)
+  process.stdout.write(install.stdout ?? '')
+  process.stderr.write(install.stderr ?? '')
+  throw new Error(`npm install failed with exit ${install.status ?? install.signal}`)
+}
+
+run('npx', ['likec4-mcp', '--help'], { cwd: installDir })
+console.log(`MCP packed install smoke passed. Tarball: ${mcpTarball}`)

--- a/packages/mcp/scripts/smoke-packed-install.mjs
+++ b/packages/mcp/scripts/smoke-packed-install.mjs
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 // SPDX-License-Identifier: MIT
 //
 // Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.

--- a/packages/mcp/src/__tests__/package-runtime-imports.spec.ts
+++ b/packages/mcp/src/__tests__/package-runtime-imports.spec.ts
@@ -162,6 +162,7 @@ function collectRuntimeImportsFromSource(sourceText: string, filePath: string): 
     }
     if (
       ts.isImportEqualsDeclaration(node)
+      && !node.isTypeOnly
       && ts.isExternalModuleReference(node.moduleReference)
       && ts.isStringLiteral(node.moduleReference.expression)
     ) {
@@ -211,6 +212,7 @@ describe('@likec4/mcp runtime package imports', () => {
         'export type { ExportType } from \'export-type-only-declaration\'',
         'const required = require(\'required-runtime\')',
         'import equalsRuntime = require(\'equals-runtime\')',
+        'import type equalsTypeOnly = require(\'equals-type-only\')',
         'async function load() { return import(\'dynamic-runtime\') }',
       ].join('\n'),
       `${packageDir}/synthetic.ts`,

--- a/packages/mcp/src/__tests__/package-runtime-imports.spec.ts
+++ b/packages/mcp/src/__tests__/package-runtime-imports.spec.ts
@@ -121,9 +121,11 @@ function collectRuntimeImportsFromSource(sourceText: string, filePath: string): 
       ts.isCallExpression(node)
       && node.expression.kind === ts.SyntaxKind.ImportKeyword
       && node.arguments.length === 1
-      && ts.isStringLiteral(node.arguments[0])
     ) {
-      addSpecifier(node.arguments[0].text)
+      const specifier = node.arguments[0]
+      if (specifier && ts.isStringLiteral(specifier)) {
+        addSpecifier(specifier.text)
+      }
     }
     ts.forEachChild(node, visit)
   }

--- a/packages/mcp/src/__tests__/package-runtime-imports.spec.ts
+++ b/packages/mcp/src/__tests__/package-runtime-imports.spec.ts
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import { readdirSync, readFileSync } from 'node:fs'
+import { builtinModules } from 'node:module'
+import { relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import * as ts from 'typescript'
+import { describe, expect, it } from 'vitest'
+
+type RuntimeImport = {
+  file: string
+  packageName: string
+  specifier: string
+}
+
+const packageDir = fileURLToPath(new URL('../..', import.meta.url))
+const srcDir = fileURLToPath(new URL('..', import.meta.url))
+
+const packageJson = JSON.parse(
+  readFileSync(new URL('../../package.json', import.meta.url), 'utf8'),
+) as {
+  dependencies?: Record<string, string>
+  devDependencies?: Record<string, string>
+}
+
+const nodeBuiltins = new Set([
+  ...builtinModules,
+  ...builtinModules.map(moduleName => `node:${moduleName}`),
+])
+
+function isRuntimeSourceFile(fileName: string): boolean {
+  return fileName.endsWith('.ts')
+    && !fileName.endsWith('.d.ts')
+    && !fileName.endsWith('.spec.ts')
+    && !fileName.endsWith('.test.ts')
+    && !fileName.endsWith('.int.spec.ts')
+}
+
+function sourceFiles(dir: string): Array<string> {
+  return readdirSync(dir, { withFileTypes: true }).flatMap(entry => {
+    if (entry.name === '__tests__') {
+      return []
+    }
+    const child = `${dir}/${entry.name}`
+    if (entry.isDirectory()) {
+      return sourceFiles(child)
+    }
+    return isRuntimeSourceFile(entry.name) ? [child] : []
+  })
+}
+
+function packageNameFromSpecifier(specifier: string): string | null {
+  if (specifier.startsWith('.') || specifier.startsWith('/') || nodeBuiltins.has(specifier)) {
+    return null
+  }
+  const parts = specifier.split('/')
+  return specifier.startsWith('@') ? `${parts[0]}/${parts[1]}` : parts[0] ?? null
+}
+
+function hasRuntimeImport(importClause: ts.ImportClause | undefined): boolean {
+  if (!importClause) {
+    return true
+  }
+  if (importClause.isTypeOnly) {
+    return false
+  }
+  if (importClause.name) {
+    return true
+  }
+  const namedBindings = importClause.namedBindings
+  if (!namedBindings) {
+    return false
+  }
+  if (ts.isNamespaceImport(namedBindings)) {
+    return true
+  }
+  if (namedBindings.elements.length === 0) {
+    return true
+  }
+  return namedBindings.elements.some(element => !element.isTypeOnly)
+}
+
+function runtimeImport(filePath: string, specifier: string): RuntimeImport | null {
+  const packageName = packageNameFromSpecifier(specifier)
+  if (!packageName) {
+    return null
+  }
+  return {
+    file: relative(packageDir, filePath),
+    packageName,
+    specifier,
+  }
+}
+
+function collectRuntimeImportsFromSource(sourceText: string, filePath: string): Array<RuntimeImport> {
+  const sourceFile = ts.createSourceFile(filePath, sourceText, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS)
+  const imports: Array<RuntimeImport> = []
+
+  function addSpecifier(specifier: string) {
+    const importInfo = runtimeImport(filePath, specifier)
+    if (importInfo) {
+      imports.push(importInfo)
+    }
+  }
+
+  function visit(node: ts.Node) {
+    if (ts.isImportDeclaration(node) && ts.isStringLiteral(node.moduleSpecifier)) {
+      if (hasRuntimeImport(node.importClause)) {
+        addSpecifier(node.moduleSpecifier.text)
+      }
+    }
+    if (
+      ts.isExportDeclaration(node) && !node.isTypeOnly && node.moduleSpecifier &&
+      ts.isStringLiteral(node.moduleSpecifier)
+    ) {
+      addSpecifier(node.moduleSpecifier.text)
+    }
+    if (
+      ts.isCallExpression(node)
+      && node.expression.kind === ts.SyntaxKind.ImportKeyword
+      && node.arguments.length === 1
+      && ts.isStringLiteral(node.arguments[0])
+    ) {
+      addSpecifier(node.arguments[0].text)
+    }
+    ts.forEachChild(node, visit)
+  }
+
+  visit(sourceFile)
+  return imports
+}
+
+function collectRuntimeImportsFromFile(filePath: string): Array<RuntimeImport> {
+  return collectRuntimeImportsFromSource(readFileSync(filePath, 'utf8'), filePath)
+}
+
+function uniqueRuntimeImports(): Array<RuntimeImport> {
+  const seen = new Set<string>()
+  return sourceFiles(srcDir)
+    .flatMap(collectRuntimeImportsFromFile)
+    .filter(importInfo => {
+      const key = `${importInfo.file}:${importInfo.specifier}`
+      if (seen.has(key)) {
+        return false
+      }
+      seen.add(key)
+      return true
+    })
+}
+
+describe('@likec4/mcp runtime package imports', () => {
+  it('extracts only runtime package imports from TypeScript source', () => {
+    const imports = collectRuntimeImportsFromSource(
+      [
+        'import type { TypeOnly } from \'type-only-package\'',
+        'import { value, type ValueType } from \'@scope/runtime/value\'',
+        'import defaultValue from \'default-runtime\'',
+        'import * as namespaceValue from \'namespace-runtime\'',
+        'import {} from \'empty-runtime\'',
+        'import \'side-effect-runtime\'',
+        'import { readFileSync } from \'node:fs\'',
+        'import { local } from \'./local\'',
+        'export { runtimeExport } from \'export-runtime\'',
+        'export type { ExportType } from \'export-type-only\'',
+        'async function load() { return import(\'dynamic-runtime\') }',
+      ].join('\n'),
+      `${packageDir}/synthetic.ts`,
+    )
+
+    expect(imports.map(({ packageName, specifier }) => [packageName, specifier])).toEqual([
+      ['@scope/runtime', '@scope/runtime/value'],
+      ['default-runtime', 'default-runtime'],
+      ['namespace-runtime', 'namespace-runtime'],
+      ['empty-runtime', 'empty-runtime'],
+      ['side-effect-runtime', 'side-effect-runtime'],
+      ['export-runtime', 'export-runtime'],
+      ['dynamic-runtime', 'dynamic-runtime'],
+    ])
+  })
+
+  it('declares direct runtime package imports as dependencies', () => {
+    const dependencies = new Set(Object.keys(packageJson.dependencies ?? {}))
+    const devDependencies = new Set(Object.keys(packageJson.devDependencies ?? {}))
+
+    const missingDependencies = uniqueRuntimeImports()
+      .filter(({ packageName }) => !dependencies.has(packageName))
+      .map(({ file, packageName, specifier }) => `${file} imports ${specifier} from ${packageName}`)
+
+    const misplacedDependencies = uniqueRuntimeImports()
+      .filter(({ packageName }) => devDependencies.has(packageName))
+      .map(({ file, packageName, specifier }) => `${file} imports ${specifier} from ${packageName}`)
+
+    expect(missingDependencies).toEqual([])
+    expect(misplacedDependencies).toEqual([])
+  })
+
+  it('uses Node-resolvable runtime MCP SDK subpaths', () => {
+    const unresolved = uniqueRuntimeImports()
+      .filter(({ specifier }) => specifier.startsWith('@modelcontextprotocol/sdk/'))
+      .flatMap(({ file, specifier }) => {
+        try {
+          import.meta.resolve(specifier)
+          return []
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error)
+          return [`${file} imports ${specifier}: ${message}`]
+        }
+      })
+
+    expect(unresolved).toEqual([])
+  })
+})

--- a/packages/mcp/src/__tests__/package-runtime-imports.spec.ts
+++ b/packages/mcp/src/__tests__/package-runtime-imports.spec.ts
@@ -52,7 +52,13 @@ function sourceFiles(dir: string): Array<string> {
 }
 
 function packageNameFromSpecifier(specifier: string): string | null {
-  if (specifier.startsWith('.') || specifier.startsWith('/') || nodeBuiltins.has(specifier)) {
+  if (
+    specifier.startsWith('.')
+    || specifier.startsWith('/')
+    || specifier.startsWith('#')
+    || specifier.startsWith('node:')
+    || nodeBuiltins.has(specifier)
+  ) {
     return null
   }
   const parts = specifier.split('/')
@@ -80,6 +86,22 @@ function hasRuntimeImport(importClause: ts.ImportClause | undefined): boolean {
     return true
   }
   return namedBindings.elements.some(element => !element.isTypeOnly)
+}
+
+function hasRuntimeExport(node: ts.ExportDeclaration): boolean {
+  if (node.isTypeOnly) {
+    return false
+  }
+  if (!node.exportClause) {
+    return true
+  }
+  if (!ts.isNamedExports(node.exportClause)) {
+    return true
+  }
+  if (node.exportClause.elements.length === 0) {
+    return true
+  }
+  return node.exportClause.elements.some(element => !element.isTypeOnly)
 }
 
 function runtimeImport(filePath: string, specifier: string): RuntimeImport | null {
@@ -112,7 +134,7 @@ function collectRuntimeImportsFromSource(sourceText: string, filePath: string): 
       }
     }
     if (
-      ts.isExportDeclaration(node) && !node.isTypeOnly && node.moduleSpecifier &&
+      ts.isExportDeclaration(node) && hasRuntimeExport(node) && node.moduleSpecifier &&
       ts.isStringLiteral(node.moduleSpecifier)
     ) {
       addSpecifier(node.moduleSpecifier.text)
@@ -126,6 +148,24 @@ function collectRuntimeImportsFromSource(sourceText: string, filePath: string): 
       if (specifier && ts.isStringLiteral(specifier)) {
         addSpecifier(specifier.text)
       }
+    }
+    if (
+      ts.isCallExpression(node)
+      && ts.isIdentifier(node.expression)
+      && node.expression.text === 'require'
+      && node.arguments.length === 1
+    ) {
+      const specifier = node.arguments[0]
+      if (specifier && ts.isStringLiteral(specifier)) {
+        addSpecifier(specifier.text)
+      }
+    }
+    if (
+      ts.isImportEqualsDeclaration(node)
+      && ts.isExternalModuleReference(node.moduleReference)
+      && ts.isStringLiteral(node.moduleReference.expression)
+    ) {
+      addSpecifier(node.moduleReference.expression.text)
     }
     ts.forEachChild(node, visit)
   }
@@ -164,8 +204,13 @@ describe('@likec4/mcp runtime package imports', () => {
         'import \'side-effect-runtime\'',
         'import { readFileSync } from \'node:fs\'',
         'import { local } from \'./local\'',
+        'import internalValue from \'#internal/runtime\'',
         'export { runtimeExport } from \'export-runtime\'',
-        'export type { ExportType } from \'export-type-only\'',
+        'export { runtimeExport, type ExportType } from \'mixed-export-runtime\'',
+        'export { type ExportType } from \'export-type-only\'',
+        'export type { ExportType } from \'export-type-only-declaration\'',
+        'const required = require(\'required-runtime\')',
+        'import equalsRuntime = require(\'equals-runtime\')',
         'async function load() { return import(\'dynamic-runtime\') }',
       ].join('\n'),
       `${packageDir}/synthetic.ts`,
@@ -178,6 +223,9 @@ describe('@likec4/mcp runtime package imports', () => {
       ['empty-runtime', 'empty-runtime'],
       ['side-effect-runtime', 'side-effect-runtime'],
       ['export-runtime', 'export-runtime'],
+      ['mixed-export-runtime', 'mixed-export-runtime'],
+      ['required-runtime', 'required-runtime'],
+      ['equals-runtime', 'equals-runtime'],
       ['dynamic-runtime', 'dynamic-runtime'],
     ])
   })
@@ -186,11 +234,13 @@ describe('@likec4/mcp runtime package imports', () => {
     const dependencies = new Set(Object.keys(packageJson.dependencies ?? {}))
     const devDependencies = new Set(Object.keys(packageJson.devDependencies ?? {}))
 
-    const missingDependencies = uniqueRuntimeImports()
+    const runtimeImports = uniqueRuntimeImports()
+
+    const missingDependencies = runtimeImports
       .filter(({ packageName }) => !dependencies.has(packageName))
       .map(({ file, packageName, specifier }) => `${file} imports ${specifier} from ${packageName}`)
 
-    const misplacedDependencies = uniqueRuntimeImports()
+    const misplacedDependencies = runtimeImports
       .filter(({ packageName }) => devDependencies.has(packageName))
       .map(({ file, packageName, specifier }) => `${file} imports ${specifier} from ${packageName}`)
 

--- a/packages/mcp/src/__tests__/smoke-packed-install.spec.ts
+++ b/packages/mcp/src/__tests__/smoke-packed-install.spec.ts
@@ -5,14 +5,35 @@
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { describe, expect, it } from 'vitest'
-import {
-  expectedPackedTarballs,
-  localMcpBin,
-  removePackedTarballs,
-} from '../../scripts/smoke-packed-install.mjs'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import { beforeAll, describe, expect, it } from 'vitest'
 
-function packageDir(name: string): string {
+type WorkspacePackage = {
+  dir: string
+  name: string
+  private: boolean
+}
+
+type SmokePackedInstallModule = {
+  expectedPackedTarballs: (packages: readonly WorkspacePackage[]) => string[]
+  localMcpBin: (installDir: string, platform: NodeJS.Platform) => string
+  removePackedTarballs: (packages: readonly WorkspacePackage[]) => void
+}
+
+const packageDir = fileURLToPath(new URL('../..', import.meta.url))
+let expectedPackedTarballs: SmokePackedInstallModule['expectedPackedTarballs']
+let localMcpBin: SmokePackedInstallModule['localMcpBin']
+let removePackedTarballs: SmokePackedInstallModule['removePackedTarballs']
+
+beforeAll(async () => {
+  const scriptUrl = pathToFileURL(join(packageDir, 'scripts/smoke-packed-install.mjs')).href
+  const module = await import(scriptUrl) as SmokePackedInstallModule
+  expectedPackedTarballs = module.expectedPackedTarballs
+  localMcpBin = module.localMcpBin
+  removePackedTarballs = module.removePackedTarballs
+})
+
+function tempPackageDir(name: string): string {
   const dir = join(tmpdir(), `likec4-smoke-script-${process.pid}-${name}`)
   rmSync(dir, { recursive: true, force: true })
   mkdirSync(dir, { recursive: true })
@@ -21,9 +42,9 @@ function packageDir(name: string): string {
 
 describe('smoke-packed-install helpers', () => {
   it('requires packed tarballs for every public workspace package', () => {
-    const publicPacked = packageDir('public-packed')
-    const publicMissing = packageDir('public-missing')
-    const privateMissing = packageDir('private-missing')
+    const publicPacked = tempPackageDir('public-packed')
+    const publicMissing = tempPackageDir('public-missing')
+    const privateMissing = tempPackageDir('private-missing')
     const publicTarball = join(publicPacked, 'package.tgz')
     writeFileSync(publicTarball, 'packed')
 
@@ -39,8 +60,8 @@ describe('smoke-packed-install helpers', () => {
   })
 
   it('returns public tarballs and ignores private workspace packages', () => {
-    const publicPacked = packageDir('only-public-packed')
-    const privateMissing = packageDir('ignored-private-missing')
+    const publicPacked = tempPackageDir('only-public-packed')
+    const privateMissing = tempPackageDir('ignored-private-missing')
     const publicTarball = join(publicPacked, 'package.tgz')
     writeFileSync(publicTarball, 'packed')
 
@@ -53,8 +74,8 @@ describe('smoke-packed-install helpers', () => {
   })
 
   it('removes stale public tarballs before packing', () => {
-    const publicPacked = packageDir('stale-public')
-    const privatePacked = packageDir('stale-private')
+    const publicPacked = tempPackageDir('stale-public')
+    const privatePacked = tempPackageDir('stale-private')
     const publicTarball = join(publicPacked, 'package.tgz')
     const privateTarball = join(privatePacked, 'package.tgz')
     writeFileSync(publicTarball, 'stale')

--- a/packages/mcp/src/__tests__/smoke-packed-install.spec.ts
+++ b/packages/mcp/src/__tests__/smoke-packed-install.spec.ts
@@ -5,33 +5,12 @@
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { fileURLToPath, pathToFileURL } from 'node:url'
-import { beforeAll, describe, expect, it } from 'vitest'
-
-type WorkspacePackage = {
-  dir: string
-  name: string
-  private: boolean
-}
-
-type SmokePackedInstallModule = {
-  expectedPackedTarballs: (packages: readonly WorkspacePackage[]) => string[]
-  localMcpBin: (installDir: string, platform: NodeJS.Platform) => string
-  removePackedTarballs: (packages: readonly WorkspacePackage[]) => void
-}
-
-const packageDir = fileURLToPath(new URL('../..', import.meta.url))
-let expectedPackedTarballs: SmokePackedInstallModule['expectedPackedTarballs']
-let localMcpBin: SmokePackedInstallModule['localMcpBin']
-let removePackedTarballs: SmokePackedInstallModule['removePackedTarballs']
-
-beforeAll(async () => {
-  const scriptUrl = pathToFileURL(join(packageDir, 'scripts/smoke-packed-install.mjs')).href
-  const module = await import(scriptUrl) as SmokePackedInstallModule
-  expectedPackedTarballs = module.expectedPackedTarballs
-  localMcpBin = module.localMcpBin
-  removePackedTarballs = module.removePackedTarballs
-})
+import { describe, expect, it } from 'vitest'
+import {
+  expectedPackedTarballs,
+  localMcpBin,
+  removePackedTarballs,
+} from '../../scripts/smoke-packed-install.mjs'
 
 function tempPackageDir(name: string): string {
   const dir = join(tmpdir(), `likec4-smoke-script-${process.pid}-${name}`)

--- a/packages/mcp/src/__tests__/smoke-packed-install.spec.ts
+++ b/packages/mcp/src/__tests__/smoke-packed-install.spec.ts
@@ -78,6 +78,6 @@ describe('smoke-packed-install helpers', () => {
 
   it('resolves the installed local MCP binary without npx', () => {
     expect(localMcpBin('/tmp/install', 'linux')).toBe('/tmp/install/node_modules/.bin/likec4-mcp')
-    expect(localMcpBin('C:\\install', 'win32')).toBe('C:\\install/node_modules/.bin/likec4-mcp.cmd')
+    expect(localMcpBin('C:\\install', 'win32')).toBe('C:\\install\\node_modules\\.bin\\likec4-mcp.cmd')
   })
 })

--- a/packages/mcp/src/__tests__/smoke-packed-install.spec.ts
+++ b/packages/mcp/src/__tests__/smoke-packed-install.spec.ts
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import {
+  expectedPackedTarballs,
+  localMcpBin,
+  removePackedTarballs,
+} from '../../scripts/smoke-packed-install.mjs'
+
+function packageDir(name: string): string {
+  const dir = join(tmpdir(), `likec4-smoke-script-${process.pid}-${name}`)
+  rmSync(dir, { recursive: true, force: true })
+  mkdirSync(dir, { recursive: true })
+  return dir
+}
+
+describe('smoke-packed-install helpers', () => {
+  it('requires packed tarballs for every public workspace package', () => {
+    const publicPacked = packageDir('public-packed')
+    const publicMissing = packageDir('public-missing')
+    const privateMissing = packageDir('private-missing')
+    const publicTarball = join(publicPacked, 'package.tgz')
+    writeFileSync(publicTarball, 'packed')
+
+    const packages = [
+      { dir: publicPacked, name: '@likec4/public-packed', private: false },
+      { dir: publicMissing, name: '@likec4/public-missing', private: false },
+      { dir: privateMissing, name: '@likec4/private-missing', private: true },
+    ]
+
+    expect(() => expectedPackedTarballs(packages)).toThrow(
+      /Expected packed tarballs are missing[\s\S]*@likec4\/public-missing/,
+    )
+  })
+
+  it('returns public tarballs and ignores private workspace packages', () => {
+    const publicPacked = packageDir('only-public-packed')
+    const privateMissing = packageDir('ignored-private-missing')
+    const publicTarball = join(publicPacked, 'package.tgz')
+    writeFileSync(publicTarball, 'packed')
+
+    const packages = [
+      { dir: publicPacked, name: '@likec4/public-packed', private: false },
+      { dir: privateMissing, name: '@likec4/private-missing', private: true },
+    ]
+
+    expect(expectedPackedTarballs(packages)).toEqual([publicTarball])
+  })
+
+  it('removes stale public tarballs before packing', () => {
+    const publicPacked = packageDir('stale-public')
+    const privatePacked = packageDir('stale-private')
+    const publicTarball = join(publicPacked, 'package.tgz')
+    const privateTarball = join(privatePacked, 'package.tgz')
+    writeFileSync(publicTarball, 'stale')
+    writeFileSync(privateTarball, 'private')
+
+    removePackedTarballs([
+      { dir: publicPacked, name: '@likec4/public-packed', private: false },
+      { dir: privatePacked, name: '@likec4/private-packed', private: true },
+    ])
+
+    expect(() =>
+      expectedPackedTarballs([
+        { dir: publicPacked, name: '@likec4/public-packed', private: false },
+        { dir: privatePacked, name: '@likec4/private-packed', private: true },
+      ])
+    ).toThrow(/@likec4\/public-packed/)
+    expect(expectedPackedTarballs([
+      { dir: privatePacked, name: '@likec4/private-packed', private: true },
+    ])).toEqual([])
+  })
+
+  it('resolves the installed local MCP binary without npx', () => {
+    expect(localMcpBin('/tmp/install', 'linux')).toBe('/tmp/install/node_modules/.bin/likec4-mcp')
+    expect(localMcpBin('C:\\install', 'win32')).toBe('C:\\install/node_modules/.bin/likec4-mcp.cmd')
+  })
+})

--- a/packages/mcp/tsconfig.json
+++ b/packages/mcp/tsconfig.json
@@ -12,6 +12,7 @@
   },
   "include": [
     "src",
+    "scripts",
     "package.json",
     "build.config.ts"
   ],


### PR DESCRIPTION
Follow-up to #3113.

## What changed

- Adds a derived source-import guard for `@likec4/mcp` runtime package dependencies.
- Verifies runtime `@modelcontextprotocol/sdk/*` subpaths are Node-resolvable.
- Adds `pnpm --filter @likec4/mcp run smoke:pack` to build, pack, install, and execute the MCP package from a fresh npm project.
- Wires the packed install smoke into the build/package CI job.

## Why

#3112 exposed a package-boundary regression: the published MCP package installed but failed at runtime because the packed artifact referenced packages that were not installed by `npx`. #3113 fixes the immediate runtime dependency issue. This follow-up adds checks that exercise the same boundary so future regressions are caught in CI.

## Validation

- `pnpm --filter @likec4/mcp exec vitest run src/__tests__/package-runtime-imports.spec.ts --no-isolate`
- `pnpm --filter @likec4/mcp build`
- `pnpm --filter @likec4/mcp test -- --no-isolate`
- `pnpm --filter @likec4/mcp typecheck`
- `pnpm --filter @likec4/mcp run smoke:pack`
- `pnpm exec dprint check .github/workflows/checks.yaml packages/mcp/package.json packages/mcp/scripts/smoke-packed-install.mjs packages/mcp/src/__tests__/package-runtime-imports.spec.ts`
- `git diff --check`
