### PR TITLE
feat(language-server): allow global predicates inside view groups

### DIFF
--- a/.changeset/global-predicate-in-group.md
+++ b/.changeset/global-predicate-in-group.md
@@ -1,0 +1,19 @@
+---
+'@likec4/language-server': patch
+'@likec4/generators': patch
+'@likec4/core': patch
+---
+
+Allow referencing global predicate groups inside view groups, so a reusable set of predicates can be scoped into a named group:
+
+```likec4
+views {
+  view of newServices {
+    include cloud.new.*
+
+    group 'Microservices' {
+      global predicate microservices
+    }
+  }
+}
+```

--- a/apps/docs/src/content/docs/dsl/Views/predicates.mdx
+++ b/apps/docs/src/content/docs/dsl/Views/predicates.mdx
@@ -570,6 +570,28 @@ view {
   }
 }
 ```
+
+Groups may also reference [global predicate groups](#global-predicate-groups), to reuse a set of predicates
+and keep the matched elements inside the group:
+
+```likec4
+global {
+  predicateGroup microservices {
+    include cloud.*
+      where kind is microservice
+  }
+}
+
+views {
+  view of newServices {
+    include cloud.new.*
+
+    group 'Microservices' {
+      global predicate microservices
+    }
+  }
+}
+```
 :::note
 Order of predicates is significant. 
 <details>

--- a/packages/core/src/compute-view/utils/resolve-global-rules.spec.ts
+++ b/packages/core/src/compute-view/utils/resolve-global-rules.spec.ts
@@ -6,6 +6,7 @@ import {
   type ModelGlobals,
   type ParsedElementView as ElementView,
   isElementView,
+  isViewRuleGroup,
   isViewRulePredicate,
   isViewRuleStyle,
   ViewId,
@@ -544,5 +545,98 @@ describe('resolveGlobalRulesInViews', () => {
     expect(isViewRulePredicate(resolvedView.rules[3])).toBeTruthy()
     if (!isViewRulePredicate(resolvedView.rules[3])) return
     expect(resolvedView.rules[3].exclude).toEqual([{ elementTag: 'obsolete' as aux.Tag<$Aux>, isEqual: true }])
+  })
+
+  // Issue #1828
+  describe('global predicates inside groups', () => {
+    it('should replace global predicate inside a group', ({ expect }) => {
+      const globals = generateGlobals()
+      const unresolvedView: ElementView = {
+        ...generateElementView(),
+        rules: [{
+          title: 'Group title',
+          groupRules: [
+            { predicateId: 'all' as GlobalPredicateId },
+          ],
+        }],
+      }
+
+      const resolvedView = resolveGlobalRules(unresolvedView, globals)
+
+      expect(resolvedView.rules).toHaveLength(1)
+      const rule = resolvedView.rules[0]
+      invariant(rule && isViewRuleGroup(rule), 'expected a group rule')
+      expect(rule.title).toBe('Group title')
+      expect(rule.groupRules).toEqual([{ include: [{ wildcard: true }] }])
+    })
+
+    it('should expand global predicate with multiple rules inside a group', ({ expect }) => {
+      const globals = generateGlobals()
+      const unresolvedView: ElementView = {
+        ...generateElementView(),
+        rules: [{
+          title: null,
+          groupRules: [
+            { include: [{ ref: { model: 'kept' as aux.Fqn<$Aux> } }] },
+            { predicateId: 'multiple' as GlobalPredicateId },
+          ],
+        }],
+      }
+
+      const resolvedView = resolveGlobalRules(unresolvedView, globals)
+
+      const rule = resolvedView.rules[0]
+      invariant(rule && isViewRuleGroup(rule), 'expected a group rule')
+      // the local predicate is preserved, the global one expands in place
+      expect(rule.groupRules).toEqual([
+        { include: [{ ref: { model: 'kept' } }] },
+        { include: [{ elementTag: 'api', isEqual: true }] },
+        { include: [{ element: 'backend' }] },
+        { exclude: [{ elementTag: 'deprecated', isEqual: true }] },
+      ])
+    })
+
+    it('should resolve global predicate inside a nested group', ({ expect }) => {
+      const globals = generateGlobals()
+      const unresolvedView: ElementView = {
+        ...generateElementView(),
+        rules: [{
+          title: 'Outer',
+          groupRules: [{
+            title: 'Inner',
+            groupRules: [
+              { predicateId: 'all' as GlobalPredicateId },
+            ],
+          }],
+        }],
+      }
+
+      const resolvedView = resolveGlobalRules(unresolvedView, globals)
+
+      const outer = resolvedView.rules[0]
+      invariant(outer && isViewRuleGroup(outer), 'expected an outer group rule')
+      const inner = outer.groupRules[0]
+      invariant(inner && isViewRuleGroup(inner), 'expected an inner group rule')
+      expect(inner.groupRules).toEqual([{ include: [{ wildcard: true }] }])
+    })
+
+    it('should remove global predicate inside a group that does not exist', ({ expect }) => {
+      const globals = generateGlobals()
+      const unresolvedView: ElementView = {
+        ...generateElementView(),
+        rules: [{
+          title: null,
+          groupRules: [
+            { predicateId: 'missing' as GlobalPredicateId },
+          ],
+        }],
+      }
+
+      const resolvedView = resolveGlobalRules(unresolvedView, globals)
+
+      const rule = resolvedView.rules[0]
+      invariant(rule && isViewRuleGroup(rule), 'expected a group rule')
+      expect(rule.groupRules).toHaveLength(0)
+    })
   })
 })

--- a/packages/core/src/compute-view/utils/resolve-global-rules.ts
+++ b/packages/core/src/compute-view/utils/resolve-global-rules.ts
@@ -5,6 +5,7 @@ import {
   type DynamicViewRule,
   type ElementViewPredicate,
   type ElementViewRule,
+  type ElementViewRuleGroup,
   type ModelGlobals,
   type ParsedDynamicView,
   type ParsedElementView,
@@ -14,6 +15,7 @@ import {
   isElementView,
   isViewRuleGlobalPredicateRef,
   isViewRuleGlobalStyle,
+  isViewRuleGroup,
 } from '../../types'
 import { nonexhaustive } from '../../utils'
 
@@ -58,9 +60,44 @@ export function resolveGlobalRulesInElementView<M extends AnyAux>(
       }
       return acc.concat(globalStyles)
     }
+    if (isViewRuleGroup(rule)) {
+      acc.push({
+        ...rule,
+        groupRules: resolveGlobalRulesInGroup(rule.groupRules, globals),
+      })
+      return acc
+    }
     acc.push(rule)
     return acc
   }, [] as Array<Exclude<ElementViewRule<M>, ViewRuleGlobal>>)
+}
+
+/**
+ * Groups may reference global predicates as well, resolve them in place
+ * to keep the elements inside the group
+ */
+function resolveGlobalRulesInGroup<M extends AnyAux>(
+  groupRules: ElementViewRuleGroup<M>['groupRules'],
+  globals: ModelGlobals<M>,
+): Array<Exclude<ElementViewRuleGroup<M>['groupRules'][number], ViewRuleGlobalPredicateRef>> {
+  return groupRules.reduce((acc, rule) => {
+    if (isViewRuleGlobalPredicateRef(rule)) {
+      const globalPredicates = globals.predicates[rule.predicateId]
+      if (isNullish(globalPredicates)) {
+        return acc
+      }
+      return acc.concat(globalPredicates as ElementViewPredicate<M>[])
+    }
+    if (isViewRuleGroup(rule)) {
+      acc.push({
+        ...rule,
+        groupRules: resolveGlobalRulesInGroup(rule.groupRules, globals),
+      })
+      return acc
+    }
+    acc.push(rule)
+    return acc
+  }, [] as Array<Exclude<ElementViewRuleGroup<M>['groupRules'][number], ViewRuleGlobalPredicateRef>>)
 }
 
 export function resolveGlobalRulesInDynamicView<M extends AnyAux>(

--- a/packages/core/src/types/view-parsed.element.ts
+++ b/packages/core/src/types/view-parsed.element.ts
@@ -28,7 +28,7 @@ export type ElementViewPredicate<A extends AnyAux = AnyAux> =
   | ElementViewExcludePredicate<A>
 
 export interface ElementViewRuleGroup<A extends AnyAux = AnyAux> {
-  groupRules: Array<ElementViewPredicate<A> | ElementViewRuleGroup<A>>
+  groupRules: Array<ElementViewPredicate<A> | ViewRuleGlobalPredicateRef | ElementViewRuleGroup<A>>
   title: string | null
   color?: Color
   border?: BorderStyle

--- a/packages/generators/src/likec4/schemas/views.ts
+++ b/packages/generators/src/likec4/schemas/views.ts
@@ -62,7 +62,9 @@ export const viewRuleRank = z
 
 // Manually typed due to recursive z.lazy schema
 export type ViewRuleGroupInput = {
-  groupRules: Array<z.input<typeof viewRulePredicate> | ViewRuleGroupInput>
+  groupRules: Array<
+    z.input<typeof viewRulePredicate> | z.input<typeof viewRuleGlobalPredicate> | ViewRuleGroupInput
+  >
   title: string | null
   color?: z.input<typeof common.color> | undefined
   border?: z.input<typeof common.border> | undefined
@@ -74,7 +76,9 @@ export type ViewRuleGroupInput = {
 }
 
 export type ViewRuleGroupOutput = {
-  groupRules: Array<z.infer<typeof viewRulePredicate> | ViewRuleGroupOutput>
+  groupRules: Array<
+    z.infer<typeof viewRulePredicate> | z.infer<typeof viewRuleGlobalPredicate> | ViewRuleGroupOutput
+  >
   title: string | null
   color?: z.infer<typeof common.color> | undefined
   border?: z.infer<typeof common.border> | undefined
@@ -87,7 +91,7 @@ export type ViewRuleGroupOutput = {
 
 export const viewRuleGroup: z.ZodType<ViewRuleGroupOutput, ViewRuleGroupInput> = z.lazy(() =>
   z.object({
-    groupRules: z.array(z.union([viewRulePredicate, viewRuleGroup])),
+    groupRules: z.array(z.union([viewRulePredicate, viewRuleGlobalPredicate, viewRuleGroup])),
     title: z.string().nullable(),
     color: common.color.optional(),
     border: common.border.optional(),

--- a/packages/language-server/src/like-c4.langium
+++ b/packages/language-server/src/like-c4.langium
@@ -428,6 +428,7 @@ ViewRuleGroup:
     )*
     groupRules+=(
       ViewRulePredicate |
+      ViewRuleGlobalPredicateRef |
       ViewRuleGroup
     )*
   '}';

--- a/packages/language-server/src/model/__tests__/model-builder-globals.spec.ts
+++ b/packages/language-server/src/model/__tests__/model-builder-globals.spec.ts
@@ -666,6 +666,45 @@ describe('LikeC4ModelBuilder -- globals', () => {
     expect(indexView.nodes.map(prop('id'))).toEqual(['sys1', 'sys2'])
   })
 
+  // Issue #1828
+  it('global predicate groups are applied inside a group', async ({ expect, t }) => {
+    const { diagnostics } = await t.validate(`
+      specification {
+        element component
+        tag deprecated
+      }
+      model {
+        component sys1
+        component sys2 {
+          #deprecated
+        }
+        sys1 -> sys2
+      }
+      views {
+        view index {
+          include sys1
+          group 'Deprecated' {
+            global predicate global_predicate_group_name
+          }
+        }
+      }
+      global {
+        predicateGroup global_predicate_group_name {
+          include * where tag is #deprecated
+        }
+      }
+    `)
+    expect(diagnostics.length).toBe(0)
+    const model = await t.buildModel()
+    const indexView = model?.views['index' as ViewId]!
+    expect(indexView).toBeDefined()
+    // sys2 is included by the global predicate and placed inside the group
+    const group = indexView.nodes.find(n => n.kind === '@group')
+    expect(group?.title).toBe('Deprecated')
+    expect(group?.children).toEqual(['sys2'])
+    expect(indexView.nodes.find(n => n.id === 'sys2')?.parent).toBe(group?.id)
+  })
+
   it('global dynamic predicate groups are applied', async ({ expect, t }) => {
     const { diagnostics } = await t.validate(`
       specification {

--- a/packages/language-server/src/model/parser/ViewsParser.ts
+++ b/packages/language-server/src/model/parser/ViewsParser.ts
@@ -210,6 +210,10 @@ export function ViewsParser<TBase extends WithPredicates & WithDeploymentView>(B
             groupRules.push(this.parseViewRulePredicate(rule))
             continue
           }
+          if (ast.isViewRuleGlobalPredicateRef(rule)) {
+            groupRules.push(this.parseViewRuleGlobalPredicateRef(rule))
+            continue
+          }
           if (ast.isViewRuleGroup(rule)) {
             groupRules.push(this.parseViewRuleGroup(rule))
             continue


### PR DESCRIPTION
Closes #1828

## Problem

`global predicate <name>` was accepted at the top level of a view, but not inside a `group { }` block, so a reusable set of predicates could not be scoped into a named group. The example from the issue failed to parse:

```likec4
views {
  view of newServices {
    include cloud.new.*
    group 'Frontend' {
      global predicate microservices   // Expecting token of type '}' but found `global`
    }
  }
}
```

The grammar was the blocker: `ViewRule` already listed `ViewRuleGlobalPredicateRef`, but `ViewRuleGroup.groupRules` only allowed `ViewRulePredicate | ViewRuleGroup`.

## Changes

- **Grammar** — add `ViewRuleGlobalPredicateRef` to `ViewRuleGroup.groupRules`.
- **Parser** — handle the node in `parseViewRuleGroup`, reusing the existing `parseViewRuleGlobalPredicateRef`. Without this the `nonexhaustive` guard at the end of the loop would throw.
- **Core** — widen `ElementViewRuleGroup['groupRules']`, and make `resolveGlobalRulesInElementView` recurse into group rules. It was a flat `reduce`, so a nested reference was left unresolved and reached compute as `{ predicateId }`, producing an empty group.
- **Generators** — widen the `viewRuleGroup` zod schema and its two manually-written recursive types, so the new shape type-checks.
- **Docs** — document it in the Groups section of `dsl/Views/predicates.mdx`.

Resolution is recursive, so a global predicate inside a nested group works as well.

No TextMate grammar updates were needed: `global`, `predicate` and `group` are already keywords, and this only permits an existing combination in a new position.

## Tests

**`packages/core/.../resolve-global-rules.spec.ts`** — 4 pure unit tests (no LSP): expansion inside a group, a multi-rule predicate expanding in place while a sibling local predicate is preserved, resolution inside a nested group, and a missing predicate id being dropped. All 4 fail without the recursion (the unresolved `{ predicateId }` leaks through) and pass with it.

**`packages/language-server/.../model-builder-globals.spec.ts`** — end-to-end from DSL, asserting not just that `sys2` is included but that it is placed *inside* the group (`group.children` and `node.parent`). This is the assertion that actually pins the feature. Before the change it failed with 2 parse errors.

## Verification

- `--project core` → 106 files, 1076 passed
- `--project generators` → 18 files, 258 passed
- `--project language-server` → 780 passed; the one failure is `should suggest deployments` timing out at 10s under parallel load, which reproduces on `main` and passes in isolation (this branch does not touch that file)
- `pnpm typecheck` clean across the monorepo, dprint clean, oxlint clean (the two zod namespace warnings in `schemas/views.ts` are pre-existing on `main`)
