### PR TITLE
docs: add VS Code screenshot evidence skill

### DIFF
--- a/.agents/skills/vscode-extension-screenshot-evidence/SKILL.md
+++ b/.agents/skills/vscode-extension-screenshot-evidence/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: vscode-extension-screenshot-evidence
+description: Use when a LikeC4 PR or bug investigation needs real before/after screenshots from the actual VS Code extension or VS Code webview preview. Trigger for VS Code preview rendering bugs, extension-only visual regressions, PR descriptions that require screenshots from VS Code, or requests to prove a VS Code fix visually without substituting browser-only screenshots.
+---
+
+# VS Code Extension Screenshot Evidence
+
+Capture visual evidence from a real VS Code Extension Development Host. Use browser or Playwright screenshots only when the user explicitly asks for browser evidence; VS Code extension bugs need VS Code screenshots.
+
+## Ground rules
+
+- Capture the real VS Code UI with the extension loaded through `--extensionDevelopmentPath`.
+- Use isolated temp user-data and extensions directories so local VS Code state does not affect the screenshot.
+- Use `origin/main` or the PR base for "before" and the PR branch for "after".
+- Keep screenshots and temporary fixtures out of the fix branch unless the user explicitly wants image assets committed.
+- Visually inspect the captured images before adding them to a PR.
+- Mention any hosting fallback used for images. GitHub `user-attachments` uploads require a browser `user_session` cookie or `GH_SESSION_TOKEN`; the normal `gh` token is not enough.
+
+## Prerequisites
+
+Check the tools before spending time on builds:
+
+```bash
+command -v code
+command -v Xvfb
+command -v xdotool
+command -v import
+```
+
+`import` is from ImageMagick. If `DISPLAY` is not already set, run the capture command under `xvfb-run -a`.
+
+## Build the extension under test
+
+For LikeC4 preview changes, build both the preview package and the VS Code extension package in each worktree you capture:
+
+```bash
+pnpm generate
+pnpm --filter @likec4/vscode-preview build
+pnpm --filter likec4-vscode build
+```
+
+If you create a clean before worktree from `origin/main`, install dependencies only when `node_modules` are missing or stale.
+
+## Create a minimal fixture
+
+Keep the fixture focused on the visual behavior. For an icon-color regression, a single `.c4` file is enough:
+
+```likec4
+specification {
+  element component {
+    style {
+      shape component
+      icon bootstrap:file-earmark-code
+      iconColor amber
+    }
+  }
+}
+
+model {
+  component test 'Test'
+}
+
+views {
+  view index {
+    include *
+  }
+}
+```
+
+Store fixtures under `/tmp` unless they are intended to become committed tests.
+
+## Capture before and after
+
+Use the helper script from this skill:
+
+```bash
+SKILL=.agents/skills/vscode-extension-screenshot-evidence
+FIXTURE=/tmp/likec4-vscode-screenshot-fixture
+OUT=/tmp/likec4-vscode-screens
+
+mkdir -p "$OUT"
+
+xvfb-run -a "$SKILL/scripts/capture-likec4-vscode-preview.sh" \
+  --label before \
+  --fixture "$FIXTURE" \
+  --extension-path /tmp/likec4-before/packages/vscode \
+  --output "$OUT/before-vscode.png"
+
+xvfb-run -a "$SKILL/scripts/capture-likec4-vscode-preview.sh" \
+  --label after \
+  --fixture "$FIXTURE" \
+  --extension-path /path/to/pr-worktree/packages/vscode \
+  --output "$OUT/after-vscode.png"
+```
+
+The script opens the command palette, runs `LikeC4: Open Preview`, selects the default view, waits for the webview, and captures the VS Code window.
+
+If the command palette flow changes, prefer adjusting the script inputs or timing over taking manual screenshots. Manual screenshots are acceptable only when automation is blocked and the PR explicitly says so.
+
+## Inspect evidence
+
+Check file metadata and visually inspect both images:
+
+```bash
+identify "$OUT/before-vscode.png" "$OUT/after-vscode.png"
+```
+
+Expected evidence should show:
+
+- the same fixture and VS Code preview in both screenshots
+- the reported broken state in the before image
+- the fixed state in the after image
+- enough surrounding VS Code UI to prove the capture is not a browser-only rendering
+
+## Add screenshots to the PR
+
+Prefer GitHub attachment URLs when a session token is available:
+
+```bash
+gh image --repo likec4/likec4 "$OUT/before-vscode.png" "$OUT/after-vscode.png"
+```
+
+If `gh image` fails because browser cookies or `GH_SESSION_TOKEN` are unavailable, use a dedicated asset branch rather than committing images into the fix branch:
+
+```bash
+ASSET_BRANCH=cgk/pr-NNNN-vscode-screenshots
+ASSET_WORKTREE=$(mktemp -d /tmp/likec4-pr-NNNN-assets.XXXXXX)
+
+cd "$ASSET_WORKTREE"
+git init
+git remote add origin https://github.com/likec4/likec4.git
+git checkout --orphan "$ASSET_BRANCH"
+mkdir -p pr-assets/prNNNN
+cp "$OUT/before-vscode.png" pr-assets/prNNNN/before-vscode.png
+cp "$OUT/after-vscode.png" pr-assets/prNNNN/after-vscode.png
+git add pr-assets/prNNNN/before-vscode.png pr-assets/prNNNN/after-vscode.png
+git commit -m "docs: add prNNNN vscode screenshots"
+git push origin HEAD:refs/heads/"$ASSET_BRANCH"
+```
+
+Then embed raw URLs in the PR body:
+
+```markdown
+## VS Code screenshots
+
+Captured from a real VS Code Extension Development Host under Xvfb against the issue fixture.
+
+| Before (`origin/main`)                           | After (this PR)                               |
+| ------------------------------------------------ | --------------------------------------------- |
+| ![Before: describe broken state](RAW_BEFORE_URL) | ![After: describe fixed state](RAW_AFTER_URL) |
+```
+
+After editing, verify the PR body:
+
+```bash
+gh pr view PR --repo likec4/likec4 --json body,url
+```

--- a/.agents/skills/vscode-extension-screenshot-evidence/SKILL.md
+++ b/.agents/skills/vscode-extension-screenshot-evidence/SKILL.md
@@ -14,6 +14,7 @@ Capture visual evidence from a real VS Code Extension Development Host. Use brow
 - Use `origin/main` or the PR base for "before" and the PR branch for "after".
 - Keep screenshots and temporary fixtures out of the fix branch unless the user explicitly wants image assets committed.
 - Visually inspect the captured images before adding them to a PR.
+- Do not publish screenshots until you have confirmed they contain no secrets, usernames, home-directory paths, private tabs, unrelated files, or unrelated windows.
 - Mention any hosting fallback used for images. GitHub `user-attachments` uploads require a browser `user_session` cookie or `GH_SESSION_TOKEN`; the normal `gh` token is not enough.
 
 ## Prerequisites
@@ -25,9 +26,17 @@ command -v code
 command -v Xvfb
 command -v xdotool
 command -v import
+command -v python3
+command -v file
 ```
 
-`import` is from ImageMagick. If `DISPLAY` is not already set, run the capture command under `xvfb-run -a`.
+`import` is from ImageMagick. Always run the capture command under an isolated Xvfb display, even when `DISPLAY` is already set. Use an explicit screen size so the default 1280x900 window is not cropped:
+
+```bash
+xvfb-run -a -s "-screen 0 1280x1024x24" ...
+```
+
+The helper script refuses common live-desktop displays such as `:0` and `:1` unless `--allow-live-display` is passed for manual debugging. Do not use live-desktop captures as PR evidence unless you have cropped or redacted them.
 
 ## Build the extension under test
 
@@ -80,13 +89,13 @@ OUT=/tmp/likec4-vscode-screens
 
 mkdir -p "$OUT"
 
-xvfb-run -a "$SKILL/scripts/capture-likec4-vscode-preview.sh" \
+xvfb-run -a -s "-screen 0 1280x1024x24" "$SKILL/scripts/capture-likec4-vscode-preview.sh" \
   --label before \
   --fixture "$FIXTURE" \
   --extension-path /tmp/likec4-before/packages/vscode \
   --output "$OUT/before-vscode.png"
 
-xvfb-run -a "$SKILL/scripts/capture-likec4-vscode-preview.sh" \
+xvfb-run -a -s "-screen 0 1280x1024x24" "$SKILL/scripts/capture-likec4-vscode-preview.sh" \
   --label after \
   --fixture "$FIXTURE" \
   --extension-path /path/to/pr-worktree/packages/vscode \
@@ -111,24 +120,29 @@ Expected evidence should show:
 - the reported broken state in the before image
 - the fixed state in the after image
 - enough surrounding VS Code UI to prove the capture is not a browser-only rendering
+- no usernames, home-directory paths, tokens, private tabs, unrelated files, or unrelated windows
 
 ## Add screenshots to the PR
 
-Prefer GitHub attachment URLs when a session token is available:
+Prefer GitHub attachment URLs when the `gh image` extension and a session token are available:
 
 ```bash
+gh extension list | grep -F "drogers0/gh-image" || gh extension install drogers0/gh-image
 gh image --repo likec4/likec4 "$OUT/before-vscode.png" "$OUT/after-vscode.png"
 ```
+
+`gh image` is not a built-in `gh` command. It uses GitHub's web upload flow and needs a browser `user_session` cookie or `GH_SESSION_TOKEN`; treat that session token like a password.
 
 If `gh image` fails because browser cookies or `GH_SESSION_TOKEN` are unavailable, use a dedicated asset branch rather than committing images into the fix branch:
 
 ```bash
 ASSET_BRANCH=cgk/pr-NNNN-vscode-screenshots
 ASSET_WORKTREE=$(mktemp -d /tmp/likec4-pr-NNNN-assets.XXXXXX)
+ASSET_REPO=OWNER/likec4
 
 cd "$ASSET_WORKTREE"
 git init
-git remote add origin https://github.com/likec4/likec4.git
+git remote add origin "https://github.com/${ASSET_REPO}.git"
 git checkout --orphan "$ASSET_BRANCH"
 mkdir -p pr-assets/prNNNN
 cp "$OUT/before-vscode.png" pr-assets/prNNNN/before-vscode.png
@@ -138,12 +152,19 @@ git commit -m "docs: add prNNNN vscode screenshots"
 git push origin HEAD:refs/heads/"$ASSET_BRANCH"
 ```
 
+Use a fork for `ASSET_REPO` unless you intentionally want a maintainer-owned upstream asset branch. If you use the upstream repository, delete the asset branch after the PR no longer needs it:
+
+```bash
+git push origin --delete "$ASSET_BRANCH"
+```
+
 Then embed raw URLs in the PR body:
 
 ```markdown
 ## VS Code screenshots
 
 Captured from a real VS Code Extension Development Host under Xvfb against the issue fixture.
+Screenshots were checked for sensitive or unrelated visible content before upload.
 
 | Before (`origin/main`)                           | After (this PR)                               |
 | ------------------------------------------------ | --------------------------------------------- |

--- a/.agents/skills/vscode-extension-screenshot-evidence/SKILL.md
+++ b/.agents/skills/vscode-extension-screenshot-evidence/SKILL.md
@@ -36,7 +36,7 @@ command -v file
 xvfb-run -a -s "-screen 0 1280x1024x24" ...
 ```
 
-The helper script refuses common live-desktop displays such as `:0` and `:1` unless `--allow-live-display` is passed for manual debugging. Do not use live-desktop captures as PR evidence unless you have cropped or redacted them.
+The helper script runs without `--allow-live-display` only when it verifies that `DISPLAY` belongs to an active Xvfb process. All other display values, including `:2` and remote displays, require `--allow-live-display` for manual debugging. Do not use live-desktop captures as PR evidence unless you have cropped or redacted them.
 
 ## Build the extension under test
 
@@ -148,6 +148,10 @@ mkdir -p pr-assets/prNNNN
 cp "$OUT/before-vscode.png" pr-assets/prNNNN/before-vscode.png
 cp "$OUT/after-vscode.png" pr-assets/prNNNN/after-vscode.png
 git add pr-assets/prNNNN/before-vscode.png pr-assets/prNNNN/after-vscode.png
+if ! git config user.name >/dev/null || ! git config user.email >/dev/null; then
+  echo "Set Git author identity before committing: git config user.name 'Your Name'; git config user.email 'you@example.com'" >&2
+  exit 1
+fi
 git commit -m "docs: add prNNNN vscode screenshots"
 git push origin HEAD:refs/heads/"$ASSET_BRANCH"
 ```

--- a/.agents/skills/vscode-extension-screenshot-evidence/scripts/capture-likec4-vscode-preview.sh
+++ b/.agents/skills/vscode-extension-screenshot-evidence/scripts/capture-likec4-vscode-preview.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  capture-likec4-vscode-preview.sh \
+    --label before|after \
+    --fixture /path/to/fixture-folder \
+    --extension-path /path/to/likec4/packages/vscode \
+    --output /path/to/screenshot.png
+
+Options:
+  --command "LikeC4: Open Preview"  VS Code command palette text to run.
+  --wait-seconds 18                 Seconds to wait after selecting the view.
+  --window-size 1280x900            Screenshot window size.
+USAGE
+}
+
+label=""
+fixture=""
+extension_path=""
+out_png=""
+command_text="LikeC4: Open Preview"
+wait_seconds="18"
+window_size="1280x900"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --label)
+      label="${2:-}"
+      shift 2
+      ;;
+    --fixture)
+      fixture="${2:-}"
+      shift 2
+      ;;
+    --extension-path)
+      extension_path="${2:-}"
+      shift 2
+      ;;
+    --output)
+      out_png="${2:-}"
+      shift 2
+      ;;
+    --command)
+      command_text="${2:-}"
+      shift 2
+      ;;
+    --wait-seconds)
+      wait_seconds="${2:-}"
+      shift 2
+      ;;
+    --window-size)
+      window_size="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$label" || -z "$fixture" || -z "$extension_path" || -z "$out_png" ]]; then
+  usage >&2
+  exit 2
+fi
+
+for required in code xdotool import python3; do
+  if ! command -v "$required" >/dev/null 2>&1; then
+    echo "Missing required command: $required" >&2
+    exit 1
+  fi
+done
+
+if [[ -z "${DISPLAY:-}" ]]; then
+  echo "DISPLAY is not set. Run this script under xvfb-run -a or start Xvfb first." >&2
+  exit 1
+fi
+
+if [[ ! -d "$fixture" ]]; then
+  echo "Fixture folder does not exist: $fixture" >&2
+  exit 1
+fi
+
+if [[ ! -d "$extension_path" ]]; then
+  echo "Extension path does not exist: $extension_path" >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$out_png")"
+
+user_data="$(mktemp -d "/tmp/likec4-vscode-${label}-user.XXXXXX")"
+extensions_dir="$(mktemp -d "/tmp/likec4-vscode-${label}-extensions.XXXXXX")"
+log_file="${out_png%.png}.log"
+
+mkdir -p "${user_data}/User"
+USER_DATA="$user_data" python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+settings = {
+    "workbench.colorTheme": "Default Dark Modern",
+    "workbench.startupEditor": "none",
+    "security.workspace.trust.enabled": False,
+    "telemetry.telemetryLevel": "off",
+    "window.restoreWindows": "none",
+    "workbench.editor.enablePreview": False,
+}
+
+Path(os.environ["USER_DATA"], "User", "settings.json").write_text(
+    json.dumps(settings, indent=2),
+    encoding="utf-8",
+)
+PY
+
+code \
+  --new-window \
+  --wait \
+  --user-data-dir "$user_data" \
+  --extensions-dir "$extensions_dir" \
+  --extensionDevelopmentPath="$extension_path" \
+  --disable-gpu \
+  --disable-workspace-trust \
+  --skip-welcome \
+  --skip-release-notes \
+  "$fixture" >"$log_file" 2>&1 &
+code_pid="$!"
+
+cleanup() {
+  set +e
+  xdotool key --clearmodifiers alt+F4 >/dev/null 2>&1
+  sleep 1
+  kill "$code_pid" >/dev/null 2>&1
+  pkill -f "$user_data" >/dev/null 2>&1
+}
+trap cleanup EXIT
+
+window_id=""
+for _ in $(seq 1 60); do
+  window_id="$(xdotool search --onlyvisible --class code 2>/dev/null | tail -n 1 || true)"
+  if [[ -n "$window_id" ]]; then
+    break
+  fi
+  sleep 1
+done
+
+if [[ -z "$window_id" ]]; then
+  echo "No VS Code window found; log follows:" >&2
+  sed -n '1,200p' "$log_file" >&2 || true
+  exit 1
+fi
+
+width="${window_size%x*}"
+height="${window_size#*x}"
+if [[ -z "$width" || -z "$height" || "$width" = "$window_size" ]]; then
+  echo "Invalid --window-size value: $window_size" >&2
+  exit 2
+fi
+
+xdotool windowfocus "$window_id"
+xdotool windowsize "$window_id" "$width" "$height"
+xdotool windowmove "$window_id" 0 0
+
+sleep 8
+xdotool key --clearmodifiers ctrl+shift+p
+sleep 1
+xdotool type --delay 1 "$command_text"
+sleep 1
+xdotool key --clearmodifiers Return
+sleep 3
+xdotool key --clearmodifiers Return
+sleep "$wait_seconds"
+
+import -window root "$out_png"
+file "$out_png"

--- a/.agents/skills/vscode-extension-screenshot-evidence/scripts/capture-likec4-vscode-preview.sh
+++ b/.agents/skills/vscode-extension-screenshot-evidence/scripts/capture-likec4-vscode-preview.sh
@@ -14,6 +14,8 @@ Options:
   --command "LikeC4: Open Preview"  VS Code command palette text to run.
   --wait-seconds 18                 Seconds to wait after selecting the view.
   --window-size 1280x900            Screenshot window size.
+  --allow-live-display              Allow running on common live desktop DISPLAY values.
+  --keep-temp                       Keep temporary VS Code user-data dirs for debugging.
 USAGE
 }
 
@@ -24,6 +26,8 @@ out_png=""
 command_text="LikeC4: Open Preview"
 wait_seconds="18"
 window_size="1280x900"
+allow_live_display="false"
+keep_temp="false"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -55,6 +59,14 @@ while [[ $# -gt 0 ]]; do
       window_size="${2:-}"
       shift 2
       ;;
+    --allow-live-display)
+      allow_live_display="true"
+      shift
+      ;;
+    --keep-temp)
+      keep_temp="true"
+      shift
+      ;;
     -h|--help)
       usage
       exit 0
@@ -72,7 +84,7 @@ if [[ -z "$label" || -z "$fixture" || -z "$extension_path" || -z "$out_png" ]]; 
   exit 2
 fi
 
-for required in code xdotool import python3; do
+for required in code xdotool import python3 file; do
   if ! command -v "$required" >/dev/null 2>&1; then
     echo "Missing required command: $required" >&2
     exit 1
@@ -83,6 +95,16 @@ if [[ -z "${DISPLAY:-}" ]]; then
   echo "DISPLAY is not set. Run this script under xvfb-run -a or start Xvfb first." >&2
   exit 1
 fi
+
+case "$DISPLAY" in
+  :0|:0.*|:1|:1.*)
+    if [[ "$allow_live_display" != "true" ]]; then
+      echo "Refusing to run against likely live desktop DISPLAY=$DISPLAY." >&2
+      echo "Run under xvfb-run -a -s '-screen 0 1280x1024x24', or pass --allow-live-display for manual debugging." >&2
+      exit 1
+    fi
+    ;;
+esac
 
 if [[ ! -d "$fixture" ]]; then
   echo "Fixture folder does not exist: $fixture" >&2
@@ -96,6 +118,16 @@ fi
 
 mkdir -p "$(dirname "$out_png")"
 
+search_code_windows() {
+  {
+    xdotool search --onlyvisible --classname code 2>/dev/null || true
+    xdotool search --onlyvisible --class code 2>/dev/null || true
+    xdotool search --onlyvisible --class Code 2>/dev/null || true
+  } | awk '!seen[$0]++'
+}
+
+existing_windows="$(search_code_windows || true)"
+fixture_name="$(basename "$fixture")"
 user_data="$(mktemp -d "/tmp/likec4-vscode-${label}-user.XXXXXX")"
 extensions_dir="$(mktemp -d "/tmp/likec4-vscode-${label}-extensions.XXXXXX")"
 log_file="${out_png%.png}.log"
@@ -133,22 +165,44 @@ code \
   --skip-release-notes \
   "$fixture" >"$log_file" 2>&1 &
 code_pid="$!"
+window_id=""
 
 cleanup() {
   set +e
-  xdotool key --clearmodifiers alt+F4 >/dev/null 2>&1
+  if [[ -n "${window_id:-}" ]]; then
+    xdotool windowfocus "$window_id" >/dev/null 2>&1
+    xdotool key --window "$window_id" --clearmodifiers alt+F4 >/dev/null 2>&1
+  fi
   sleep 1
   kill "$code_pid" >/dev/null 2>&1
   pkill -f "$user_data" >/dev/null 2>&1
+  if [[ "$keep_temp" != "true" ]]; then
+    rm -rf "$user_data" "$extensions_dir"
+  else
+    echo "Kept temp dirs: $user_data $extensions_dir" >&2
+  fi
 }
 trap cleanup EXIT
 
-window_id=""
 for _ in $(seq 1 60); do
-  window_id="$(xdotool search --onlyvisible --class code 2>/dev/null | tail -n 1 || true)"
-  if [[ -n "$window_id" ]]; then
-    break
-  fi
+  fallback_window_id=""
+  while IFS= read -r candidate; do
+    if [[ -z "$candidate" ]]; then
+      continue
+    fi
+    if grep -Fxq "$candidate" <<<"$existing_windows"; then
+      continue
+    fi
+    title="$(xdotool getwindowname "$candidate" 2>/dev/null || true)"
+    fallback_window_id="${fallback_window_id:-$candidate}"
+    if [[ "$title" == *"Extension Development Host"* || "$title" == *"$fixture_name"* ]]; then
+      window_id="$candidate"
+      break
+    fi
+  done < <(search_code_windows)
+
+  window_id="${window_id:-$fallback_window_id}"
+  [[ -n "$window_id" ]] && break
   sleep 1
 done
 
@@ -170,14 +224,15 @@ xdotool windowsize "$window_id" "$width" "$height"
 xdotool windowmove "$window_id" 0 0
 
 sleep 8
-xdotool key --clearmodifiers ctrl+shift+p
+xdotool windowfocus "$window_id"
+xdotool key --window "$window_id" --clearmodifiers ctrl+shift+p
 sleep 1
-xdotool type --delay 1 "$command_text"
+xdotool type --window "$window_id" --delay 1 "$command_text"
 sleep 1
-xdotool key --clearmodifiers Return
+xdotool key --window "$window_id" --clearmodifiers Return
 sleep 3
-xdotool key --clearmodifiers Return
+xdotool key --window "$window_id" --clearmodifiers Return
 sleep "$wait_seconds"
 
-import -window root "$out_png"
+import -window "$window_id" "$out_png"
 file "$out_png"

--- a/.agents/skills/vscode-extension-screenshot-evidence/scripts/capture-likec4-vscode-preview.sh
+++ b/.agents/skills/vscode-extension-screenshot-evidence/scripts/capture-likec4-vscode-preview.sh
@@ -14,7 +14,7 @@ Options:
   --command "LikeC4: Open Preview"  VS Code command palette text to run.
   --wait-seconds 18                 Seconds to wait after selecting the view.
   --window-size 1280x900            Screenshot window size.
-  --allow-live-display              Allow running on common live desktop DISPLAY values.
+  --allow-live-display              Allow running with an unverified DISPLAY value.
   --keep-temp                       Keep temporary VS Code user-data dirs for debugging.
 USAGE
 }
@@ -96,15 +96,31 @@ if [[ -z "${DISPLAY:-}" ]]; then
   exit 1
 fi
 
-case "$DISPLAY" in
-  :0|:0.*|:1|:1.*)
-    if [[ "$allow_live_display" != "true" ]]; then
-      echo "Refusing to run against likely live desktop DISPLAY=$DISPLAY." >&2
-      echo "Run under xvfb-run -a -s '-screen 0 1280x1024x24', or pass --allow-live-display for manual debugging." >&2
-      exit 1
-    fi
-    ;;
-esac
+is_isolated_xvfb_display() {
+  local display_number="${DISPLAY%%.*}"
+  local pid
+  local command
+  local arguments
+  local argument
+
+  [[ "$display_number" =~ ^:[0-9]+$ ]] || return 1
+
+  while read -r pid command; do
+    [[ "$command" == "Xvfb" ]] || continue
+    arguments="$(ps -p "$pid" -o args=)"
+    for argument in $arguments; do
+      [[ "$argument" == "$display_number" ]] && return 0
+    done
+  done < <(ps -eo pid=,comm=)
+
+  return 1
+}
+
+if ! is_isolated_xvfb_display && [[ "$allow_live_display" != "true" ]]; then
+  echo "DISPLAY=$DISPLAY is not verified as an isolated Xvfb display." >&2
+  echo "Run under xvfb-run -a -s '-screen 0 1280x1024x24', or pass --allow-live-display for manual debugging." >&2
+  exit 1
+fi
 
 if [[ ! -d "$fixture" ]]; then
   echo "Fixture folder does not exist: $fixture" >&2

--- a/.claude/skills/vscode-extension-screenshot-evidence
+++ b/.claude/skills/vscode-extension-screenshot-evidence
@@ -1,0 +1,1 @@
+../../.agents/skills/vscode-extension-screenshot-evidence

--- a/devops/check-agent-skills.mjs
+++ b/devops/check-agent-skills.mjs
@@ -35,6 +35,7 @@ const expectedClaudeSkillLinks = new Map([
   ['.claude/skills/likec4-issue-repro', '../../.agents/skills/likec4-issue-repro'],
   ['.claude/skills/likec4-project-config-workflow', '../../.agents/skills/likec4-project-config-workflow'],
   ['.claude/skills/refactor', '../../.agents/skills/refactor'],
+  ['.claude/skills/vscode-extension-screenshot-evidence', '../../.agents/skills/vscode-extension-screenshot-evidence'],
 ])
 
 const fail = message => failures.push(message)

--- a/devops/check-agent-skills.mjs
+++ b/devops/check-agent-skills.mjs
@@ -45,6 +45,17 @@ const gitPathJoin = (...segments) => path.posix.normalize(path.posix.join(...seg
 const legacyLikeC4SkillMetadataFields = new Set([
   'disable-model-invocation',
 ])
+const skillScriptSmokeChecks = new Map([
+  [
+    '.agents/skills/vscode-extension-screenshot-evidence/scripts/capture-likec4-vscode-preview.sh',
+    [
+      '--fixture',
+      '--extension-path',
+      '--output',
+      '--allow-live-display',
+    ],
+  ],
+])
 
 const validateSkillFile = relativePath => {
   if (!existsSync(absolute(relativePath))) {
@@ -86,6 +97,53 @@ const validateSkillFile = relativePath => {
 
   if (!body.trim()) {
     fail(`${relativePath} must contain a non-empty skill body after frontmatter`)
+  }
+}
+
+const validateSkillScript = (relativePath, expectedHelpFragments) => {
+  const entry = tracked.get(relativePath)
+  if (!entry) {
+    fail(`${relativePath} must be tracked`)
+    return
+  }
+
+  if (entry.mode !== '100755') {
+    fail(`${relativePath} must be tracked as executable, but git mode is ${entry.mode}`)
+    return
+  }
+
+  if (!existsSync(absolute(relativePath))) {
+    fail(`${relativePath} must exist`)
+    return
+  }
+
+  try {
+    execFileSync('bash', ['-n', absolute(relativePath)], {
+      cwd: root,
+      encoding: 'utf8',
+      stdio: 'pipe',
+    })
+  } catch (error) {
+    fail(`${relativePath} must pass bash -n: ${error.stderr || error.message}`)
+    return
+  }
+
+  let help
+  try {
+    help = execFileSync(absolute(relativePath), ['--help'], {
+      cwd: root,
+      encoding: 'utf8',
+      stdio: 'pipe',
+    })
+  } catch (error) {
+    fail(`${relativePath} --help must exit successfully: ${error.stderr || error.message}`)
+    return
+  }
+
+  for (const fragment of expectedHelpFragments) {
+    if (!help.includes(fragment)) {
+      fail(`${relativePath} --help must mention ${fragment}`)
+    }
   }
 }
 
@@ -172,6 +230,10 @@ for (const skillFile of trackedSkillFiles) {
   if (!expectedClaudeSkillTargets.has(skillDir)) {
     fail(`${skillDir} is tracked but missing an explicit Claude skill symlink adapter`)
   }
+}
+
+for (const [scriptFile, expectedHelpFragments] of skillScriptSmokeChecks) {
+  validateSkillScript(scriptFile, expectedHelpFragments)
 }
 
 if (failures.length > 0) {

--- a/devops/check-agent-skills.spec.mjs
+++ b/devops/check-agent-skills.spec.mjs
@@ -20,6 +20,7 @@ const expectedClaudeSkillLinks = new Map([
   ['.claude/skills/likec4-issue-repro', '../../.agents/skills/likec4-issue-repro'],
   ['.claude/skills/likec4-project-config-workflow', '../../.agents/skills/likec4-project-config-workflow'],
   ['.claude/skills/refactor', '../../.agents/skills/refactor'],
+  ['.claude/skills/vscode-extension-screenshot-evidence', '../../.agents/skills/vscode-extension-screenshot-evidence'],
 ])
 
 afterEach(() => {

--- a/devops/check-agent-skills.spec.mjs
+++ b/devops/check-agent-skills.spec.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import { execFileSync, spawnSync } from 'node:child_process'
-import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { afterEach, describe, it } from 'node:test'
@@ -35,6 +35,11 @@ function writeFixtureFile(root, relativePath, content) {
   writeFileSync(file, content)
 }
 
+function writeFixtureExecutable(root, relativePath, content) {
+  writeFixtureFile(root, relativePath, content)
+  chmodSync(path.join(root, relativePath), 0o755)
+}
+
 function createSymlink(root, relativePath, target) {
   const link = path.join(root, relativePath)
   mkdirSync(path.dirname(link), { recursive: true })
@@ -64,6 +69,19 @@ function validSkill(name) {
   }---\n\n# ${name}\n\nUse this skill in tests.\n`
 }
 
+function validScreenshotScript() {
+  return `#!/usr/bin/env bash
+if [[ "\${1:-}" = "--help" ]]; then
+  echo "--fixture"
+  echo "--extension-path"
+  echo "--output"
+  echo "--allow-live-display"
+  exit 0
+fi
+exit 0
+`
+}
+
 function createFixture(customize) {
   const root = mkdtempSync(path.join(tmpdir(), 'likec4-agent-skills-check-'))
   tempRoots.push(root)
@@ -72,6 +90,16 @@ function createFixture(customize) {
 
   for (const [linkPath, target] of expectedClaudeSkillLinks) {
     writeFixtureFile(root, targetSkillPath(linkPath, target), validSkill(path.posix.basename(linkPath)))
+    if (path.posix.basename(linkPath) === 'vscode-extension-screenshot-evidence') {
+      writeFixtureExecutable(
+        root,
+        path.posix.join(
+          path.posix.dirname(targetSkillPath(linkPath, target)),
+          'scripts/capture-likec4-vscode-preview.sh',
+        ),
+        validScreenshotScript(),
+      )
+    }
     createSymlink(root, linkPath, target)
   }
 
@@ -205,6 +233,18 @@ describe('check-agent-skills', () => {
         )
       }),
       /\.agents\/skills\/likec4-cli-codegen-regression\/SKILL\.md must contain a non-empty skill body after frontmatter/,
+    )
+  })
+
+  it('rejects missing checked skill helper scripts', () => {
+    expectFail(
+      createFixture(root => {
+        removeFixturePath(
+          root,
+          '.agents/skills/vscode-extension-screenshot-evidence/scripts/capture-likec4-vscode-preview.sh',
+        )
+      }),
+      /vscode-extension-screenshot-evidence\/scripts\/capture-likec4-vscode-preview\.sh must be tracked/,
     )
   })
 })


### PR DESCRIPTION
Follow-up to #3096.

## Summary

- Add a repo-local skill for collecting real before/after screenshots from the VS Code Extension Development Host.
- Include a reusable Xvfb/xdotool/ImageMagick helper script for opening the LikeC4 preview and capturing the VS Code window.
- Harden the helper around isolated-display usage, selected-window capture, temporary directory cleanup, live-desktop refusal, screenshot redaction checks, and asset upload guidance.
- Add the matching Claude skill symlink and validator entries so the new skill and helper script stay discoverable and checked.

## Validation

- python3 /home/ckeller/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/vscode-extension-screenshot-evidence
- bash -n .agents/skills/vscode-extension-screenshot-evidence/scripts/capture-likec4-vscode-preview.sh
- .agents/skills/vscode-extension-screenshot-evidence/scripts/capture-likec4-vscode-preview.sh --help
- DISPLAY=:0 .agents/skills/vscode-extension-screenshot-evidence/scripts/capture-likec4-vscode-preview.sh --label test --fixture /tmp --extension-path /tmp --output /tmp/unused.png rejects likely live desktop capture
- node_modules/.bin/dprint check .agents/skills/vscode-extension-screenshot-evidence/SKILL.md .agents/skills/vscode-extension-screenshot-evidence/scripts/capture-likec4-vscode-preview.sh devops/check-agent-skills.mjs devops/check-agent-skills.spec.mjs
- pnpm check:agent-instructions
- git diff --check

## Notes

- This PR targets the skills branch from #3096, not main.
- No changeset: repo-local skill/docs only.
