### PR TITLE
fix: resolve imported elements in dynamic views

### DIFF
--- a/.changeset/fix-dynamic-view-imports.md
+++ b/.changeset/fix-dynamic-view-imports.md
@@ -1,0 +1,7 @@
+---
+"@likec4/language-server": patch
+---
+
+Fix dynamic views that reference imported elements from another project.
+
+Fixes [#2989](https://github.com/likec4/likec4/issues/2989)

--- a/packages/language-server/src/model/__tests__/issue-2989.spec.ts
+++ b/packages/language-server/src/model/__tests__/issue-2989.spec.ts
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import { type ViewId, invariant, isDynamicView, ProjectId, stepGuards } from '@likec4/core'
+import { describe, it } from 'vitest'
+import { createMultiProjectTestServices } from '../../test'
+
+const importedBackend = '@contrat.entreprise.refonteExtranetEntrepriseBack'
+const localService = 'hermesPrevoyance.noyau_wsedimachine'
+
+function projects(hermesSource: string) {
+  return createMultiProjectTestServices({
+    contrat: {
+      'model.c4': `
+        specification {
+          element system
+          element backend
+          element service
+          relationship async {
+            technology 'Async channel'
+          }
+        }
+        model {
+          entreprise = system 'Entreprise' {
+            refonteExtranetEntrepriseBack = backend 'Back'
+          }
+        }
+      `,
+    },
+    hermes: {
+      'model.c4': `
+        specification {
+          element system
+          element backend
+          element service
+          relationship async {
+            technology 'Async channel'
+          }
+        }
+        import { entreprise } from 'contrat'
+        model {
+          hermesPrevoyance = system 'Hermes' {
+            noyau_wsedimachine = service 'WS EDI Machine'
+          }
+        }
+        views {
+          ${hermesSource}
+        }
+      `,
+    },
+  })
+}
+
+describe('issue #2989', () => {
+  it('computes dynamic-only steps that reference imported nested elements', async ({ expect }) => {
+    await using t = await projects(`
+      dynamic view process_reception_dat_entreprise {
+        entreprise.refonteExtranetEntrepriseBack -> hermesPrevoyance.noyau_wsedimachine 'Transmission'
+      }
+    `)
+
+    const model = await t.buildLikeC4Model('hermes')
+    const view = model.$data.views['process_reception_dat_entreprise' as ViewId]
+    invariant(view)
+    invariant(isDynamicView(view))
+
+    expect(model.findElement(importedBackend)).not.toBeNull()
+    expect(model.findElement('entreprise.refonteExtranetEntrepriseBack')).toBeNull()
+    expect(view.nodes.map(n => n.id)).toEqual(expect.arrayContaining([
+      importedBackend,
+      localService,
+    ]))
+    expect(view.edges).toMatchObject([
+      {
+        source: importedBackend,
+        target: localService,
+        label: 'Transmission',
+      },
+    ])
+  })
+
+  it('preserves imported endpoints in parsed direct, backward, and chained steps', async ({ expect }) => {
+    await using t = await projects(`
+      dynamic view imported_as_source {
+        entreprise.refonteExtranetEntrepriseBack -> hermesPrevoyance.noyau_wsedimachine
+      }
+
+      dynamic view imported_as_target {
+        hermesPrevoyance.noyau_wsedimachine -> entreprise.refonteExtranetEntrepriseBack
+      }
+
+      dynamic view imported_backward {
+        hermesPrevoyance.noyau_wsedimachine <- entreprise.refonteExtranetEntrepriseBack
+      }
+
+      dynamic view imported_chain {
+        entreprise.refonteExtranetEntrepriseBack
+          -> hermesPrevoyance.noyau_wsedimachine
+          -> entreprise.refonteExtranetEntrepriseBack
+      }
+    `)
+
+    await t.validateAll()
+    const parsed = await t.services.likec4.ModelBuilder.parseModel(ProjectId('hermes'))
+    invariant(parsed)
+
+    const importedAsSource = parsed.$data.views['imported_as_source' as ViewId]
+    invariant(importedAsSource)
+    invariant(isDynamicView(importedAsSource))
+    expect(importedAsSource.steps[0]).toMatchObject({
+      source: importedBackend,
+      target: localService,
+    })
+
+    const importedAsTarget = parsed.$data.views['imported_as_target' as ViewId]
+    invariant(importedAsTarget)
+    invariant(isDynamicView(importedAsTarget))
+    expect(importedAsTarget.steps[0]).toMatchObject({
+      source: localService,
+      target: importedBackend,
+    })
+
+    const importedBackward = parsed.$data.views['imported_backward' as ViewId]
+    invariant(importedBackward)
+    invariant(isDynamicView(importedBackward))
+    expect(importedBackward.steps[0]).toMatchObject({
+      source: importedBackend,
+      target: localService,
+      isBackward: true,
+    })
+
+    const importedChain = parsed.$data.views['imported_chain' as ViewId]
+    invariant(importedChain)
+    invariant(isDynamicView(importedChain))
+    const [series] = importedChain.steps
+    invariant(stepGuards.isSeries(series))
+    expect(series.steps).toMatchObject([
+      {
+        source: importedBackend,
+        target: localService,
+      },
+      {
+        source: localService,
+        target: importedBackend,
+        isBackward: true,
+      },
+    ])
+  })
+
+  it('computes imported endpoints inside nested dynamic flows', async ({ expect }) => {
+    await using t = await projects(`
+      dynamic view nested_flows {
+        parallel {
+          entreprise.refonteExtranetEntrepriseBack -> hermesPrevoyance.noyau_wsedimachine
+          try {
+            hermesPrevoyance.noyau_wsedimachine <- entreprise.refonteExtranetEntrepriseBack
+          } finally {
+            hermesPrevoyance.noyau_wsedimachine -> entreprise.refonteExtranetEntrepriseBack
+          }
+        }
+      }
+    `)
+
+    const model = await t.buildModel('hermes')
+    const view = model.views['nested_flows' as ViewId]
+    invariant(view)
+    invariant(isDynamicView(view))
+
+    expect(view.edges.map(e => [e.source, e.target])).toEqual([
+      [importedBackend, localService],
+      [importedBackend, localService],
+      [localService, importedBackend],
+    ])
+  })
+
+  it('derives relation metadata for imported dynamic endpoints', async ({ expect }) => {
+    await using t = await projects(`
+      dynamic view relation_metadata {
+        entreprise.refonteExtranetEntrepriseBack -> hermesPrevoyance.noyau_wsedimachine
+      }
+    `)
+
+    await t.addDocument(
+      'hermes/relations.c4',
+      `
+        import { entreprise } from 'contrat'
+        model {
+          entreprise.refonteExtranetEntrepriseBack
+            .async hermesPrevoyance.noyau_wsedimachine
+            'Sends DAT archive'
+            'Compressed DAT payload'
+        }
+      `,
+    )
+
+    const model = await t.buildModel('hermes')
+    const view = model.views['relation_metadata' as ViewId]
+    invariant(view)
+    invariant(isDynamicView(view))
+
+    expect(view.edges).toMatchObject([
+      {
+        source: importedBackend,
+        target: localService,
+        label: 'Sends DAT archive',
+        technology: 'Async channel',
+        relations: [expect.any(String)],
+      },
+    ])
+  })
+})

--- a/packages/language-server/src/model/__tests__/issue-2989.spec.ts
+++ b/packages/language-server/src/model/__tests__/issue-2989.spec.ts
@@ -2,14 +2,15 @@
 //
 // Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
-import { type ViewId, invariant, isDynamicView, ProjectId, stepGuards } from '@likec4/core'
+import type { ViewId } from '@likec4/core'
+import { invariant, isDynamicView, ProjectId, stepGuards } from '@likec4/core'
 import { describe, it } from 'vitest'
 import { createMultiProjectTestServices } from '../../test'
 
 const importedBackend = '@contrat.entreprise.refonteExtranetEntrepriseBack'
 const localService = 'hermesPrevoyance.noyau_wsedimachine'
 
-function projects(hermesSource: string) {
+function projects(hermesSource: string): ReturnType<typeof createMultiProjectTestServices> {
   return createMultiProjectTestServices({
     contrat: {
       'model.c4': `

--- a/packages/language-server/src/model/parser/ViewsParser.ts
+++ b/packages/language-server/src/model/parser/ViewsParser.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import * as c4 from '@likec4/core'
 import { type ModelFqnExpr, invariant, isNonEmptyArray, nonexhaustive } from '@likec4/core'
 import { filter, find, isDefined, isEmpty, isNumber, isTruthy, last, mapToObj, pipe } from 'remeda'
@@ -416,13 +423,9 @@ export function ViewsParser<TBase extends WithPredicates & WithDeploymentView>(B
     }
 
     parseStep(node: ast.Step): c4.Step {
-      const sourceEl = elementRef(node.source)
-      if (!sourceEl) {
-        throw new Error('Invalid reference to source')
-      }
       let baseStep = {
         ...this.parseAbstractDynamicStep(node),
-        source: this.resolveFqn(sourceEl),
+        source: this.parseDynamicStepEndpoint(node.source, 'source'),
       }
 
       if (node.isBackward) {
@@ -439,13 +442,9 @@ export function ViewsParser<TBase extends WithPredicates & WithDeploymentView>(B
     parseAbstractDynamicStep(
       astnode: ast.AbstractStep,
     ): Writable<Except<c4.Step, 'source', { requireExactProps: true }>> {
-      const targetEl = elementRef(astnode.target)
-      if (!targetEl) {
-        throw new Error('Invalid reference to target')
-      }
       const astPath = pathInsideDynamicView(astnode)
       const step: Writable<Omit<c4.Step, 'source'>> = {
-        target: this.resolveFqn(targetEl),
+        target: this.parseDynamicStepEndpoint(astnode.target, 'target'),
         astPath: astPath,
       }
 
@@ -520,6 +519,14 @@ export function ViewsParser<TBase extends WithPredicates & WithDeploymentView>(B
         }
       }
       return step
+    }
+
+    parseDynamicStepEndpoint(node: ast.ElementRef, endpoint: 'source' | 'target'): c4.Fqn {
+      const ref = this.parseFqnRef(node.modelElement)
+      if (!c4.FqnRef.isModelRef(ref)) {
+        throw new Error(`Invalid reference to ${endpoint}`)
+      }
+      return c4.FqnRef.flatten(ref)
     }
 
     parseSubflowStep(node: ast.SubflowStep): c4.Step.Opt | c4.Step.Break | c4.Step.Loop | c4.Step.Parallel {


### PR DESCRIPTION
Fixes #2989

## Summary

- Fix dynamic-view step parsing so imported element references keep their source project id.
- Cover imported dynamic endpoints as source, target, backward arrows, chained steps, nested flows, and relation metadata.
- Add a patch changeset for `@likec4/language-server`.

## Repro

The reduced repro has two projects:

- `contrat` exports `entreprise.refonteExtranetEntrepriseBack`
- `hermes` imports `entreprise` and has a dynamic view:

```likec4
dynamic view process_reception_dat_entreprise {
  entreprise.refonteExtranetEntrepriseBack
    -> hermesPrevoyance.noyau_wsedimachine
    'Transmission des DAT en ZIP'
}
```

Before the fix, the parser flattened the dynamic-step endpoint as the local FQN
`entreprise.refonteExtranetEntrepriseBack`, so the dynamic view was not computed.

After the fix, CLI JSON export contains the visualizable dynamic view with the imported endpoint preserved:

```json
{
  "view": "process_reception_dat_entreprise",
  "nodes": [
    "@contrat.entreprise.refonteExtranetEntrepriseBack",
    "hermesPrevoyance.noyau_wsedimachine"
  ],
  "edges": [
    {
      "source": "@contrat.entreprise.refonteExtranetEntrepriseBack",
      "target": "hermesPrevoyance.noyau_wsedimachine",
      "label": "Transmission des DAT en ZIP"
    }
  ]
}
```

## Real Playwright screenshots

These are real screenshots from the actual LikeC4 SPA served against the reduced #2989 repro.

### Before

The app was run with the old parser behavior. Hermes had only 2 computed views, and the dynamic view route rendered the real LikeC4 error page.

![Before fix: real LikeC4 UI says the dynamic view does not exist or contains errors](https://raw.githubusercontent.com/likec4/likec4/cgk/pr-3135-screenshots/.github/pr-assets/3135/before-real-view.png)

### After

The app was run with this PR. Hermes had 3 computed views, and the same dynamic view route rendered the imported `Back -> WS EDI Machine` interaction.

![After fix: real LikeC4 UI renders the dynamic view with the imported endpoint](https://raw.githubusercontent.com/likec4/likec4/cgk/pr-3135-screenshots/.github/pr-assets/3135/after-real-view.png)

## Verification

- `pnpm --filter @likec4/language-server test -- issue-2989`
- `pnpm --filter @likec4/language-server test -- model-parser-dynamic-views model-builder-projects`
- `pnpm --filter @likec4/language-server typecheck`
- `pnpm exec dprint check packages/language-server/src/model/parser/ViewsParser.ts packages/language-server/src/model/__tests__/issue-2989.spec.ts .changeset/fix-dynamic-view-imports.md`
- `python3 /home/ckeller/src/agent-skills/skills/likec4-license-headers/scripts/apply_likec4_headers.py --base origin/main --check packages/language-server/src/model/parser/ViewsParser.ts packages/language-server/src/model/__tests__/issue-2989.spec.ts`
- `pnpm --filter likec4 cli validate --project hermes /tmp/likec4-2989-demo --json`
- `pnpm --filter likec4 cli export json --project hermes /tmp/likec4-2989-demo --outfile /tmp/likec4-2989-json/after/model.json --pretty`
- Real UI screenshot before: `pnpm --filter @likec4/spa exec tsx --conditions=sources ./start-dev.ts /tmp/likec4-2989-demo`, with old parser behavior temporarily restored locally; captured `http://localhost:5175/project/hermes/view/process_reception_dat_entreprise/` via Playwright.
- Real UI screenshot after: same server and route, with this PR restored; captured via Playwright.
