### PR TITLE
fix: preserve bundled icon colors

### DIFF
--- a/.changeset/preserve-brand-icon-colors.md
+++ b/.changeset/preserve-brand-icon-colors.md
@@ -4,4 +4,4 @@
 "@likec4/style-preset": patch
 ---
 
-Preserve original colors for bundled brand and cloud provider icons in diagrams unless `iconColor` is explicitly set. Fixes [#3153](https://github.com/likec4/likec4/issues/3153).
+Preserve original colors for non-Bootstrap diagram icons, including bundled brand, cloud provider, and image-based icons. Fixes [#3153](https://github.com/likec4/likec4/issues/3153).

--- a/.changeset/preserve-brand-icon-colors.md
+++ b/.changeset/preserve-brand-icon-colors.md
@@ -1,0 +1,7 @@
+---
+"@likec4/diagram": patch
+"@likec4/styles": patch
+"@likec4/style-preset": patch
+---
+
+Preserve original colors for bundled brand and cloud provider icons in diagrams unless `iconColor` is explicitly set. Fixes [#3153](https://github.com/likec4/likec4/issues/3153).

--- a/packages/diagram/src/base-primitives/element/ElementData.spec.tsx
+++ b/packages/diagram/src/base-primitives/element/ElementData.spec.tsx
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import type { ComputedNodeStyle, NodeId } from '@likec4/core'
+import type { Color } from '@likec4/core/types'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { ElementData } from './ElementData'
+
+function renderElementData(icon: string | null | undefined, style: ComputedNodeStyle = {}) {
+  return renderToStaticMarkup(
+    <ElementData
+      data={{
+        id: 'test' as NodeId,
+        title: 'Test',
+        color: 'blue' as Color,
+        style,
+        ...(icon !== undefined && { icon }),
+      }}
+    />,
+  )
+}
+
+describe('ElementData icon blending', () => {
+  it('does not add the blending recipe variant for brand, provider, and image icons', () => {
+    const icons = [
+      'tech:postgresql',
+      'tech:react',
+      'aws:lambda',
+      'azure:virtual-machine',
+      'gcp:cloud-run',
+      'https://example.com/icon.svg',
+      'data:image/svg+xml,%3Csvg%3E%3C/svg%3E',
+      'file:///tmp/icon.svg',
+      'none',
+      null,
+      undefined,
+    ]
+
+    for (const icon of icons) {
+      const html = renderElementData(icon)
+
+      expect(html).toContain('likec4-element-node-data--withIconBlend_false')
+      expect(html).not.toContain('likec4-element-node-data--withIconBlend_true')
+    }
+  })
+
+  it('adds the blending recipe variant for bootstrap icons without explicit iconColor', () => {
+    expect(renderElementData('bootstrap:house')).toContain('likec4-element-node-data--withIconBlend_true')
+    expect(renderElementData('bootstrap:house', { iconColor: 'indigo' })).toContain(
+      'likec4-element-node-data--withIconBlend_false',
+    )
+  })
+})

--- a/packages/diagram/src/base-primitives/element/ElementData.spec.tsx
+++ b/packages/diagram/src/base-primitives/element/ElementData.spec.tsx
@@ -48,8 +48,11 @@ describe('ElementData icon blending', () => {
 
   it('adds the blending recipe variant for bootstrap icons without explicit iconColor', () => {
     expect(renderElementData('bootstrap:house')).toContain('likec4-element-node-data--withIconBlend_true')
-    expect(renderElementData('bootstrap:house', { iconColor: 'indigo' })).toContain(
-      'likec4-element-node-data--withIconBlend_false',
-    )
+
+    const html = renderElementData('bootstrap:house', { iconColor: 'indigo' })
+
+    expect(html).toContain('likec4-element-node-data--withIconColor_true')
+    expect(html).toContain('likec4-element-node-data--withIconBlend_false')
+    expect(html).toContain('--likec4-icon-color:')
   })
 })

--- a/packages/diagram/src/base-primitives/element/ElementData.tsx
+++ b/packages/diagram/src/base-primitives/element/ElementData.tsx
@@ -55,6 +55,11 @@ const resolveIconColor = (styles: LikeC4Styles, data: RequiredData): ColorLitera
   return iconColor === data.color ? colors.stroke : colors.fill
 }
 
+function shouldBlendIconWithPalette(icon: string | null | undefined, hasIconColor: boolean): boolean {
+  // Bootstrap icons are monochrome currentColor SVGs. Other bundled groups use brand/provider fills.
+  return !hasIconColor && icon?.startsWith('bootstrap:') === true
+}
+
 const Root = forwardRef<
   HTMLDivElement,
   RootProps
@@ -72,6 +77,7 @@ const Root = forwardRef<
     ? styles.nodeSizes(data.style).values.iconSize
     : undefined
   const resolvedIconColor = resolveIconColor(styles, data)
+  const hasIconColor = !!resolvedIconColor
   return (
     <div
       {...props}
@@ -80,7 +86,8 @@ const Root = forwardRef<
         className,
         elementNodeData({
           iconPosition: data.style.iconPosition,
-          withIconColor: !!resolvedIconColor,
+          withIconColor: hasIconColor,
+          withIconBlend: shouldBlendIconWithPalette(data.icon, hasIconColor),
         }),
         'likec4-element',
       )}

--- a/styled-system/preset/src/recipes/elementNodeData.ts
+++ b/styled-system/preset/src/recipes/elementNodeData.ts
@@ -280,7 +280,10 @@ export const elementNodeData = defineRecipe({
           },
         },
       }),
-      false: parts({
+      false: parts({}),
+    },
+    withIconBlend: {
+      true: parts({
         icon: {
           mixBlendMode: {
             base: 'hard-light',
@@ -288,11 +291,13 @@ export const elementNodeData = defineRecipe({
           },
         },
       }),
+      false: parts({}),
     },
   },
   defaultVariants: {
     iconPosition: 'left',
     withIconColor: false,
+    withIconBlend: false,
   },
   staticCss: ['*'],
 })


### PR DESCRIPTION
## Summary

Fixes #3153.

- Preserve original colors for bundled brand/provider icons such as `tech:postgresql`, `tech:react`, `aws:lambda`, `azure:virtual-machine`, and `gcp:cloud-run`.
- Keep the previous palette-blending behavior only for monochrome `bootstrap:*` icons when no explicit `iconColor` is set.
- Add regression coverage for brand/provider/image icons and `bootstrap:*` behavior.

## Validation

- `pnpm generate`
- `pnpm --filter @likec4/diagram test -- ElementData.spec.tsx`
- `pnpm --filter @likec4/diagram test`
- `pnpm --filter @likec4/style-preset typecheck`
- `pnpm --filter @likec4/diagram typecheck`
- `pnpm --filter @likec4/diagram exec oxlint --type-aware src/base-primitives/element/ElementData.tsx src/base-primitives/element/ElementData.spec.tsx`

Note: full `pnpm --filter @likec4/diagram lint` currently fails on existing unrelated files, including `src/likec4diagram/ui/sequence-outline/state.ts`, `src/likec4diagram/xyflow-sequence/utils.ts`, and `src/likec4diagram/custom/nodes/SequenceSubFlow.tsx`.