### PR TITLE
fix(core): apply children selector only to direct children

### DIFF
--- a/.changeset/fix-children-selector-in-view-rules.md
+++ b/.changeset/fix-children-selector-in-view-rules.md
@@ -1,0 +1,5 @@
+---
+'@likec4/core': patch
+---
+
+Fix `.*` (children) selector matching deeper descendants in view rules. Styles and property overrides written as `cloud.*` were applied to grandchildren like `cloud.backend.storage` as well, behaving the same as `cloud.**`. Now `.*` matches only direct children, as documented, and `.**` remains for all descendants. Affects `style` rules, `include ... with { }` overrides and relationship customizations, in both element and dynamic views.

--- a/packages/core/src/compute-view/element-view/__test__/fixture.ts
+++ b/packages/core/src/compute-view/element-view/__test__/fixture.ts
@@ -619,20 +619,21 @@ export function $expr(expr: Expression | ModelExpression<$Aux>): ModelExpression
       selector: 'expanded',
     }
   }
-  if (expr.endsWith('.*')) {
-    return {
-      ref: {
-        model: expr.replace('.*', '') as aux.Fqn<$Aux>,
-      },
-      selector: 'children',
-    }
-  }
+  // Check `.**` before `.*`, otherwise descendants are parsed as children
   if (expr.endsWith('.**')) {
     return {
       ref: {
         model: expr.replace('.**', '') as aux.Fqn<$Aux>,
       },
       selector: 'descendants',
+    }
+  }
+  if (expr.endsWith('.*')) {
+    return {
+      ref: {
+        model: expr.replace('.*', '') as aux.Fqn<$Aux>,
+      },
+      selector: 'children',
     }
   }
   return {

--- a/packages/core/src/compute-view/element-view/__test__/legacy.spec.ts
+++ b/packages/core/src/compute-view/element-view/__test__/legacy.spec.ts
@@ -344,10 +344,10 @@ describe('compute-element-view', () => {
           icon: 'http://some-icon' as IconUrl,
         },
       },
-      // cloud.*
+      // cloud.**
       // shape: browser
       {
-        targets: [$expr('cloud.*')],
+        targets: [$expr('cloud.**')],
         style: {
           shape: 'browser',
         },

--- a/packages/core/src/compute-view/utils/applyViewRuleStyles.spec.ts
+++ b/packages/core/src/compute-view/utils/applyViewRuleStyles.spec.ts
@@ -148,4 +148,28 @@ describe('applyViewRuleStyles', () => {
     expect(applyViewRuleStyles([r([$expr('*')], {})], nodes)).toStrictEqual([nodes[0]])
     expect(applyViewRuleStyles([r([$expr('*')], { style: {} })], nodes)).toStrictEqual([nodes[0]])
   })
+
+  it('applies children selector only to direct children', () => {
+    const nodes = [
+      nd('cloud'),
+      nd('cloud.backend'),
+      nd('cloud.backend.storage'),
+    ] as ComputedNode[]
+
+    const styled = applyViewRuleStyles([r([$expr('cloud.*')], { style: { color: 'red' } })], nodes)
+
+    expect(styled.map(n => n.color)).toEqual([undefined, 'red', undefined])
+  })
+
+  it('applies descendants selector to all descendants', () => {
+    const nodes = [
+      nd('cloud'),
+      nd('cloud.backend'),
+      nd('cloud.backend.storage'),
+    ] as ComputedNode[]
+
+    const styled = applyViewRuleStyles([r([$expr('cloud.**')], { style: { color: 'red' } })], nodes)
+
+    expect(styled.map(n => n.color)).toEqual([undefined, 'red', 'red'])
+  })
 })

--- a/packages/core/src/compute-view/utils/elementExpressionToPredicate.spec.ts
+++ b/packages/core/src/compute-view/utils/elementExpressionToPredicate.spec.ts
@@ -56,10 +56,21 @@ describe('elementExprToPredicate', () => {
     no({ id: 'customer' })
   })
 
-  it('returns a function that checks if the node id matches the descedant element expression', () => {
+  it('returns a function that checks if the node id matches the children element expression', () => {
     const { yes, no } = test$expr('cloud.*')
-    yes({ id: 'cloud.backend.storage' })
     yes({ id: 'cloud.frontend' })
+    yes({ id: 'cloud.backend' })
+    // only direct children, not deeper descendants
+    no({ id: 'cloud.backend.storage' })
+    no({ id: 'cloud' })
+    no({ id: 'customer' })
+  })
+
+  it('returns a function that checks if the node id matches the descendants element expression', () => {
+    const { yes, no } = test$expr('cloud.**')
+    yes({ id: 'cloud.frontend' })
+    yes({ id: 'cloud.backend' })
+    yes({ id: 'cloud.backend.storage' })
     no({ id: 'cloud' })
     no({ id: 'customer' })
   })

--- a/packages/core/src/compute-view/utils/elementExpressionToPredicate.ts
+++ b/packages/core/src/compute-view/utils/elementExpressionToPredicate.ts
@@ -35,10 +35,15 @@ export function elementExprToPredicate<T extends { id: string; tags: readonly st
         return n.id === fqn || parentFqn(n.id) === fqn
       }
     }
-    if (target.selector === 'descendants' || target.selector === 'children') {
+    if (target.selector === 'descendants') {
       const fqnWithDot = fqn + '.'
       return (n) => {
         return n.id.startsWith(fqnWithDot)
+      }
+    }
+    if (target.selector === 'children') {
+      return (n) => {
+        return parentFqn(n.id) === fqn
       }
     }
     return (n) => {


### PR DESCRIPTION
## Problem

`elementExprToPredicate` folded the `children` selector into `descendants`:

```ts
if (target.selector === 'descendants' || target.selector === 'children') {
  const fqnWithDot = fqn + '.'
  return (n) => n.id.startsWith(fqnWithDot)
}
```

So a rule written as `cloud.*` also matched grandchildren, behaving identically to `cloud.**`. For example `style cloud.* { color red }` also coloured `cloud.backend.storage`.

The documented behaviour is different — `dsl/Views/predicates.mdx` states `.*` includes *children* and `.**` includes *descendants*, and `expression.ts` declares the selectors the same way (`'children' // ele.*`).

No existing issue for this; found while reading the code.

This affects four user-facing paths, all going through this one function:

- `applyViewRuleStyles.ts:51` — `style cloud.* { … }`
- `applyCustomElementProperties.ts:70` — `include cloud.* with { … }`
- `relationExpressionToPredicates.ts:97` — relationship customizations
- `dynamic-view/utils.ts:38` — the same in dynamic views

## Fix

Handle the two selectors separately and match children by parent fqn. This mirrors the existing correct implementation in the deployment view (`deployment-view/utils.ts:86,112`), which already does `parentFqn(…) === fqn`. `parentFqn` was already imported and used a few lines above for the `expanded` selector, so no new imports.

I checked that this matches how `include` itself resolves the selector: `element-view/predicates/_utils.ts:36-41` uses `element.children()` vs `element.descendants()` from the model hierarchy — so styles now agree with includes.

## Tests

- `elementExpressionToPredicate.spec.ts` — the existing test was titled *"matches the **descedant** element expression"* but tested `cloud.*` and asserted `yes({ id: 'cloud.backend.storage' })`, i.e. it encoded the bug. Renamed it to *children*, corrected the assertion, and added a real `cloud.**` descendants test.
- `applyViewRuleStyles.spec.ts` — two end-to-end tests: `style cloud.*` colours only `cloud.backend`, `style cloud.**` colours `cloud.backend` and `cloud.backend.storage`.

Both new assertions fail before the fix (`expected [ undefined, 'red', 'red' ] to deeply equal [ undefined, 'red', undefined ]`) and pass after.

### Two follow-on changes worth calling out

1. **Test fixture** (`element-view/__test__/fixture.ts`) checked `.*` before `.**`, so `'cloud.**'` entered the `.*` branch and `replace('.*','')` produced `'cloud.*'` as the fqn — the `descendants` branch was unreachable. The production builder has the correct order (`Builder.view-element.ts:201,209`). Swapped the two branches; this was a precondition for writing the descendants test, and it changes no existing test result.

2. **`legacy.spec.ts`** — the `index view with applied styles` test applied `style cloud.* { shape browser }` and expected `cloud.frontend.dashboard` to become `browser`. That element's model parent is `cloud.frontend`, so it is a grandchild of `cloud` and must not match `cloud.*`. (It reads as a direct child in that view only because `cloud.frontend` is not included, so the view flattens its parent to `cloud` — but the selector resolves against the model hierarchy, as `_utils.ts` and the deployment view both do.) I changed the rule to `cloud.**`, which preserves the test's original intent rather than weakening its expectation.

## Verification

- `--project core` → 106 files, 1075 passed (baseline 1072 + 3 new)
- `--project language-server --project generators --project layouts` → 1061 passed; the single failure is `should suggest deployments` timing out at 10s under parallel load, which reproduces on `main` and passes in isolation (this branch touches no language-server source)
- `pnpm exec tsc --build` and `pnpm typecheck` clean, dprint clean, oxlint clean
