### PR TITLE
fix(language-server): wrap document symbol detail in parens to avoid merging with name

### DIFF
--- a/.changeset/fix-document-symbol-detail.md
+++ b/.changeset/fix-document-symbol-detail.md
@@ -1,0 +1,5 @@
+---
+"@likec4/language-server": patch
+---
+
+Fix outline entries merging an element's kind into its name, such as `modelmodel`. The kind now renders in parentheses. Fixes [#3091](https://github.com/likec4/likec4/issues/3091)

--- a/packages/language-server/src/lsp/DocumentSymbolProvider.spec.ts
+++ b/packages/language-server/src/lsp/DocumentSymbolProvider.spec.ts
@@ -93,4 +93,32 @@ describe('LikeC4DocumentSymbolProvider', () => {
       },
     ])
   })
+
+  it('should keep element detail from visually merging with name when kind equals name (#3091)', async ({ expect, t, validate }) => {
+    const { document, diagnostics } = await validate(`
+        specification {
+          element model
+        }
+        model {
+          model model
+        }
+      `)
+    expect(diagnostics).to.be.empty
+    const symbols = await t.services.lsp.DocumentSymbolProvider.getSymbols(
+      document,
+      textDocumentParams(document),
+    )
+    const modelContainer = symbols.find(s => s.name === 'model')
+    expect(modelContainer).toBeDefined()
+    expect(modelContainer!.detail).toBeUndefined()
+
+    const elementSymbol = modelContainer!.children?.[0]
+    expect(elementSymbol).toBeDefined()
+    // Regression: `detail` used to be the bare kind ('model'), which some LSP clients
+    // (e.g. Zed) render directly adjacent to `name` with no separator of their own,
+    // producing the literal displayed text 'modelmodel'. Wrapping in parens keeps the
+    // two fields visually distinct regardless of client-side formatting.
+    expect(elementSymbol!.name).toBe('model')
+    expect(elementSymbol!.detail).toBe('(model)')
+  })
 })

--- a/packages/language-server/src/lsp/DocumentSymbolProvider.ts
+++ b/packages/language-server/src/lsp/DocumentSymbolProvider.ts
@@ -203,7 +203,10 @@ export class LikeC4DocumentSymbolProvider implements DocumentSymbolProvider {
     const name = astElement.name
     const kind = astElement.kind.$refText
     // TODO: return the title as well
-    const detail = kind // + (astElement.title ? ': ' + astElement.title : '').replaceAll('\n', ' ').trim()
+    // Wrapped in parens so the kind never visually merges with `name` when a client
+    // renders `name` and `detail` adjacently without its own separator (e.g. an element
+    // named the same as its kind, such as `model model`, would otherwise show as `modelmodel`)
+    const detail = `(${kind})` // + (astElement.title ? ': ' + astElement.title : '').replaceAll('\n', ' ').trim()
     return [
       {
         kind: this.symbolKind(astElement),
@@ -306,7 +309,10 @@ export class LikeC4DocumentSymbolProvider implements DocumentSymbolProvider {
     const name = this.nameProvider.getNameStrict(astElement)
     const kind = astElement.kind.$refText
     // TODO: return the title as well
-    const detail = kind // + (astElement.title ? ': ' + astElement.title : '').replaceAll('\n', ' ').trim()
+    // Wrapped in parens so the kind never visually merges with `name` when a client
+    // renders `name` and `detail` adjacently without its own separator (e.g. a deployment
+    // node named the same as its kind would otherwise show as e.g. `nodenode`)
+    const detail = `(${kind})` // + (astElement.title ? ': ' + astElement.title : '').replaceAll('\n', ' ').trim()
     return [
       {
         kind: this.symbolKind(astElement),


### PR DESCRIPTION
## Summary

Fixes #3091 — in some LSP clients (e.g. Zed), a document symbol's `name` and `detail` are rendered adjacently without a separator. Since `detail` was set to the bare element kind, an element whose name equals its kind (like `model model`) displayed as `modelmodel`.

This wraps the kind in parentheses (`(model)`), so the two stay visually distinct in any client, matching the common convention used by other language servers.

Applied to both logical elements and deployment nodes in `DocumentSymbolProvider`.

## Verification

Added a regression test reproducing the issue with `element model` / `model model`:

```
pnpm vitest run DocumentSymbolProvider
# Test Files  1 passed (1)
#      Tests  2 passed (2)
```

`pnpm typecheck` passes on this branch.

A full `pnpm test` run does not complete in my environment: 20 test files fail to import `@likec4/styles/css` and `prompt-system.generated`, i.e. build artifacts that a plain checkout does not have. Those are missing-package errors, not assertion failures — the run still reports 2528 passing tests and no failing assertions. Flagging it rather than ticking the box below, since I could not verify the whole suite myself.

## Checklist

- [x] I've thoroughly read the latest [contribution guidelines](https://github.com/likec4/likec4/blob/main/CONTRIBUTING.md).
- [x] I've rebased my branch onto `main` **before** creating this PR. <sup>(current at creation; 3 commits have landed on `main` since — happy to rebase if you'd like it refreshed before merge)</sup>
- [x] I've added tests to cover my changes (if applicable).
- [ ] I've verified `pnpm typecheck` and `pnpm test`. <sup>(`typecheck` verified; full `pnpm test` not verifiable locally — see Verification above)</sup>
- [x] I've added [changesets](https://changesets-docs.vercel.app/) (you can use `/changeset-generator` SKILL).
- [ ] My change requires documentation updates.
- [ ] I've updated the documentation accordingly (or will do in follow-up PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
