### PR TITLE
feat: add optional view order metadata

### DIFF
--- a/.changeset/add-view-order.md
+++ b/.changeset/add-view-order.md
@@ -1,0 +1,7 @@
+---
+'@likec4/core': patch
+'@likec4/generators': patch
+'@likec4/language-server': patch
+---
+
+Add optional view order metadata for sorting sibling views in navigation.

--- a/apps/docs/likec4.tmLanguage.json
+++ b/apps/docs/likec4.tmLanguage.json
@@ -339,7 +339,7 @@
     },
     {
       "name": "keyword.control.likec4",
-      "match": "\\b(alt|and|autoLayout|border|break|browser|bucket|catch|color|component|crow|cylinder|dashed|description|diamond|document|dot|dotted|dynamic|deployment|else|finally|global|group|element|environment|exclude|extend|extends|head|icon|icons|if|include|includeAncestors|it|kind|line|likec4lib|link|loop|metadata|mobile|model|navigateTo|none|not|normal|notes|odiamond|odot|of|onormal|opacity|open|opt|or|parallel|par|person|predicateGroup|predicate|queue|rank|rectangle|relationship|shape|solid|specification|storage|styleGroup|style|tag|tail|technology|this|title|try|vee|view|views|when|where|source|target|with|zone|vm)\\b"
+      "match": "\\b(alt|and|autoLayout|border|break|browser|bucket|catch|color|component|crow|cylinder|dashed|description|diamond|document|dot|dotted|dynamic|deployment|else|finally|global|group|element|environment|exclude|extend|extends|head|icon|icons|if|include|includeAncestors|it|kind|line|likec4lib|link|loop|metadata|mobile|model|navigateTo|none|not|normal|notes|odiamond|odot|of|onormal|opacity|open|opt|or|order|parallel|par|person|predicateGroup|predicate|queue|rank|rectangle|relationship|shape|solid|specification|storage|styleGroup|style|tag|tail|technology|this|title|try|vee|view|views|when|where|source|target|with|zone|vm)\\b"
     },
     {
       "match": "(\\b\\.)?(\\*|_),?",

--- a/apps/docs/src/content/docs/dsl/Views/organize.mdx
+++ b/apps/docs/src/content/docs/dsl/Views/organize.mdx
@@ -27,6 +27,30 @@ On the UI, this view will be displayed as:
 
 ![organize views](../../../../assets/views/organize.png)
 
+## Order views
+
+Views in the same folder can be ordered with `order` followed by a non-negative integer.
+Views with an explicit order are shown first in ascending order. Views with the same order, and views without an order, keep their declaration order.
+Folders are still sorted alphabetically.
+
+```likec4
+views {
+  view api {
+    title 'Services / API'
+    order 1
+  }
+
+  dynamic view checkout {
+    title 'Services / Checkout flow'
+    order 2
+  }
+
+  deployment view production {
+    title 'Services / Production'
+  }
+}
+```
+
 Views can be defined in the same file, but placed in different folders:
 
 ```likec4

--- a/apps/playground/likec4.tmLanguage.json
+++ b/apps/playground/likec4.tmLanguage.json
@@ -76,7 +76,7 @@
     { "include": "#colors" },
     {
       "name": "keyword.control.likec4",
-      "match": "\\b(alt|and|as|autoLayout|border|break|catch|color|crow|dashed|description|deployment|deploymentNode|diamond|dot|dotted|dynamic|else|finally|from|global|group|element|exclude|extend|extends|head|icon|iconColor|iconPosition|iconSize|icons|if|import|include|includeAncestors|instance(Of)?|it|kind|line|likec4lib|link|loop|metadata|model|navigateTo|node|none|not|normal|odiamond|odot|of|onormal|opacity|open|opt|or|parallel|par|predicateGroup|predicate|relationship|shape|solid|specification|styleGroup|style|tag|tail|technology|this|title|try|vee|view|views|when|where|source|target|with)\\b"
+      "match": "\\b(alt|and|as|autoLayout|border|break|catch|color|crow|dashed|description|deployment|deploymentNode|diamond|dot|dotted|dynamic|else|finally|from|global|group|element|exclude|extend|extends|head|icon|iconColor|iconPosition|iconSize|icons|if|import|include|includeAncestors|instance(Of)?|it|kind|line|likec4lib|link|loop|metadata|model|navigateTo|node|none|not|normal|odiamond|odot|of|onormal|opacity|open|opt|or|order|parallel|par|predicateGroup|predicate|relationship|shape|solid|specification|styleGroup|style|tag|tail|technology|this|title|try|vee|view|views|when|where|source|target|with)\\b"
     },
     {
       "name": "keyword.symbol.likec4",

--- a/packages/core/src/builder/Builder.ts
+++ b/packages/core/src/builder/Builder.ts
@@ -453,6 +453,10 @@ function builder<Spec extends BuilderSpecification, T extends AnyTypes>(
       tags = [],
       ...props
     } = typeof _props === 'string' ? { title: _props } : { ..._props }
+    invariant(
+      props.order === undefined || Number.isInteger(props.order) && props.order >= 0,
+      'View order must be a non-negative integer',
+    )
 
     const links = mapLinks(_links)
     return [

--- a/packages/core/src/builder/_types.ts
+++ b/packages/core/src/builder/_types.ts
@@ -127,6 +127,9 @@ export type NewDeploymentNodeProps<Tag, Metadata> = {
 export type NewViewProps<Tag> = {
   title?: string
   description?: MarkdownOrString | string
+  /**
+   * Optional per-view navigation order.
+   */
   order?: number
   tags?: [Tag, ...Tag[]]
   links?: Array<string | { title?: string; url: string }>

--- a/packages/core/src/builder/_types.ts
+++ b/packages/core/src/builder/_types.ts
@@ -127,6 +127,7 @@ export type NewDeploymentNodeProps<Tag, Metadata> = {
 export type NewViewProps<Tag> = {
   title?: string
   description?: MarkdownOrString | string
+  order?: number
   tags?: [Tag, ...Tag[]]
   links?: Array<string | { title?: string; url: string }>
 }

--- a/packages/core/src/compute-view/utils/resolve-extended-views.ts
+++ b/packages/core/src/compute-view/utils/resolve-extended-views.ts
@@ -63,8 +63,10 @@ export function resolveRulesExtendedViews<A extends AnyAux, V extends Record<any
       ...(view.links ?? []),
     ]
 
+    const { order: _order, ...parent } = extendsFrom
+
     acc[view.id] = {
-      ...extendsFrom,
+      ...parent,
       ...view,
       title: view.title ?? extendsFrom.title ?? null,
       description: view.description ?? extendsFrom.description ?? null,

--- a/packages/core/src/compute-view/utils/view-hash.spec.ts
+++ b/packages/core/src/compute-view/utils/view-hash.spec.ts
@@ -97,4 +97,15 @@ describe('calcViewLayoutHash', () => {
     const hashed2 = calcViewLayoutHash(JSON.parse(JSON.stringify(view1)))
     expect(hashed1.hash).toBe(hashed2.hash)
   })
+
+  it('ignores navigation order metadata', () => {
+    const view = builder
+      .views(v => v.view('test', v.$include('*')))
+      .toLikeC4Model()
+      .view('test').$view
+
+    expect(calcViewLayoutHash({ ...view, order: 1 } as any).hash).toBe(
+      calcViewLayoutHash({ ...view, order: 2 } as any).hash,
+    )
+  })
 })

--- a/packages/core/src/model/LikeC4Model.ts
+++ b/packages/core/src/model/LikeC4Model.ts
@@ -196,6 +196,24 @@ export class LikeC4Model<A extends Any = Any> {
 
     if (isOnStage($data, 'computed') || isOnStage($data, 'layouted')) {
       const compare = compareNaturalHierarchically(VIEW_FOLDERS_SEPARATOR)
+      const compareViews = (a: { view: $View<A>; folderPath: string }, b: { view: $View<A>; folderPath: string }) => {
+        const folder = compare(a.folderPath, b.folderPath)
+        if (folder !== 0) {
+          return folder
+        }
+        const aOrder = a.view.order
+        const bOrder = b.view.order
+        if (aOrder === bOrder) {
+          return 0
+        }
+        if (aOrder === undefined) {
+          return 1
+        }
+        if (bOrder === undefined) {
+          return -1
+        }
+        return aOrder - bOrder
+      }
 
       const views = pipe(
         values($data.views as Record<string, $View<A>>),
@@ -204,8 +222,7 @@ export class LikeC4Model<A extends Any = Any> {
           path: normalizeViewPath(view.title ?? view.id),
           folderPath: view.title && getViewFolderPath(view.title) || '',
         })),
-        // Sort hierarchically by groups, but keep same order within groups
-        sort((a, b) => compare(a.folderPath, b.folderPath)),
+        sort(compareViews),
       )
 
       const getOrCreateFolder = (path: string) => {

--- a/packages/core/src/model/view/LikeC4ViewModel.ts
+++ b/packages/core/src/model/view/LikeC4ViewModel.ts
@@ -61,6 +61,7 @@ export class LikeC4ViewModel<A extends Any = Any, V extends ProcessedView<A> = $
    * The title of the view
    */
   public readonly title: string | null
+  public readonly order: number | undefined
 
   /**
    * View folder this view belongs to.
@@ -84,6 +85,7 @@ export class LikeC4ViewModel<A extends Any = Any, V extends ProcessedView<A> = $
     this.$model = model
     this.#view = view
     this.id = view.id
+    this.order = view.order
     this.folder = folder
     this.#manualLayoutSnapshot = manualLayoutSnapshot as ViewManualLayoutSnapshot<inferType<V>>
 

--- a/packages/core/src/model/view/LikeC4ViewModel.ts
+++ b/packages/core/src/model/view/LikeC4ViewModel.ts
@@ -61,6 +61,9 @@ export class LikeC4ViewModel<A extends Any = Any, V extends ProcessedView<A> = $
    * The title of the view
    */
   public readonly title: string | null
+  /**
+   * Optional per-view navigation order.
+   */
   public readonly order: number | undefined
 
   /**

--- a/packages/core/src/model/view/LikeC4ViewsFolder.spec.ts
+++ b/packages/core/src/model/view/LikeC4ViewsFolder.spec.ts
@@ -75,6 +75,45 @@ describe('LikeC4ViewsGroup', () => {
     })
   })
 
+  it('orders sibling views by explicit order only within the same folder', ({ expect }) => {
+    const ordered = Builder
+      .specification({
+        elements: {
+          el: {},
+        },
+      })
+      .model(({ el }, _) => _(el('sys')))
+      .views(({ view, dynamicView, deploymentView }, _) =>
+        _(
+          view('root-default'),
+          view('root-late', { order: 10 }),
+          view('root-first', { order: 0 }),
+          view('same-a', { title: 'Ordered / Same A', order: 2 }),
+          dynamicView('same-b', { title: 'Ordered / Same B', order: 2 }),
+          deploymentView('same-c', { title: 'Ordered / Same C', order: 2 }),
+          view('unordered-a', 'Ordered / Unordered A'),
+          view('ordered-first', { title: 'Ordered / First', order: 1 }),
+          view('unordered-b', 'Ordered / Unordered B'),
+        )
+      )
+      .toLikeC4Model()
+
+    expect([...ordered.rootViewFolder.children]).toEqual([
+      ordered.viewFolder('Ordered'),
+      ordered.view('root-first'),
+      ordered.view('root-late'),
+      ordered.view('root-default'),
+    ])
+    expect([...ordered.viewFolder('Ordered').views]).toEqual([
+      ordered.view('ordered-first'),
+      ordered.view('same-a'),
+      ordered.view('same-b'),
+      ordered.view('same-c'),
+      ordered.view('unordered-a'),
+      ordered.view('unordered-b'),
+    ])
+  })
+
   describe('view folder (level 2)', () => {
     it('One/Cloud 1', ({ expect }) => {
       const folder = model.viewFolder('One/Cloud 1')

--- a/packages/core/src/types/view-common.ts
+++ b/packages/core/src/types/view-common.ts
@@ -95,6 +95,9 @@ export interface BaseViewProperties<A extends AnyAux> extends aux.WithOptionalTa
   readonly id: aux.StrictViewId<A>
   readonly title: string | null
   readonly description: scalar.MarkdownOrString | null
+  /**
+   * Optional per-view navigation order.
+   */
   readonly order?: number
   /**
    * Source file containing this view, relative to the project root.

--- a/packages/core/src/types/view-common.ts
+++ b/packages/core/src/types/view-common.ts
@@ -95,6 +95,7 @@ export interface BaseViewProperties<A extends AnyAux> extends aux.WithOptionalTa
   readonly id: aux.StrictViewId<A>
   readonly title: string | null
   readonly description: scalar.MarkdownOrString | null
+  readonly order?: number
   /**
    * Source file containing this view, relative to the project root.
    * Undefined if the view is auto-generated.

--- a/packages/generators/src/likec4/operators/views.spec.ts
+++ b/packages/generators/src/likec4/operators/views.spec.ts
@@ -92,6 +92,7 @@ describe('view', () => {
         'index',
         {
           title: 'Index',
+          order: 3,
           tags: ['tag1'],
           description: {
             md: 'Cloud **description**',
@@ -108,6 +109,7 @@ describe('view', () => {
         view index {
           #tag1
           title 'Index'
+          order 3
           description '''
             Cloud **description**
           '''
@@ -354,7 +356,37 @@ describe('view', () => {
     })
   })
 
+  it('should print deployment view order', () => {
+    const result = expect(
+      deploymentView(
+        'deployment',
+        {
+          title: 'Deployment',
+          order: 2,
+        },
+        $include('*'),
+      ),
+    )
+    result.toContain('deployment view deployment {\n    title \'Deployment\'\n    order 2')
+    result.toContain('include *')
+  })
+
   describe('dynamic view', () => {
+    it('should print dynamic view order', () => {
+      const result = expect(
+        dynamicView(
+          'test',
+          {
+            title: 'Flow',
+            order: 1,
+          },
+          $step('cloud.frontend -> cloud.backend.api'),
+        ),
+      )
+      result.toContain('dynamic view test {\n    title \'Flow\'\n    order 1')
+      result.toContain('cloud.frontend -> cloud.backend.api')
+    })
+
     it('should print steps', () => {
       expect(
         dynamicView(

--- a/packages/generators/src/likec4/operators/views.ts
+++ b/packages/generators/src/likec4/operators/views.ts
@@ -187,6 +187,7 @@ export const elementView = zodOp(schemas.views.elementView.partial({ _type: true
         lines(
           tagsProperty(),
           viewTitleProperty(),
+          property('order'),
           descriptionProperty(),
           linksProperty(),
         ),
@@ -237,6 +238,7 @@ export const deploymentView = zodOp(schemas.views.deploymentView.partial({ _type
         lines(
           tagsProperty(),
           viewTitleProperty(),
+          property('order'),
           descriptionProperty(),
           linksProperty(),
         ),
@@ -460,6 +462,7 @@ export const dynamicView = zodOp(schemas.views.dynamicView.partial({ _type: true
         lines(
           tagsProperty(),
           viewTitleProperty(),
+          property('order'),
           descriptionProperty(),
           linksProperty(),
           property('variant'),

--- a/packages/generators/src/likec4/schemas/views.ts
+++ b/packages/generators/src/likec4/schemas/views.ts
@@ -114,6 +114,7 @@ const viewProps = z.object({
   id: common.viewId,
   title: z.string().nullish(),
   description: common.markdownOrString.nullish(),
+  order: z.number().int().nonnegative().optional(),
   tags: common.tags.nullish(),
   links: common.links.nullish(),
 })

--- a/packages/language-server/src/ast.ts
+++ b/packages/language-server/src/ast.ts
@@ -155,6 +155,9 @@ export interface ParsedAstElementView {
   astPath: string
   title: string | null
   description: c4.MarkdownOrString | null
+  /**
+   * Optional per-view navigation order.
+   */
   order?: number
   tags: c4.NonEmptyArray<c4.Tag> | null
   links: c4.NonEmptyArray<c4.Link> | null
@@ -167,6 +170,9 @@ export interface ParsedAstDynamicView {
   astPath: string
   title: string | null
   description: c4.MarkdownOrString | null
+  /**
+   * Optional per-view navigation order.
+   */
   order?: number
   tags: c4.NonEmptyArray<c4.Tag> | null
   links: c4.NonEmptyArray<c4.Link> | null
@@ -181,6 +187,9 @@ export interface ParsedAstDeploymentView {
   astPath: string
   title: string | null
   description: c4.MarkdownOrString | null
+  /**
+   * Optional per-view navigation order.
+   */
   order?: number
   tags: c4.NonEmptyArray<c4.Tag> | null
   links: c4.NonEmptyArray<c4.Link> | null

--- a/packages/language-server/src/ast.ts
+++ b/packages/language-server/src/ast.ts
@@ -155,6 +155,7 @@ export interface ParsedAstElementView {
   astPath: string
   title: string | null
   description: c4.MarkdownOrString | null
+  order?: number
   tags: c4.NonEmptyArray<c4.Tag> | null
   links: c4.NonEmptyArray<c4.Link> | null
   rules: c4.ElementViewRule[]
@@ -166,6 +167,7 @@ export interface ParsedAstDynamicView {
   astPath: string
   title: string | null
   description: c4.MarkdownOrString | null
+  order?: number
   tags: c4.NonEmptyArray<c4.Tag> | null
   links: c4.NonEmptyArray<c4.Link> | null
   steps: c4.Step.Any[]
@@ -179,6 +181,7 @@ export interface ParsedAstDeploymentView {
   astPath: string
   title: string | null
   description: c4.MarkdownOrString | null
+  order?: number
   tags: c4.NonEmptyArray<c4.Tag> | null
   links: c4.NonEmptyArray<c4.Link> | null
   rules: Array<c4.DeploymentViewRule>

--- a/packages/language-server/src/formatting/LikeC4Formatter.spec.ts
+++ b/packages/language-server/src/formatting/LikeC4Formatter.spec.ts
@@ -29,6 +29,60 @@ const it = test.extend<{
 })
 
 describe('formating', () => {
+  describe('formats view order', () => {
+    it(
+      'formats order properties in all view kinds',
+      async ({ expect, format }) =>
+        expect(
+          await format`
+          specification {
+            element component
+          }
+          model {
+            component sys1
+            component sys2
+          }
+          views {
+            view index {
+              order     1
+              include *
+            }
+            dynamic view flow {
+              order 2
+              sys1 -> sys2
+            }
+            deployment view infra {
+              order 3
+              include *
+            }
+          }`,
+        ).toMatchInlineSnapshot(`
+          "
+          specification {
+            element component
+          }
+          model {
+            component sys1
+            component sys2
+          }
+          views {
+            view index {
+              order 1
+              include *
+            }
+            dynamic view flow {
+              order 2
+              sys1 -> sys2
+            }
+            deployment view infra {
+              order 3
+              include *
+            }
+          }"
+        `),
+    )
+  })
+
   describe('formats imports', () => {
     it(
       'formats import rules',

--- a/packages/language-server/src/formatting/LikeC4Formatter.ts
+++ b/packages/language-server/src/formatting/LikeC4Formatter.ts
@@ -330,6 +330,7 @@ export class LikeC4Formatter extends AbstractFormatter {
       ast.isElementStringProperty(node)
       || ast.isRelationStringProperty(node)
       || ast.isViewStringProperty(node)
+      || ast.isViewOrderProperty(node)
       || ast.isNotationProperty(node)
       || ast.isNotesProperty(node)
       || ast.isSpecificationElementStringProperty(node)
@@ -354,6 +355,7 @@ export class LikeC4Formatter extends AbstractFormatter {
       const propertyName = formatter.keywords(
         'title',
         'description',
+        'order',
         'technology',
         'summary',
         'notation',

--- a/packages/language-server/src/like-c4.langium
+++ b/packages/language-server/src/like-c4.langium
@@ -392,11 +392,14 @@ type AnyProperty =
 ;
 
 ViewProperty:
-  ViewStringProperty | LinkProperty
+  ViewStringProperty | ViewOrderProperty | LinkProperty
 ;
 
 ViewStringProperty:
   key=('title' | 'description') ':'? value=MarkdownOrString ';'?;
+
+ViewOrderProperty:
+  key='order' value=Number ';'?;
 
 ViewLayoutDirection returns string:
   'TopBottom' | 'LeftRight' | 'BottomTop' | 'RightLeft';

--- a/packages/language-server/src/lsp/CompletionProvider.spec.ts
+++ b/packages/language-server/src/lsp/CompletionProvider.spec.ts
@@ -375,6 +375,7 @@ describe('LikeC4CompletionProvider', () => {
       expectedItems: [
         'title',
         'description',
+        'order',
         'link',
         'include',
         'exclude',

--- a/packages/language-server/src/model/__tests__/model-builder-view-folders.spec.ts
+++ b/packages/language-server/src/model/__tests__/model-builder-view-folders.spec.ts
@@ -144,6 +144,86 @@ describe('LikeC4ModelBuilder -- view folders', () => {
     ])
   })
 
+  it('orders sibling views by explicit order', async ({ expect }) => {
+    const { validate, buildModel, buildLikeC4Model } = createTestServices({ projectConfig: {} })
+    const { errors } = await validate(`
+      specification {
+        element component
+      }
+      model {
+        component sys1
+        component sys2
+      }
+      views 'Group 1' {
+        view unordered1 {
+          title 'Same / Unordered 1'
+          include *
+        }
+        view ordered2 {
+          title 'Same / Ordered 2'
+          order 2
+          include *
+        }
+        dynamic view ordered1 {
+          title 'Same / Ordered 1'
+          order 1
+          sys1 -> sys2
+        }
+        deployment view ordered2b {
+          title 'Same / Ordered 2B'
+          order 2
+          include *
+        }
+        view unordered2 {
+          title 'Same / Unordered 2'
+          include *
+        }
+      }
+    `)
+    expect(errors).toEqual([])
+
+    const computed = await buildModel()
+    expect(computed.views['ordered1']?.order).toBe(1)
+    expect(computed.views['ordered2']?.order).toBe(2)
+    expect(computed.views['ordered2b']?.order).toBe(2)
+    expect(computed.views['unordered1']?.order).toBeUndefined()
+
+    const model = await buildLikeC4Model()
+    expect([...model.viewFolder('Group 1/Same').views]).toEqual([
+      model.view('ordered1'),
+      model.view('ordered2'),
+      model.view('ordered2b'),
+      model.view('unordered1'),
+      model.view('unordered2'),
+    ])
+  })
+
+  it('does not inherit order from extended views', async ({ expect }) => {
+    const { validate, buildModel } = createTestServices({ projectConfig: {} })
+    const { errors } = await validate(`
+      specification {
+        element component
+      }
+      model {
+        component sys1
+      }
+      views {
+        view base {
+          order 1
+          include *
+        }
+        view child extends base {
+          title 'Child'
+        }
+      }
+    `)
+    expect(errors).toEqual([])
+
+    const computed = await buildModel()
+    expect(computed.views['base']?.order).toBe(1)
+    expect(computed.views['child']?.order).toBeUndefined()
+  })
+
   it('implicit views are placed in Auto folder', async ({ expect }) => {
     const { validate, buildLikeC4Model } = createTestServices({
       projectConfig: { implicitViews: true },

--- a/packages/language-server/src/model/__tests__/model-builder-view-folders.spec.ts
+++ b/packages/language-server/src/model/__tests__/model-builder-view-folders.spec.ts
@@ -198,6 +198,69 @@ describe('LikeC4ModelBuilder -- view folders', () => {
     ])
   })
 
+  it('drops unsafe view order values from parsed and computed model', async ({ expect }) => {
+    const { validate, buildModel, services } = createTestServices({ projectConfig: {} })
+    const { errors } = await validate(`
+      specification {
+        element component
+      }
+      model {
+        component sys1
+        component sys2
+      }
+      views 'Group 1' {
+        view validElement {
+          order 0
+          include *
+        }
+        view unsafeElement {
+          order 9007199254740992
+          include *
+        }
+        dynamic view validDynamic {
+          order 1
+          sys1 -> sys2
+        }
+        dynamic view unsafeDynamic {
+          order 9007199254740992
+          sys1 -> sys2
+        }
+        deployment view validDeployment {
+          order 2
+          include *
+        }
+        deployment view unsafeDeployment {
+          order 9007199254740992
+          include *
+        }
+      }
+    `)
+    expect(errors).toEqual([
+      'View order must be a non-negative safe integer',
+      'View order must be a non-negative safe integer',
+      'View order must be a non-negative safe integer',
+    ])
+
+    const parsed = await services.likec4.ModelBuilder.parseModel()
+    if (!parsed) {
+      throw new Error('Expected parsed model')
+    }
+    expect(parsed.$data.views['validElement']?.order).toBe(0)
+    expect(parsed.$data.views['validDynamic']?.order).toBe(1)
+    expect(parsed.$data.views['validDeployment']?.order).toBe(2)
+    expect(parsed.$data.views['unsafeElement']?.order).toBeUndefined()
+    expect(parsed.$data.views['unsafeDynamic']?.order).toBeUndefined()
+    expect(parsed.$data.views['unsafeDeployment']?.order).toBeUndefined()
+
+    const computed = await buildModel()
+    expect(computed.views['validElement']?.order).toBe(0)
+    expect(computed.views['validDynamic']?.order).toBe(1)
+    expect(computed.views['validDeployment']?.order).toBe(2)
+    expect(computed.views['unsafeElement']?.order).toBeUndefined()
+    expect(computed.views['unsafeDynamic']?.order).toBeUndefined()
+    expect(computed.views['unsafeDeployment']?.order).toBeUndefined()
+  })
+
   it('does not inherit order from extended views', async ({ expect }) => {
     const { validate, buildModel } = createTestServices({ projectConfig: {} })
     const { errors } = await validate(`

--- a/packages/language-server/src/model/__tests__/model-builder-view-folders.spec.ts
+++ b/packages/language-server/src/model/__tests__/model-builder-view-folders.spec.ts
@@ -261,6 +261,66 @@ describe('LikeC4ModelBuilder -- view folders', () => {
     expect(computed.views['unsafeDeployment']?.order).toBeUndefined()
   })
 
+  it('drops recovered negative view order values from parsed and computed model', async ({ expect }) => {
+    const { validate, buildModel, services } = createTestServices({ projectConfig: {} })
+    const { errors } = await validate(`
+      specification {
+        element component
+      }
+      model {
+        component sys1
+        component sys2
+      }
+      views {
+        view validElement {
+          order 0
+          include *
+        }
+        view negativeElement {
+          order -1
+          include *
+        }
+        dynamic view validDynamic {
+          order 1
+          sys1 -> sys2
+        }
+        dynamic view negativeDynamic {
+          order -1
+          sys1 -> sys2
+        }
+        deployment view validDeployment {
+          order 2
+          include *
+        }
+        deployment view negativeDeployment {
+          order -1
+          include *
+        }
+      }
+    `)
+    expect(errors).toHaveLength(3)
+    expect(errors.every(error => error.startsWith('unexpected character: ->-<-'))).toBe(true)
+
+    const parsed = await services.likec4.ModelBuilder.parseModel()
+    if (!parsed) {
+      throw new Error('Expected parsed model')
+    }
+    expect(parsed.$data.views['validElement']?.order).toBe(0)
+    expect(parsed.$data.views['validDynamic']?.order).toBe(1)
+    expect(parsed.$data.views['validDeployment']?.order).toBe(2)
+    expect(parsed.$data.views['negativeElement']?.order).toBeUndefined()
+    expect(parsed.$data.views['negativeDynamic']?.order).toBeUndefined()
+    expect(parsed.$data.views['negativeDeployment']?.order).toBeUndefined()
+
+    const computed = await buildModel()
+    expect(computed.views['validElement']?.order).toBe(0)
+    expect(computed.views['validDynamic']?.order).toBe(1)
+    expect(computed.views['validDeployment']?.order).toBe(2)
+    expect(computed.views['negativeElement']?.order).toBeUndefined()
+    expect(computed.views['negativeDynamic']?.order).toBeUndefined()
+    expect(computed.views['negativeDeployment']?.order).toBeUndefined()
+  })
+
   it('does not inherit order from extended views', async ({ expect }) => {
     const { validate, buildModel } = createTestServices({ projectConfig: {} })
     const { errors } = await validate(`

--- a/packages/language-server/src/model/parser/Base.ts
+++ b/packages/language-server/src/model/parser/Base.ts
@@ -104,6 +104,16 @@ export function removeIndent(str: ast.MarkdownOrString | string | undefined) {
   }
 }
 
+/**
+ * Returns a non-negative safe view order while discarding recovered negative literals.
+ */
+export function parseViewOrder(prop: ast.ViewOrderProperty | undefined): number | undefined {
+  if (!prop || /^\s*order\b\s*-/.test(prop.$cstNode?.text ?? '')) {
+    return undefined
+  }
+  return Number.isSafeInteger(prop.value) && prop.value >= 0 ? prop.value : undefined
+}
+
 export type Base = GConstructor<BaseParser>
 
 type ParserLevel =

--- a/packages/language-server/src/model/parser/DeploymentViewParser.ts
+++ b/packages/language-server/src/model/parser/DeploymentViewParser.ts
@@ -43,6 +43,7 @@ export function DeploymentViewParser<TBase extends WithExpressionV2 & WithDeploy
       const tags = this.convertTags(body)
       const links = this.convertLinks(body)
       const order = props.find(ast.isViewOrderProperty)?.value
+      const validOrder = typeof order === 'number' && Number.isSafeInteger(order) && order >= 0 ? order : undefined
 
       ViewOps.writeId(astNode, id as c4.ViewId)
 
@@ -52,7 +53,7 @@ export function DeploymentViewParser<TBase extends WithExpressionV2 & WithDeploy
         astPath,
         title: toSingleLine(title) ?? null,
         description,
-        ...(order !== undefined && { order }),
+        ...(validOrder !== undefined && { order: validOrder }),
         tags,
         links: isNonEmptyArray(links) ? links : null,
         rules: this.tryMap('deployment', body.rules, n => this.parseDeploymentViewRule(n)),

--- a/packages/language-server/src/model/parser/DeploymentViewParser.ts
+++ b/packages/language-server/src/model/parser/DeploymentViewParser.ts
@@ -42,6 +42,7 @@ export function DeploymentViewParser<TBase extends WithExpressionV2 & WithDeploy
 
       const tags = this.convertTags(body)
       const links = this.convertLinks(body)
+      const order = props.find(ast.isViewOrderProperty)?.value
 
       ViewOps.writeId(astNode, id as c4.ViewId)
 
@@ -51,6 +52,7 @@ export function DeploymentViewParser<TBase extends WithExpressionV2 & WithDeploy
         astPath,
         title: toSingleLine(title) ?? null,
         description,
+        ...(order !== undefined && { order }),
         tags,
         links: isNonEmptyArray(links) ? links : null,
         rules: this.tryMap('deployment', body.rules, n => this.parseDeploymentViewRule(n)),

--- a/packages/language-server/src/model/parser/DeploymentViewParser.ts
+++ b/packages/language-server/src/model/parser/DeploymentViewParser.ts
@@ -4,7 +4,7 @@ import { filter, isNonNullish, mapToObj, pipe } from 'remeda'
 import { type ParsedAstDeploymentView, ast, parseMarkdownAsString, toAutoLayout, ViewOps } from '../../ast'
 import { logWarnError } from '../../logger'
 import { stringHash } from '../../utils'
-import { removeIndent, toSingleLine } from './Base'
+import { parseViewOrder, removeIndent, toSingleLine } from './Base'
 import type { WithDeploymentModel } from './DeploymentModelParser'
 import type { WithExpressionV2 } from './FqnRefParser'
 
@@ -42,8 +42,7 @@ export function DeploymentViewParser<TBase extends WithExpressionV2 & WithDeploy
 
       const tags = this.convertTags(body)
       const links = this.convertLinks(body)
-      const order = props.find(ast.isViewOrderProperty)?.value
-      const validOrder = typeof order === 'number' && Number.isSafeInteger(order) && order >= 0 ? order : undefined
+      const order = parseViewOrder(props.find(ast.isViewOrderProperty))
 
       ViewOps.writeId(astNode, id as c4.ViewId)
 
@@ -53,7 +52,7 @@ export function DeploymentViewParser<TBase extends WithExpressionV2 & WithDeploy
         astPath,
         title: toSingleLine(title) ?? null,
         description,
-        ...(validOrder !== undefined && { order: validOrder }),
+        ...(order !== undefined && { order }),
         tags,
         links: isNonEmptyArray(links) ? links : null,
         rules: this.tryMap('deployment', body.rules, n => this.parseDeploymentViewRule(n)),

--- a/packages/language-server/src/model/parser/ViewsParser.ts
+++ b/packages/language-server/src/model/parser/ViewsParser.ts
@@ -20,7 +20,7 @@ import {
 } from '../../ast'
 import { safeCall, stringHash } from '../../utils'
 import { elementRef } from '../../utils/elementRef'
-import { removeIndent, toSingleLine } from './Base'
+import { parseViewOrder, removeIndent, toSingleLine } from './Base'
 import type { WithDeploymentView } from './DeploymentViewParser'
 import type { WithPredicates } from './PredicatesParser'
 
@@ -115,8 +115,7 @@ export function ViewsParser<TBase extends WithPredicates & WithDeploymentView>(B
 
       const tags = this.convertTags(body)
       const links = this.convertLinks(body)
-      const order = props.find(ast.isViewOrderProperty)?.value
-      const validOrder = typeof order === 'number' && Number.isSafeInteger(order) && order >= 0 ? order : undefined
+      const order = parseViewOrder(props.find(ast.isViewOrderProperty))
 
       const view: ParsedAstElementView = {
         [c4._type]: 'element',
@@ -124,7 +123,7 @@ export function ViewsParser<TBase extends WithPredicates & WithDeploymentView>(B
         astPath,
         title: toSingleLine(title) ?? null,
         description,
-        ...(validOrder !== undefined && { order: validOrder }),
+        ...(order !== undefined && { order }),
         tags,
         links: isNonEmptyArray(links) ? links : null,
         rules: [
@@ -289,8 +288,7 @@ export function ViewsParser<TBase extends WithPredicates & WithDeploymentView>(B
 
       const tags = this.convertTags(body)
       const links = this.convertLinks(body)
-      const order = props.find(ast.isViewOrderProperty)?.value
-      const validOrder = typeof order === 'number' && Number.isSafeInteger(order) && order >= 0 ? order : undefined
+      const order = parseViewOrder(props.find(ast.isViewOrderProperty))
 
       ViewOps.writeId(astNode, id as c4.ViewId)
 
@@ -302,7 +300,7 @@ export function ViewsParser<TBase extends WithPredicates & WithDeploymentView>(B
         astPath,
         title: toSingleLine(title) ?? null,
         description,
-        ...(validOrder !== undefined && { order: validOrder }),
+        ...(order !== undefined && { order }),
         tags,
         links: isNonEmptyArray(links) ? links : null,
         variant,

--- a/packages/language-server/src/model/parser/ViewsParser.ts
+++ b/packages/language-server/src/model/parser/ViewsParser.ts
@@ -79,6 +79,8 @@ export function ViewsParser<TBase extends WithPredicates & WithDeploymentView>(B
     ): ParsedAstElementView {
       const body = astNode.body
       invariant(body, 'ElementView body is not defined')
+      // only valid props
+      const props = body.props.filter(this.isValid)
       const astPath = this.getAstNodePath(astNode)
 
       let viewOf = null as c4.Fqn | null
@@ -105,8 +107,7 @@ export function ViewsParser<TBase extends WithPredicates & WithDeploymentView>(B
 
       const { title = null, description = null } = this.parseBaseProps(
         pipe(
-          body.props,
-          filter(p => this.isValid(p)),
+          props,
           filter(ast.isViewStringProperty),
           mapToObj(p => [p.key, p.value as ast.MarkdownOrString | undefined]),
         ),
@@ -114,7 +115,8 @@ export function ViewsParser<TBase extends WithPredicates & WithDeploymentView>(B
 
       const tags = this.convertTags(body)
       const links = this.convertLinks(body)
-      const order = body.props.find(ast.isViewOrderProperty)?.value
+      const order = props.find(ast.isViewOrderProperty)?.value
+      const validOrder = typeof order === 'number' && Number.isSafeInteger(order) && order >= 0 ? order : undefined
 
       const view: ParsedAstElementView = {
         [c4._type]: 'element',
@@ -122,7 +124,7 @@ export function ViewsParser<TBase extends WithPredicates & WithDeploymentView>(B
         astPath,
         title: toSingleLine(title) ?? null,
         description,
-        ...(order !== undefined && { order }),
+        ...(validOrder !== undefined && { order: validOrder }),
         tags,
         links: isNonEmptyArray(links) ? links : null,
         rules: [
@@ -288,6 +290,7 @@ export function ViewsParser<TBase extends WithPredicates & WithDeploymentView>(B
       const tags = this.convertTags(body)
       const links = this.convertLinks(body)
       const order = props.find(ast.isViewOrderProperty)?.value
+      const validOrder = typeof order === 'number' && Number.isSafeInteger(order) && order >= 0 ? order : undefined
 
       ViewOps.writeId(astNode, id as c4.ViewId)
 
@@ -299,7 +302,7 @@ export function ViewsParser<TBase extends WithPredicates & WithDeploymentView>(B
         astPath,
         title: toSingleLine(title) ?? null,
         description,
-        ...(order !== undefined && { order }),
+        ...(validOrder !== undefined && { order: validOrder }),
         tags,
         links: isNonEmptyArray(links) ? links : null,
         variant,

--- a/packages/language-server/src/model/parser/ViewsParser.ts
+++ b/packages/language-server/src/model/parser/ViewsParser.ts
@@ -114,6 +114,7 @@ export function ViewsParser<TBase extends WithPredicates & WithDeploymentView>(B
 
       const tags = this.convertTags(body)
       const links = this.convertLinks(body)
+      const order = body.props.find(ast.isViewOrderProperty)?.value
 
       const view: ParsedAstElementView = {
         [c4._type]: 'element',
@@ -121,6 +122,7 @@ export function ViewsParser<TBase extends WithPredicates & WithDeploymentView>(B
         astPath,
         title: toSingleLine(title) ?? null,
         description,
+        ...(order !== undefined && { order }),
         tags,
         links: isNonEmptyArray(links) ? links : null,
         rules: [
@@ -285,6 +287,7 @@ export function ViewsParser<TBase extends WithPredicates & WithDeploymentView>(B
 
       const tags = this.convertTags(body)
       const links = this.convertLinks(body)
+      const order = props.find(ast.isViewOrderProperty)?.value
 
       ViewOps.writeId(astNode, id as c4.ViewId)
 
@@ -296,6 +299,7 @@ export function ViewsParser<TBase extends WithPredicates & WithDeploymentView>(B
         astPath,
         title: toSingleLine(title) ?? null,
         description,
+        ...(order !== undefined && { order }),
         tags,
         links: isNonEmptyArray(links) ? links : null,
         variant,

--- a/packages/language-server/src/validation/index.ts
+++ b/packages/language-server/src/validation/index.ts
@@ -46,7 +46,7 @@ import {
   checkSpecificationRule,
   checkTag,
 } from './specification'
-import { viewChecks } from './view'
+import { viewChecks, viewOrderChecks } from './view'
 import { viewRuleRankChecks } from './view-checks'
 import {
   checkFqnExprWith,
@@ -194,6 +194,7 @@ export function registerValidationChecks(services: LikeC4Services) {
     ColorLiteral: colorLiteralRuleChecks(services),
     DynamicViewDisplayVariantProperty: dynamicViewDisplayVariant(services),
     ViewRuleRank: viewRuleRankChecks(services),
+    ViewOrderProperty: viewOrderChecks(services),
   })
   const connection = services.shared.lsp.Connection
   if (connection) {

--- a/packages/language-server/src/validation/view.spec.ts
+++ b/packages/language-server/src/validation/view.spec.ts
@@ -95,4 +95,43 @@ describe('viewChecks', () => {
       expect(diagnostic.message, 'diagnostic message').toBe('Duplicate view \'v3\'')
     }
   })
+
+  it('should accept safe view order values', async ({ expect, validate }) => {
+    const { errors, warnings } = await validate(`
+      views {
+        view elementView {
+          order 0
+        }
+        dynamic view dynamicView {
+          order 1
+        }
+        deployment view deploymentView {
+          order 2
+        }
+      }
+    `)
+    expect(errors).toHaveLength(0)
+    expect(warnings).toHaveLength(0)
+  })
+
+  it('should reject unsafe view order values', async ({ expect, validate }) => {
+    const { errors } = await validate(`
+      views {
+        view elementView {
+          order 9007199254740992
+        }
+        dynamic view dynamicView {
+          order 9007199254740992
+        }
+        deployment view deploymentView {
+          order 9007199254740992
+        }
+      }
+    `)
+    expect(errors).toEqual([
+      'View order must be a non-negative safe integer',
+      'View order must be a non-negative safe integer',
+      'View order must be a non-negative safe integer',
+    ])
+  })
 })

--- a/packages/language-server/src/validation/view.ts
+++ b/packages/language-server/src/validation/view.ts
@@ -40,3 +40,17 @@ export const viewChecks = (services: LikeC4Services): ValidationCheck<ast.LikeC4
     }
   })
 }
+
+/**
+ * Validates per-view navigation order values.
+ */
+export const viewOrderChecks = (_services: LikeC4Services): ValidationCheck<ast.ViewOrderProperty> => {
+  return tryOrLog((node, accept) => {
+    if (!Number.isSafeInteger(node.value) || node.value < 0) {
+      accept('error', 'View order must be a non-negative safe integer', {
+        node,
+        property: 'value',
+      })
+    }
+  })
+}

--- a/packages/vscode/likec4.tmLanguage.json
+++ b/packages/vscode/likec4.tmLanguage.json
@@ -80,7 +80,7 @@
     { "include": "#colors" },
     {
       "name": "keyword.control.likec4",
-      "match": "\\b(alt|and|as|autoLayout|border|break|catch|color|crow|dashed|description|deployment|deploymentNode|diamond|dot|dotted|dynamic|else|finally|from|global|group|element|exclude|extend|extends|head|icon|iconColor|iconPosition|iconSize|icons|if|import|include|includeAncestors|instance(Of)?|it|kind|line|likec4lib|link|loop|metadata|model|navigateTo|node|none|not|normal|odiamond|odot|of|onormal|opacity|open|opt|or|parallel|par|predicateGroup|predicate|rank|relationship|shape|solid|specification|styleGroup|style|tag|tail|technology|this|title|try|vee|view|views|when|where|source|target|with)\\b"
+      "match": "\\b(alt|and|as|autoLayout|border|break|catch|color|crow|dashed|description|deployment|deploymentNode|diamond|dot|dotted|dynamic|else|finally|from|global|group|element|exclude|extend|extends|head|icon|iconColor|iconPosition|iconSize|icons|if|import|include|includeAncestors|instance(Of)?|it|kind|line|likec4lib|link|loop|metadata|model|navigateTo|node|none|not|normal|odiamond|odot|of|onormal|opacity|open|opt|or|order|parallel|par|predicateGroup|predicate|rank|relationship|shape|solid|specification|styleGroup|style|tag|tail|technology|this|title|try|vee|view|views|when|where|source|target|with)\\b"
     },
     {
       "name": "keyword.symbol.likec4",


### PR DESCRIPTION
## Checklist

- [x] I've thoroughly read the latest [contribution guidelines](https://github.com/likec4/likec4/blob/main/CONTRIBUTING.md).
- [x] My branch is based on current `main` (`f9700621`); it was created directly from that commit, so no rebase was required.
- [x] I've added tests to cover my changes.
- [x] I've verified `pnpm typecheck` and `pnpm test`.
- [x] I've added [changesets](https://changesets-docs.vercel.app/).
- [x] My change requires documentation updates.
- [x] I've updated the documentation accordingly.

Closes #3100

## Summary

- Add optional `order <non-negative integer>` metadata to element, dynamic, and deployment views.
- Sort sibling views by ascending explicit order while preserving declaration order for ties and unordered views; folder ordering remains alphabetical.
- Preserve `order` through parsing, Builder APIs, formatting, DSL generation, completion, documentation, and a patch changeset.

## Verification

- `corepack pnpm typecheck` — passed (26 packages).
- `corepack pnpm test` — passed (261 files, 2,688 tests; 1 expected failure, 23 skipped, 4 todo).
- `corepack pnpm exec vitest run --no-isolate --maxWorkers=1 src/model/view/LikeC4ViewsFolder.spec.ts src/compute-view/utils/view-hash.spec.ts src/compute-view/utils/resolve-extended-views.spec.ts`
- `corepack pnpm exec vitest run --no-isolate --maxWorkers=1 src/model/__tests__/model-builder-view-folders.spec.ts src/formatting/LikeC4Formatter.spec.ts src/lsp/CompletionProvider.spec.ts`
- `corepack pnpm exec vitest run --no-isolate --maxWorkers=1 src/likec4/operators/views.spec.ts`
- `git diff --check`
- Real SPA visual verification: served a fixture whose declaration order was `order 30`, unordered, `order 10`, `order 20`; the navigation rendered `10`, `20`, `30`, then unordered, with zero browser console/page errors.
