### PR TITLE
fix(language-server): do not duplicate keyword in completions

### DIFF
--- a/.changeset/fix-completion-duplicate-keyword.md
+++ b/.changeset/fix-completion-duplicate-keyword.md
@@ -1,0 +1,5 @@
+---
+'@likec4/language-server': patch
+---
+
+Fix keyword completions inserting the keyword twice (e.g. `modelmodel`) in editors other than VS Code. Snippet and property completions now provide an explicit text edit that replaces the typed prefix, instead of relying on the client to prefer it over the plain insert text.

--- a/packages/language-server/src/lsp/CompletionProvider.spec.ts
+++ b/packages/language-server/src/lsp/CompletionProvider.spec.ts
@@ -1167,4 +1167,54 @@ describe('LikeC4CompletionProvider', () => {
       ],
     })
   })
+
+  // Issue #3091 - completion items must carry an explicit textEdit,
+  // otherwise clients relying on insertText duplicate the typed keyword ("modelmodel")
+  it('should not duplicate typed keyword in snippet completions', async ({ expect, completion }) => {
+    const text = `mod<|>`
+    await completion({
+      text,
+      index: 0,
+      assert: completions => {
+        const item = completions.items.find(i => i.label === 'model')
+        expect(item, 'expected a "model" completion item').toBeDefined()
+        // The typed prefix `mod` must be replaced, not appended to
+        expect(item!.textEdit).toEqual({
+          newText: 'model {\n\t$0\n}',
+          range: {
+            start: { line: 0, character: 0 },
+            end: { line: 0, character: 3 },
+          },
+        })
+        // insertText must never be the sole carrier of the snippet, otherwise
+        // clients that ignore textEdit insert at the cursor and duplicate the keyword
+        expect(item!.insertText).toBeUndefined()
+      },
+    })
+  })
+
+  it('should not duplicate typed keyword in property completions', async ({ expect, completion }) => {
+    const text = `
+      specification {
+        element component
+      }
+      model {
+        component c1 {
+          titl<|>
+        }
+      }
+    `
+    await completion({
+      text,
+      index: 0,
+      assert: completions => {
+        const item = completions.items.find(i => i.label === 'title')
+        expect(item, 'expected a "title" completion item').toBeDefined()
+        expect(item!.textEdit).toMatchObject({
+          newText: `title '$0'`,
+        })
+        expect(item!.insertText).toBeUndefined()
+      },
+    })
+  })
 })

--- a/packages/language-server/src/lsp/CompletionProvider.spec.ts
+++ b/packages/language-server/src/lsp/CompletionProvider.spec.ts
@@ -1210,11 +1210,56 @@ describe('LikeC4CompletionProvider', () => {
       assert: completions => {
         const item = completions.items.find(i => i.label === 'title')
         expect(item, 'expected a "title" completion item').toBeDefined()
+        // The typed prefix `titl` must be replaced, not appended to
         expect(item!.textEdit).toMatchObject({
           newText: `title '$0'`,
+          range: {
+            start: { line: 6, character: 10 },
+            end: { line: 6, character: 14 },
+          },
         })
         expect(item!.insertText).toBeUndefined()
       },
     })
+  })
+
+  it('should not duplicate typed keyword in predicate completions', async ({ expect, completion }) => {
+    const text = `
+      specification {
+        element component
+      }
+      model {
+        component c1
+      }
+      views {
+        view v1 {
+          inc<|>
+        }
+        view v2 {
+          include *
+          exc<|>
+        }
+      }
+    `
+    // `include` is on line 9, `exclude` on line 13
+    for (const [index, [keyword, line]] of ([['include', 9], ['exclude', 13]] as const).entries()) {
+      await completion({
+        text,
+        index,
+        assert: completions => {
+          const item = completions.items.find(i => i.label === keyword)
+          expect(item, `expected an "${keyword}" completion item`).toBeDefined()
+          // The typed 3-char prefix must be replaced, not appended to
+          expect(item!.textEdit).toMatchObject({
+            newText: `${keyword} `,
+            range: {
+              start: { line, character: 10 },
+              end: { line, character: 13 },
+            },
+          })
+          expect(item!.insertText).toBeUndefined()
+        },
+      })
+    }
   })
 })

--- a/packages/language-server/src/lsp/CompletionProvider.ts
+++ b/packages/language-server/src/lsp/CompletionProvider.ts
@@ -209,13 +209,11 @@ export class LikeC4CompletionProvider extends DefaultCompletionProvider {
         acceptPropertyAndSuggest(['sequence', 'diagram'])
         break
       case ['include', 'exclude'].includes(keyword.value):
-        acceptor(context, {
-          label: keyword.value,
+        acceptReplacing({
           kind: CompletionItemKind.Operator,
           detail: `Insert ${keyword.value} predicate`,
           insertTextFormat: InsertTextFormat.PlainText,
-          insertText: `${keyword.value} `,
-        })
+        }, `${keyword.value} `)
         break
       default:
         acceptor(context, {

--- a/packages/language-server/src/lsp/CompletionProvider.ts
+++ b/packages/language-server/src/lsp/CompletionProvider.ts
@@ -63,25 +63,40 @@ export class LikeC4CompletionProvider extends DefaultCompletionProvider {
       return
     }
 
-    const acceptProperty = (insertAfterText: string) => {
+    /**
+     * The generated text starts with the keyword itself, so it must replace the
+     * already typed prefix. We provide an explicit `textEdit` instead of `insertText`,
+     * because clients that apply `insertText` at the cursor would duplicate the
+     * keyword (see https://github.com/likec4/likec4/issues/3091)
+     */
+    const acceptReplacing = (item: Partial<CompletionItem>, newText: string) => {
+      // Keep the default fuzzy-matching behavior, which also decides
+      // whether the item is offered at all for the typed prefix
+      const textEdit = this.buildCompletionTextEdit(context, keyword.value, newText)
+      if (!textEdit) {
+        return
+      }
       acceptor(context, {
         label: keyword.value,
-        detail: `Insert ${keyword.value} property`,
-        kind: CompletionItemKind.Property,
         insertTextFormat: InsertTextFormat.Snippet,
-        insertText: `${keyword.value} ${insertAfterText}`,
+        ...item,
+        textEdit,
       })
     }
 
+    const acceptProperty = (insertAfterText: string) => {
+      acceptReplacing({
+        detail: `Insert ${keyword.value} property`,
+        kind: CompletionItemKind.Property,
+      }, `${keyword.value} ${insertAfterText}`)
+    }
+
     const acceptSnippet = ({ insertText, ...item }: SetRequired<Partial<CompletionItem>, 'insertText'>) => {
-      acceptor(context, {
-        label: keyword.value,
+      acceptReplacing({
         detail: `Insert ${keyword.value}`,
         kind: CompletionItemKind.Snippet,
-        insertTextFormat: InsertTextFormat.Snippet,
         ...item,
-        insertText: `${keyword.value} ${insertText}`,
-      })
+      }, `${keyword.value} ${insertText}`)
     }
 
     const acceptPropertyAndSuggest = (variants: readonly string[]) => {


### PR DESCRIPTION
Closes #3091

## Problem

Keyword completions build an `insertText` that **starts with the keyword itself**, but do not set a `textEdit`:

https://github.com/likec4/likec4/blob/v1.59.2/packages/language-server/src/lsp/CompletionProvider.ts#L76-L85

Langium's `fillCompletionItem` then emits an item carrying **both** the `insertText` and a derived `textEdit` whose range replaces the typed token.

Per LSP, a client must prefer `textEdit` — VS Code does, so completions look correct there. Clients that apply `insertText` at the cursor instead insert the keyword a second time. Typing `model` and accepting the suggestion produces `modelmodel`, as reported on Zed.

This affected every snippet/property keyword, not just `model`: `views`, `specification`, `deployment`, `style`, `group`, `title`, `description`, and so on.

## Fix

Provide an explicit `textEdit` for these items so the typed prefix is always replaced, regardless of how the client resolves the item.

The helper delegates to the inherited `buildCompletionTextEdit`, which means the existing fuzzy-match gating is preserved — items are still only offered when the typed prefix matches the keyword. This was important: an earlier attempt that built the range by hand and set `filterText` regressed 10 tests by bypassing that gate.

No behaviour change in VS Code, which already used the `textEdit`.

## Tests

Two tests in `CompletionProvider.spec.ts` assert the emitted payload directly, which the existing tests did not cover (they only ever assert `label`):

- typing `mod` → the `model` item's `textEdit` replaces `[0,0]-[0,3]` with `model {\n\t$0\n}`, and `insertText` is absent
- typing `titl` inside an element → the `title` item's `textEdit` carries `title '$0'`

Both fail before the fix (`expected 'model {\n\t$0\n}' to be undefined`) and pass after.

## Verification

- `pnpm vitest run --project language-server packages/language-server/src/lsp/CompletionProvider.spec.ts` → 19 passed, 1 todo
- Full `--project language-server` suite compared against `main`: same results, no regressions (+2 from the new tests)
- `tsc --noEmit` clean, oxlint clean, dprint clean

