### PR TITLE
fix: preserve imported scoped view targets

### DIFF
--- a/.changeset/fix-imported-viewof-scope.md
+++ b/.changeset/fix-imported-viewof-scope.md
@@ -1,0 +1,5 @@
+---
+"@likec4/language-server": patch
+---
+
+Preserve imported project prefixes for scoped `view of` element views.

--- a/packages/language-server/src/model/__tests__/issue-2989.spec.ts
+++ b/packages/language-server/src/model/__tests__/issue-2989.spec.ts
@@ -2,8 +2,7 @@
 //
 // Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
-import type { ViewId } from '@likec4/core'
-import { invariant, isDynamicView, isElementView, ProjectId, stepGuards } from '@likec4/core'
+import { invariant, isDynamicView, isElementView, ProjectId, stepGuards, ViewId } from '@likec4/core'
 import { describe, it } from 'vitest'
 import { createMultiProjectTestServices } from '../../test'
 
@@ -74,17 +73,17 @@ describe('issue #2989', () => {
     const parsed = await t.services.likec4.ModelBuilder.parseModel(ProjectId('hermes'))
     invariant(parsed)
 
-    const localView = parsed.$data.views['local_scope' as ViewId]
+    const localView = parsed.$data.views[ViewId('local_scope')]
     invariant(localView)
     invariant(isElementView(localView))
     expect(localView.viewOf).toBe(localService)
 
-    const rootView = parsed.$data.views['imported_root_scope' as ViewId]
+    const rootView = parsed.$data.views[ViewId('imported_root_scope')]
     invariant(rootView)
     invariant(isElementView(rootView))
     expect(rootView.viewOf).toBe(importedRoot)
 
-    const nestedView = parsed.$data.views['imported_nested_scope' as ViewId]
+    const nestedView = parsed.$data.views[ViewId('imported_nested_scope')]
     invariant(nestedView)
     invariant(isElementView(nestedView))
     expect(nestedView.viewOf).toBe(importedBackend)
@@ -112,7 +111,7 @@ describe('issue #2989', () => {
     `)
 
     const model = await t.buildModel('hermes')
-    const localView = model.views['local_scope' as ViewId]
+    const localView = model.views[ViewId('local_scope')]
     invariant(localView)
     invariant(isElementView(localView))
     expect(localView.viewOf).toBe(localService)
@@ -120,7 +119,7 @@ describe('issue #2989', () => {
       localService,
     ]))
 
-    const rootView = model.views['imported_root_scope' as ViewId]
+    const rootView = model.views[ViewId('imported_root_scope')]
     invariant(rootView)
     invariant(isElementView(rootView))
     expect(rootView.viewOf).toBe(importedRoot)
@@ -129,7 +128,7 @@ describe('issue #2989', () => {
       importedBackend,
     ]))
 
-    const nestedView = model.views['imported_nested_scope' as ViewId]
+    const nestedView = model.views[ViewId('imported_nested_scope')]
     invariant(nestedView)
     invariant(isElementView(nestedView))
     expect(nestedView.viewOf).toBe(importedBackend)
@@ -149,7 +148,7 @@ describe('issue #2989', () => {
     const parsed = await t.services.likec4.ModelBuilder.parseModel(ProjectId('hermes'))
     invariant(parsed)
 
-    const parsedView = parsed.$data.views['imported_root_scope' as ViewId]
+    const parsedView = parsed.$data.views[ViewId('imported_root_scope')]
     invariant(parsedView)
     invariant(isElementView(parsedView))
     expect(parsedView.title).toBe('Entreprise')
@@ -159,7 +158,7 @@ describe('issue #2989', () => {
     ])
 
     const model = await t.buildModel('hermes')
-    const view = model.views['imported_root_scope' as ViewId]
+    const view = model.views[ViewId('imported_root_scope')]
     invariant(view)
     invariant(isElementView(view))
     expect(view.title).toBe('Entreprise')
@@ -178,7 +177,7 @@ describe('issue #2989', () => {
     `)
 
     const model = await t.buildLikeC4Model('hermes')
-    const view = model.$data.views['process_reception_dat_entreprise' as ViewId]
+    const view = model.$data.views[ViewId('process_reception_dat_entreprise')]
     invariant(view)
     invariant(isDynamicView(view))
 
@@ -222,7 +221,7 @@ describe('issue #2989', () => {
     const parsed = await t.services.likec4.ModelBuilder.parseModel(ProjectId('hermes'))
     invariant(parsed)
 
-    const importedAsSource = parsed.$data.views['imported_as_source' as ViewId]
+    const importedAsSource = parsed.$data.views[ViewId('imported_as_source')]
     invariant(importedAsSource)
     invariant(isDynamicView(importedAsSource))
     expect(importedAsSource.steps[0]).toMatchObject({
@@ -230,7 +229,7 @@ describe('issue #2989', () => {
       target: localService,
     })
 
-    const importedAsTarget = parsed.$data.views['imported_as_target' as ViewId]
+    const importedAsTarget = parsed.$data.views[ViewId('imported_as_target')]
     invariant(importedAsTarget)
     invariant(isDynamicView(importedAsTarget))
     expect(importedAsTarget.steps[0]).toMatchObject({
@@ -238,7 +237,7 @@ describe('issue #2989', () => {
       target: importedBackend,
     })
 
-    const importedBackward = parsed.$data.views['imported_backward' as ViewId]
+    const importedBackward = parsed.$data.views[ViewId('imported_backward')]
     invariant(importedBackward)
     invariant(isDynamicView(importedBackward))
     expect(importedBackward.steps[0]).toMatchObject({
@@ -247,7 +246,7 @@ describe('issue #2989', () => {
       isBackward: true,
     })
 
-    const importedChain = parsed.$data.views['imported_chain' as ViewId]
+    const importedChain = parsed.$data.views[ViewId('imported_chain')]
     invariant(importedChain)
     invariant(isDynamicView(importedChain))
     const [series] = importedChain.steps
@@ -280,7 +279,7 @@ describe('issue #2989', () => {
     `)
 
     const model = await t.buildModel('hermes')
-    const view = model.views['nested_flows' as ViewId]
+    const view = model.views[ViewId('nested_flows')]
     invariant(view)
     invariant(isDynamicView(view))
 
@@ -312,7 +311,7 @@ describe('issue #2989', () => {
     )
 
     const model = await t.buildModel('hermes')
-    const view = model.views['relation_metadata' as ViewId]
+    const view = model.views[ViewId('relation_metadata')]
     invariant(view)
     invariant(isDynamicView(view))
 

--- a/packages/language-server/src/model/__tests__/issue-2989.spec.ts
+++ b/packages/language-server/src/model/__tests__/issue-2989.spec.ts
@@ -138,6 +138,38 @@ describe('issue #2989', () => {
     ]))
   })
 
+  it('computes imported root scoped wildcard views with descendants and default title', async ({ expect }) => {
+    await using t = await projects(`
+      view imported_root_scope of entreprise {
+        include *
+      }
+    `)
+
+    await t.validateAll()
+    const parsed = await t.services.likec4.ModelBuilder.parseModel(ProjectId('hermes'))
+    invariant(parsed)
+
+    const parsedView = parsed.$data.views['imported_root_scope' as ViewId]
+    invariant(parsedView)
+    invariant(isElementView(parsedView))
+    expect(parsedView.title).toBe('Entreprise')
+    expect(parsed.$data.imports['contrat']?.map(e => e.id)).toEqual([
+      'entreprise',
+      'entreprise.refonteExtranetEntrepriseBack',
+    ])
+
+    const model = await t.buildModel('hermes')
+    const view = model.views['imported_root_scope' as ViewId]
+    invariant(view)
+    invariant(isElementView(view))
+    expect(view.title).toBe('Entreprise')
+    expect(view.viewOf).toBe(importedRoot)
+    expect(view.nodes.map(n => n.id)).toEqual(expect.arrayContaining([
+      importedRoot,
+      importedBackend,
+    ]))
+  })
+
   it('computes dynamic-only steps that reference imported nested elements', async ({ expect }) => {
     await using t = await projects(`
       dynamic view process_reception_dat_entreprise {

--- a/packages/language-server/src/model/__tests__/issue-2989.spec.ts
+++ b/packages/language-server/src/model/__tests__/issue-2989.spec.ts
@@ -3,10 +3,11 @@
 // Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import type { ViewId } from '@likec4/core'
-import { invariant, isDynamicView, ProjectId, stepGuards } from '@likec4/core'
+import { invariant, isDynamicView, isElementView, ProjectId, stepGuards } from '@likec4/core'
 import { describe, it } from 'vitest'
 import { createMultiProjectTestServices } from '../../test'
 
+const importedRoot = '@contrat.entreprise'
 const importedBackend = '@contrat.entreprise.refonteExtranetEntrepriseBack'
 const localService = 'hermesPrevoyance.noyau_wsedimachine'
 
@@ -54,6 +55,89 @@ function projects(hermesSource: string): ReturnType<typeof createMultiProjectTes
 }
 
 describe('issue #2989', () => {
+  it('preserves project id in scoped element views that reference imported elements', async ({ expect }) => {
+    await using t = await projects(`
+      view local_scope of hermesPrevoyance.noyau_wsedimachine {
+        include *
+      }
+
+      view imported_root_scope of entreprise {
+        include *
+      }
+
+      view imported_nested_scope of entreprise.refonteExtranetEntrepriseBack {
+        include *
+      }
+    `)
+
+    await t.validateAll()
+    const parsed = await t.services.likec4.ModelBuilder.parseModel(ProjectId('hermes'))
+    invariant(parsed)
+
+    const localView = parsed.$data.views['local_scope' as ViewId]
+    invariant(localView)
+    invariant(isElementView(localView))
+    expect(localView.viewOf).toBe(localService)
+
+    const rootView = parsed.$data.views['imported_root_scope' as ViewId]
+    invariant(rootView)
+    invariant(isElementView(rootView))
+    expect(rootView.viewOf).toBe(importedRoot)
+
+    const nestedView = parsed.$data.views['imported_nested_scope' as ViewId]
+    invariant(nestedView)
+    invariant(isElementView(nestedView))
+    expect(nestedView.viewOf).toBe(importedBackend)
+
+    // This proves `viewOf` parsing registered both imported targets, not only the explicit import alias.
+    expect(parsed.$data.imports['contrat']?.map(e => e.id)).toEqual(expect.arrayContaining([
+      'entreprise',
+      'entreprise.refonteExtranetEntrepriseBack',
+    ]))
+  })
+
+  it('computes scoped element views that reference imported nested elements', async ({ expect }) => {
+    await using t = await projects(`
+      view local_scope of hermesPrevoyance.noyau_wsedimachine {
+        include *
+      }
+
+      view imported_root_scope of entreprise {
+        include *
+      }
+
+      view imported_nested_scope of entreprise.refonteExtranetEntrepriseBack {
+        include *
+      }
+    `)
+
+    const model = await t.buildModel('hermes')
+    const localView = model.views['local_scope' as ViewId]
+    invariant(localView)
+    invariant(isElementView(localView))
+    expect(localView.viewOf).toBe(localService)
+    expect(localView.nodes.map(n => n.id)).toEqual(expect.arrayContaining([
+      localService,
+    ]))
+
+    const rootView = model.views['imported_root_scope' as ViewId]
+    invariant(rootView)
+    invariant(isElementView(rootView))
+    expect(rootView.viewOf).toBe(importedRoot)
+    expect(rootView.nodes.map(n => n.id)).toEqual(expect.arrayContaining([
+      importedRoot,
+      importedBackend,
+    ]))
+
+    const nestedView = model.views['imported_nested_scope' as ViewId]
+    invariant(nestedView)
+    invariant(isElementView(nestedView))
+    expect(nestedView.viewOf).toBe(importedBackend)
+    expect(nestedView.nodes.map(n => n.id)).toEqual(expect.arrayContaining([
+      importedBackend,
+    ]))
+  })
+
   it('computes dynamic-only steps that reference imported nested elements', async ({ expect }) => {
     await using t = await projects(`
       dynamic view process_reception_dat_entreprise {

--- a/packages/language-server/src/model/model-builder.ts
+++ b/packages/language-server/src/model/model-builder.ts
@@ -90,7 +90,7 @@ function withImportedScopedViewTitles(
   return mapValues(views, view => {
     if (view[_type] === 'element' && view.title === null && view.viewOf) {
       const title = titles.get(view.viewOf)
-      if (title) {
+      if (title !== undefined) {
         return {
           ...view,
           title,

--- a/packages/language-server/src/model/model-builder.ts
+++ b/packages/language-server/src/model/model-builder.ts
@@ -1,8 +1,17 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import {
   type ProjectId,
   type UnknownComputed,
   type UnknownParsed,
   _stage,
+  _type,
+  GlobalFqn,
 } from '@likec4/core'
 import { computeView } from '@likec4/core/compute-view'
 import { LikeC4Model } from '@likec4/core/model'
@@ -28,6 +37,7 @@ import {
   isArray,
   isEmptyish,
   map,
+  mapValues,
   pipe,
   piped,
   prop,
@@ -49,6 +59,47 @@ import type { LikeC4ModelParser } from './model-parser'
 const builderLogger = mainLogger.getChild('builder')
 
 type ModelParsedListener = (projectId: ProjectId, docs: URI[]) => void
+
+function isRequestedImportedElement(fqns: ReadonlySet<c4.Fqn>, element: c4.Element): boolean {
+  for (const fqn of fqns) {
+    if (element.id === fqn || element.id.startsWith(`${fqn}.`)) {
+      return true
+    }
+  }
+  return false
+}
+
+function importedElementTitles(imports: c4.ParsedLikeC4ModelData['imports']): ReadonlyMap<string, string> {
+  const titles = new Map<string, string>()
+  for (const [projectId, elements] of entries(imports)) {
+    for (const element of elements) {
+      titles.set(GlobalFqn(projectId, element.id), element.title)
+    }
+  }
+  return titles
+}
+
+function withImportedScopedViewTitles(
+  views: c4.ParsedLikeC4ModelData['views'],
+  imports: c4.ParsedLikeC4ModelData['imports'],
+): c4.ParsedLikeC4ModelData['views'] {
+  const titles = importedElementTitles(imports)
+  if (titles.size === 0) {
+    return views
+  }
+  return mapValues(views, view => {
+    if (view[_type] === 'element' && view.title === null && view.viewOf) {
+      const title = titles.get(view.viewOf)
+      if (title) {
+        return {
+          ...view,
+          title,
+        }
+      }
+    }
+    return view
+  })
+}
 
 export interface LikeC4ModelBuilder extends Disposable {
   parseModel(
@@ -174,7 +225,9 @@ export class DefaultLikeC4ModelBuilder extends ADisposable implements LikeC4Mode
         }
         const anotherProject = this.unsafeSyncParseModelData(projectId)
         if (anotherProject) {
-          const imported = [...fqns].flatMap(fqn => anotherProject.data.elements[fqn] ?? [])
+          const imported = values(anotherProject.data.elements).filter(element =>
+            isRequestedImportedElement(fqns, element)
+          )
           if (hasAtLeast(imported, 1)) {
             acc[projectId] = structuredClone(imported)
           }
@@ -184,6 +237,7 @@ export class DefaultLikeC4ModelBuilder extends ADisposable implements LikeC4Mode
       return {
         ...result.data,
         imports,
+        views: withImportedScopedViewTitles(result.data.views, imports),
       }
     })
   }

--- a/packages/language-server/src/model/parser/ViewsParser.ts
+++ b/packages/language-server/src/model/parser/ViewsParser.ts
@@ -19,7 +19,6 @@ import {
   ViewOps,
 } from '../../ast'
 import { safeCall, stringHash } from '../../utils'
-import { elementRef } from '../../utils/elementRef'
 import { parseViewOrder, removeIndent, toSingleLine } from './Base'
 import type { WithDeploymentView } from './DeploymentViewParser'
 import type { WithPredicates } from './PredicatesParser'

--- a/packages/language-server/src/model/parser/ViewsParser.ts
+++ b/packages/language-server/src/model/parser/ViewsParser.ts
@@ -84,13 +84,13 @@ export function ViewsParser<TBase extends WithPredicates & WithDeploymentView>(B
       const astPath = this.getAstNodePath(astNode)
 
       let viewOf = null as c4.Fqn | null
-      if ('viewOf' in astNode) {
-        const viewOfEl = elementRef(astNode.viewOf)
-        const _viewOf = viewOfEl && safeCall(() => this.resolveFqn(viewOfEl))
+      const viewOfNode = astNode.viewOf
+      if (viewOfNode) {
+        const _viewOf = safeCall(() => this.parseModelElementRef(viewOfNode, 'Invalid reference to viewOf'))
         if (!_viewOf) {
           const viewId = astNode.name ?? 'unnamed'
-          const msg = astNode.viewOf.$cstNode?.text ?? '<unknown>'
-          this.logError(`viewOf ${viewId} not resolved ${msg}`, astNode.viewOf)
+          const msg = viewOfNode.$cstNode?.text ?? '<unknown>'
+          this.logError(`viewOf ${viewId} not resolved ${msg}`, viewOfNode)
         } else {
           viewOf = _viewOf
         }
@@ -526,12 +526,16 @@ export function ViewsParser<TBase extends WithPredicates & WithDeploymentView>(B
       return step
     }
 
-    parseDynamicStepEndpoint(node: ast.ElementRef, endpoint: 'source' | 'target'): c4.Fqn {
+    parseModelElementRef(node: ast.ElementRef, errorMessage: string): c4.Fqn {
       const ref = this.parseFqnRef(node.modelElement)
       if (!c4.FqnRef.isModelRef(ref)) {
-        throw new Error(`Invalid reference to ${endpoint}`)
+        throw new Error(errorMessage)
       }
       return c4.FqnRef.flatten(ref)
+    }
+
+    parseDynamicStepEndpoint(node: ast.ElementRef, endpoint: 'source' | 'target'): c4.Fqn {
+      return this.parseModelElementRef(node, `Invalid reference to ${endpoint}`)
     }
 
     parseSubflowStep(node: ast.SubflowStep): c4.Step.Opt | c4.Step.Break | c4.Step.Loop | c4.Step.Parallel {


### PR DESCRIPTION
Follow-up found while fixing #2989 in #3135.

## Summary

- Preserves `@project.` prefixes when `view of` targets an imported element.
- Covers local scoped views, imported root aliases, imported nested element references, and root-scoped wildcard descendants/default titles.
- Reuses the same project-aware `parseFqnRef(...)` + `FqnRef.flatten(...)` path used for imported dynamic-view endpoints.

## Reduced repro fragment

```likec4
import { entreprise } from 'contrat'

views {
  view imported_nested_scope of entreprise.refonteExtranetEntrepriseBack {
    include *
  }
}
```

Before this fix, the parsed view target was local:

```txt
entreprise.refonteExtranetEntrepriseBack
```

After this fix, the parsed view target keeps the source project:

```txt
@contrat.entreprise.refonteExtranetEntrepriseBack
```

## Real Playwright screenshots

Both screenshots were captured with Playwright from the actual LikeC4 SPA route:

```txt
/project/hermes/view/imported_nested_scope/
```

### Before: `origin/main`

The view cannot be opened because the imported `view of` target is treated as a local FQN and the computed view is omitted.

![Before fix: imported scoped view route shows LikeC4 error state](https://raw.githubusercontent.com/likec4/likec4/d7263a0d6781b432b3844f7e8943c30f8a1bfa42/.github/pr-assets/3143/before-real-view.png)

### After: this PR

The same route renders the imported scoped view and shows the imported `Entreprise`/`Back` scope.

![After fix: imported scoped view route renders the diagram](https://raw.githubusercontent.com/likec4/likec4/d7263a0d6781b432b3844f7e8943c30f8a1bfa42/.github/pr-assets/3143/after-real-view.png)

## Additional regression covered

A root-scoped imported view now keeps its element-derived default title and includes descendants:

```likec4
view imported_root_scope of entreprise {
  include *
}
```

CLI export now returns title `Entreprise`, `viewOf` `@contrat.entreprise`, and nodes `@contrat.entreprise` plus `@contrat.entreprise.refonteExtranetEntrepriseBack`.

## Validation

- `pnpm --filter @likec4/language-server test -- issue-2989 --run`
- `pnpm --filter @likec4/language-server test -- model-parser-dynamic-views model-builder-projects --run`
- `pnpm --filter @likec4/language-server test -- CompletionProvider --run -t 'should suggest deployments'`
- `pnpm --filter @likec4/language-server typecheck`
- `pnpm exec dprint check packages/language-server/src/model/model-builder.ts packages/language-server/src/model/parser/ViewsParser.ts packages/language-server/src/model/__tests__/issue-2989.spec.ts .changeset/fix-imported-viewof-scope.md`
- `pnpm exec oxlint --type-aware packages/language-server/src/model/model-builder.ts packages/language-server/src/model/parser/ViewsParser.ts packages/language-server/src/model/__tests__/issue-2989.spec.ts`
- `python3 /home/ckeller/src/agent-skills/skills/likec4-license-headers/scripts/apply_likec4_headers.py --base origin/main --check packages/language-server/src/model/model-builder.ts packages/language-server/src/model/parser/ViewsParser.ts packages/language-server/src/model/__tests__/issue-2989.spec.ts`
- `git diff --check`
- CLI repro: `pnpm --filter likec4 cli export json --project hermes /tmp/likec4-viewof-root-only-3143 --outfile /tmp/likec4-viewof-root-only-3143/model-after.json --pretty`

Local full-suite note: `pnpm --filter @likec4/language-server test` was attempted twice and hit the same unrelated timeout in `CompletionProvider.spec.ts > should suggest deployments`; that exact test passes when run directly, as listed above.

