### PR TITLE
fix: color bootstrap icons in VS Code preview

### DIFF
--- a/.changeset/vscode-bootstrap-icon-color.md
+++ b/.changeset/vscode-bootstrap-icon-color.md
@@ -1,0 +1,6 @@
+---
+"@likec4/vscode-preview": patch
+"likec4-vscode": patch
+---
+
+Fix Bootstrap icons in the VS Code preview so `iconColor` colors them correctly.

--- a/packages/vscode-preview/src/IconRenderer.spec.tsx
+++ b/packages/vscode-preview/src/IconRenderer.spec.tsx
@@ -1,0 +1,40 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+import { IconRenderer } from './IconRenderer'
+
+vi.mock('./vscode', () => ({
+  ExtensionApi: {
+    readLocalIcon: vi.fn<(_: string) => Promise<{ base64data: string | null }>>(),
+  },
+}))
+
+describe('IconRenderer', () => {
+  it('renders bootstrap icons as a colorable mask instead of an image', () => {
+    const html = renderToStaticMarkup(
+      <IconRenderer
+        node={{
+          id: 'test',
+          title: 'Test',
+          icon: 'bootstrap:file-earmark-code',
+        }} />,
+    )
+
+    expect(html).not.toContain('<img')
+    expect(html).toContain('https://icons.like-c4.dev/bootstrap/file-earmark-code.svg')
+    expect(html).toContain('background-color:currentColor')
+  })
+
+  it('keeps non-bootstrap bundled icons as CDN images', () => {
+    const html = renderToStaticMarkup(
+      <IconRenderer
+        node={{
+          id: 'test',
+          title: 'Test',
+          icon: 'tech:react',
+        }} />,
+    )
+
+    expect(html).toContain('<img')
+    expect(html).toContain('src="https://icons.like-c4.dev/tech/react.svg"')
+  })
+})

--- a/packages/vscode-preview/src/IconRenderer.tsx
+++ b/packages/vscode-preview/src/IconRenderer.tsx
@@ -1,7 +1,28 @@
 import { DefaultMap } from '@likec4/core/utils'
 import { type ElementIconRenderer, type ElementIconRendererProps, IconRendererProvider } from '@likec4/diagram'
-import { lazy, memo, Suspense } from 'react'
+import { type CSSProperties, lazy, memo, Suspense } from 'react'
 import { ExtensionApi as extensionApi } from './vscode'
+
+const iconUrl = (group: string, name: string) => `https://icons.like-c4.dev/${group}/${name}.svg`
+
+function BootstrapIconMask({ name, ...props }: Omit<ElementIconRendererProps, 'node'> & { name: string }) {
+  const url = iconUrl('bootstrap', name)
+  const style = {
+    display: 'inline-block',
+    width: '100%',
+    height: '100%',
+    backgroundColor: 'currentColor',
+    maskImage: `url("${url}")`,
+    maskRepeat: 'no-repeat',
+    maskPosition: 'center',
+    maskSize: 'contain',
+    WebkitMaskImage: `url("${url}")`,
+    WebkitMaskRepeat: 'no-repeat',
+    WebkitMaskPosition: 'center',
+    WebkitMaskSize: 'contain',
+  } satisfies CSSProperties
+  return <span {...props} aria-hidden="true" style={style} />
+}
 
 const DefaultIconRenderer: ElementIconRenderer = ({ node, ...props }) => {
   if (!node.icon || node.icon === 'none') {
@@ -12,7 +33,11 @@ const DefaultIconRenderer: ElementIconRenderer = ({ node, ...props }) => {
     return null
   }
 
-  return <img {...props} src={`https://icons.like-c4.dev/${group}/${name}.svg`} />
+  if (group === 'bootstrap') {
+    return <BootstrapIconMask {...props} name={name} />
+  }
+
+  return <img {...props} src={iconUrl(group, name)} />
 }
 
 const icons = new DefaultMap<string, ElementIconRenderer>(icon => {


### PR DESCRIPTION
## Summary

- Fixes #3142.
- Render Bootstrap CDN icons in the VS Code preview as a CSS mask so the existing currentColor/iconColor styling can color them.
- Keep non-Bootstrap CDN icons and local file icon loading behavior unchanged.
- Add a regression test for Bootstrap vs non-Bootstrap rendering.

## Root cause

The VS Code preview overrides the diagram icon renderer and rendered every bundled icon as an external img from icons.like-c4.dev. Bootstrap icons are monochrome currentColor SVGs, but currentColor cannot cross an img boundary, so iconColor had no effect in the preview.

## VS Code screenshots

Captured from a real VS Code Extension Development Host under Xvfb against the #3142 fixture.

| Before (`origin/main`) | After (this PR) |
| --- | --- |
| ![Before: Bootstrap icon is black in the VS Code preview](https://raw.githubusercontent.com/likec4/likec4/cgk-pr3144-vscode-screenshots/pr-assets/pr3144/before-vscode.png) | ![After: Bootstrap icon uses amber iconColor in the VS Code preview](https://raw.githubusercontent.com/likec4/likec4/cgk-pr3144-vscode-screenshots/pr-assets/pr3144/after-vscode.png) |

## Verification

- pnpm generate
- pnpm --filter @likec4/vscode-preview test -- src/IconRenderer.spec.tsx
- pnpm --filter @likec4/vscode-preview test
- pnpm --filter @likec4/vscode-preview typecheck
- pnpm --filter @likec4/vscode-preview build
- pnpm exec dprint check packages/vscode-preview/src/IconRenderer.tsx packages/vscode-preview/src/IconRenderer.spec.tsx .changeset/vscode-bootstrap-icon-color.md
- pnpm exec oxlint packages/vscode-preview/src/IconRenderer.tsx packages/vscode-preview/src/IconRenderer.spec.tsx

## Notes

The regression test was verified RED first: the Bootstrap case failed because the old renderer produced an img for https://icons.like-c4.dev/bootstrap/file-earmark-code.svg.
