### PR TITLE
docs: add Chinese and Japanese README translations

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,74 @@
+# アーキテクチャをコードとして
+
+[English](./README.md) | [简体中文](./README.zh-CN.md)
+
+コードから生成され、常に最新に保たれるライブ図を使って、ソフトウェアアーキテクチャを可視化し、共同作業し、進化させます。
+
+[ドキュメント](https://likec4.dev/) - [プレイグラウンド](https://playground.likec4.dev/) - [デモ](https://template.likec4.dev/view/index)
+
+<a href="https://www.npmjs.com/package/likec4" target="_blank"> ![NPM バージョン](https://img.shields.io/npm/v/likec4) </a>
+<a href="https://www.npmjs.com/package/likec4" target="_blank">![NPM ダウンロード数](https://img.shields.io/npm/dm/likec4)</a>
+<a href="https://marketplace.visualstudio.com/items?itemName=likec4.likec4-vscode" target="_blank">![VSCode インストール数](https://img.shields.io/visual-studio-marketplace/azure-devops/installs/total/likec4.likec4-vscode?label=vscode%20installs)</a>
+<a href="https://open-vsx.org/extension/likec4/likec4-vscode" target="_blank">![Open VSX インストール数](https://img.shields.io/open-vsx/dt/likec4/likec4-vscode?label=open-vsx&color=%23A60EE5)</a>
+
+![VSCode 拡張機能](https://github.com/likec4/likec4/assets/824903/d6994540-55d1-4167-b66b-45056754cc29)
+
+## LikeC4 とは？なぜ「Like」なのか？
+
+LikeC4 は、ソフトウェアアーキテクチャを記述するためのモデリング言語であり、モデルから図を生成するためのツール群です。
+
+LikeC4 は [C4 Model](https://c4model.com/) と [Structurizr DSL](https://github.com/structurizr/dsl) に着想を得ながら、一定の柔軟性も備えています。
+独自の表記法や要素タイプ、アーキテクチャモデル内の任意の数の入れ子階層をカスタマイズまたは定義できます。\
+ニーズにぴったり合わせられます。
+
+## LikeC4 はどのようなもの？
+
+LikeC4 のソース：
+
+<div align="center">
+  <img src="https://github.com/likec4/.github/assets/824903/c0f22106-dba6-469e-ab47-85e7b8565513" width="675px">
+</div>
+
+[CLI](./packages/likec4/README.md) を実行してプレビューします：
+
+```sh
+npx likec4 start
+```
+
+結果：
+
+<div align="center">
+  <img src="https://github.com/likec4/likec4/assets/824903/27eabe54-7d97-47a8-a7e4-1bb44a8e03e5" width="984px">
+</div>
+
+テンプレートリポジトリ — [likec4/template](https://github.com/likec4/template)\
+デプロイ先 — [https://template.likec4.dev](https://template.likec4.dev/view/index)
+
+[![StackBlitz で開く](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/~/github.com/likec4/template)
+
+[チュートリアル](https://likec4.dev/tutorial/)で LikeC4 の概要をすばやく確認できます。
+
+## ヘルプ
+
+使い始める際には、いつでも喜んでお手伝いします：
+
+- [Discord コミュニティに参加](https://discord.gg/86ZSpjKAdA) — 最も手軽にサポートを得られます
+- [GitHub Discussions](https://github.com/likec4/likec4/discussions) — プロジェクトについて質問したり、フィードバックを寄せたりできます
+
+## コントリビューター
+
+<a href="https://github.com/likec4/likec4/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=likec4/likec4" />
+</a>
+
+[コントリビューターになる](./CONTRIBUTING.md)
+
+## 開発を支援する
+
+LikeC4 は MIT ライセンスのオープンソースプロジェクトであり、継続的な開発は皆さまの支援によって成り立っています。\
+このプロジェクトを気に入っていただけたら、成長と改善のために資金面での支援をご検討ください。\
+[OpenCollective](https://opencollective.com/likec4) または [GitHub Sponsors](https://github.com/sponsors/likec4) から支援できます。
+
+## ライセンス
+
+本プロジェクトは [MIT License](LICENSE) のもとで公開されています。

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Architecture as a code
 
+[简体中文](./README.zh-CN.md) | [日本語](./README.ja.md)
+
 Visualize, collaborate on, and evolve your software architecture with always up-to-date, live diagrams generated from your code.
 
 [docs](https://likec4.dev/) - [playground](https://playground.likec4.dev/) - [demo](https://template.likec4.dev/view/index)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,74 @@
+# 代码即架构
+
+[English](./README.md) | [日本語](./README.ja.md)
+
+使用由代码生成且始终保持最新的实时图表，可视化、协作并演进软件架构。
+
+[文档](https://likec4.dev/) - [在线演练场](https://playground.likec4.dev/) - [演示](https://template.likec4.dev/view/index)
+
+<a href="https://www.npmjs.com/package/likec4" target="_blank"> ![NPM 版本](https://img.shields.io/npm/v/likec4) </a>
+<a href="https://www.npmjs.com/package/likec4" target="_blank">![NPM 下载量](https://img.shields.io/npm/dm/likec4)</a>
+<a href="https://marketplace.visualstudio.com/items?itemName=likec4.likec4-vscode" target="_blank">![VSCode 安装量](https://img.shields.io/visual-studio-marketplace/azure-devops/installs/total/likec4.likec4-vscode?label=vscode%20installs)</a>
+<a href="https://open-vsx.org/extension/likec4/likec4-vscode" target="_blank">![Open VSX 安装量](https://img.shields.io/open-vsx/dt/likec4/likec4-vscode?label=open-vsx&color=%23A60EE5)</a>
+
+![VSCode 扩展](https://github.com/likec4/likec4/assets/824903/d6994540-55d1-4167-b66b-45056754cc29)
+
+## LikeC4 是什么？为什么叫“Like”？
+
+LikeC4 是一种用于描述软件架构的建模语言，也是一套可根据模型生成图表的工具。
+
+LikeC4 的灵感来自 [C4 Model](https://c4model.com/) 和 [Structurizr DSL](https://github.com/structurizr/dsl)，同时提供了一定的灵活性。
+你可以自定义或定义自己的表示法、元素类型，以及架构模型中任意数量的嵌套层级。\
+完全贴合你的需求。
+
+## LikeC4 是什么样的？
+
+LikeC4 源文件：
+
+<div align="center">
+  <img src="https://github.com/likec4/.github/assets/824903/c0f22106-dba6-469e-ab47-85e7b8565513" width="675px">
+</div>
+
+运行 [CLI](./packages/likec4/README.md) 进行预览：
+
+```sh
+npx likec4 start
+```
+
+结果如下：
+
+<div align="center">
+  <img src="https://github.com/likec4/likec4/assets/824903/27eabe54-7d97-47a8-a7e4-1bb44a8e03e5" width="984px">
+</div>
+
+模板仓库 — [likec4/template](https://github.com/likec4/template)\
+已部署至 — [https://template.likec4.dev](https://template.likec4.dev/view/index)
+
+[![在 StackBlitz 中打开](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/~/github.com/likec4/template)
+
+查看[教程](https://likec4.dev/tutorial/)，快速了解 LikeC4。
+
+## 获取帮助
+
+我们随时乐意帮助你开始使用：
+
+- [加入 Discord 社区](https://discord.gg/86ZSpjKAdA) — 这是获取帮助最便捷的方式
+- [GitHub Discussions](https://github.com/likec4/likec4/discussions) — 询问有关项目的任何问题或提供反馈
+
+## 贡献者
+
+<a href="https://github.com/likec4/likec4/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=likec4/likec4" />
+</a>
+
+[成为贡献者](./CONTRIBUTING.md)
+
+## 支持开发
+
+LikeC4 是采用 MIT 许可证的开源项目，其持续开发完全依赖于你的支持。\
+如果你喜欢这个项目，请考虑提供资金支持，帮助它不断发展和改进。\
+你可以通过 [OpenCollective](https://opencollective.com/likec4) 或 [GitHub Sponsors](https://github.com/sponsors/likec4) 支持我们。
+
+## 许可证
+
+本项目依据 [MIT 许可证](LICENSE)发布。


### PR DESCRIPTION
## Summary

- Add complete Simplified Chinese and Japanese README translations.
- Add language navigation links to the root README.

## Validation

- `git diff --check`
- Verified Markdown structure, code blocks, URL targets, and relative links against the English README.

## Checklist

- [x] I have read the contribution guidelines.
- [x] The branch is based on the current `main`.
- [x] Tests are not applicable to this documentation-only change.
- [ ] `pnpm typecheck` and `pnpm test` were not run for this documentation-only change.
- [ ] A changeset is not required for docs-only changes under the repository guidelines.
- [x] This change updates documentation.