### PR TITLE
fix: render local svg icons consistently

### DIFF
--- a/.changeset/fix-local-svg-icons.md
+++ b/.changeset/fix-local-svg-icons.md
@@ -1,0 +1,6 @@
+---
+"@likec4/diagram": patch
+"@likec4/vite-plugin": patch
+---
+
+Render custom SVG icons reliably in relationship views and allow local SVG icons that use `currentColor` to follow `iconColor`.

--- a/packages/diagram/src/context/IconRenderer.spec.tsx
+++ b/packages/diagram/src/context/IconRenderer.spec.tsx
@@ -3,9 +3,30 @@ import { describe, expect, it } from 'vitest'
 import { IconRenderer } from './IconRenderer'
 
 describe('IconRenderer', () => {
-  it('inlines decodable SVG data URLs so iconColor can style currentColor', () => {
+  it('renders SVG data URLs as colorable masks so iconColor can style currentColor', () => {
     const svgDataUrl =
       'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg"%3E%3Cpath stroke="currentColor"/%3E%3C/svg%3E'
+
+    const html = renderToStaticMarkup(
+      <IconRenderer
+        element={{
+          id: 'test',
+          title: 'Test',
+          icon: svgDataUrl,
+        }}
+        style={{ color: 'red' }} />,
+    )
+
+    expect(html).toContain('style="color:red"')
+    expect(html).toContain('background-color:currentColor')
+    expect(html).toContain('mask-image:url(')
+    expect(html).toContain('data:image/svg+xml')
+    expect(html).not.toContain('<svg')
+    expect(html).not.toContain('<img')
+  })
+
+  it('keeps base64 SVG data URLs as safe mask image sources', () => {
+    const svgDataUrl = 'data:image/svg+xml;base64,PHN2Zz48cGF0aCBzdHJva2U9ImN1cnJlbnRDb2xvciIvPjwvc3ZnPg=='
 
     const html = renderToStaticMarkup(
       <IconRenderer
@@ -16,14 +37,18 @@ describe('IconRenderer', () => {
         }} />,
     )
 
-    expect(html).toContain('<svg')
-    expect(html).toContain('stroke="currentColor"')
+    expect(html).toContain('mask-image:url(')
+    expect(html).toContain('data:image/svg+xml;base64,')
+    expect(html).not.toContain('<svg')
     expect(html).not.toContain('<img')
   })
 
-  it('falls back to an image when an SVG data URL cannot be decoded', () => {
-    const svgDataUrl =
-      'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%"><path stroke="currentColor"/></svg>'
+  it('keeps URL-encoded SVG data URLs with commas intact as mask image sources', () => {
+    const svgDataUrl = `data:image/svg+xml,${
+      encodeURIComponent(
+        '<svg xmlns="http://www.w3.org/2000/svg"><path d="M1,2" stroke="currentColor"/></svg>',
+      )
+    }`
 
     const html = renderToStaticMarkup(
       <IconRenderer
@@ -35,7 +60,44 @@ describe('IconRenderer', () => {
     )
 
     expect(html).toContain('class="likec4-element-icon"')
+    expect(html).toContain('mask-image:url(')
+    expect(html).toContain('data:image/svg+xml,')
+    expect(html).not.toContain('<img')
+  })
+
+  it('detects currentColor in raw SVG data URLs with commas and percent characters', () => {
+    const svgDataUrl =
+      'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="100%"><path d="M1,2" stroke="currentColor"/></svg>'
+
+    const html = renderToStaticMarkup(
+      <IconRenderer
+        element={{
+          id: 'test',
+          title: 'Test',
+          icon: svgDataUrl,
+        }} />,
+    )
+
+    expect(html).toContain('mask-image:url(')
+    expect(html).not.toContain('<img')
+  })
+
+  it('keeps non-currentColor SVG data URLs as images to preserve original SVG colors', () => {
+    const svgDataUrl = `data:image/svg+xml,${
+      encodeURIComponent('<svg xmlns="http://www.w3.org/2000/svg"><path fill="red"/></svg>')
+    }`
+
+    const html = renderToStaticMarkup(
+      <IconRenderer
+        element={{
+          id: 'test',
+          title: 'Test',
+          icon: svgDataUrl,
+        }} />,
+    )
+
     expect(html).toContain('<img')
     expect(html).toContain('src="data:image/svg+xml,')
+    expect(html).not.toContain('mask-image:url(')
   })
 })

--- a/packages/diagram/src/context/IconRenderer.spec.tsx
+++ b/packages/diagram/src/context/IconRenderer.spec.tsx
@@ -1,0 +1,41 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { IconRenderer } from './IconRenderer'
+
+describe('IconRenderer', () => {
+  it('inlines decodable SVG data URLs so iconColor can style currentColor', () => {
+    const svgDataUrl =
+      'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg"%3E%3Cpath stroke="currentColor"/%3E%3C/svg%3E'
+
+    const html = renderToStaticMarkup(
+      <IconRenderer
+        element={{
+          id: 'test',
+          title: 'Test',
+          icon: svgDataUrl,
+        }} />,
+    )
+
+    expect(html).toContain('<svg')
+    expect(html).toContain('stroke="currentColor"')
+    expect(html).not.toContain('<img')
+  })
+
+  it('falls back to an image when an SVG data URL cannot be decoded', () => {
+    const svgDataUrl =
+      'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%"><path stroke="currentColor"/></svg>'
+
+    const html = renderToStaticMarkup(
+      <IconRenderer
+        element={{
+          id: 'test',
+          title: 'Test',
+          icon: svgDataUrl,
+        }} />,
+    )
+
+    expect(html).toContain('class="likec4-element-icon"')
+    expect(html).toContain('<img')
+    expect(html).toContain('src="data:image/svg+xml,')
+  })
+})

--- a/packages/diagram/src/context/IconRenderer.spec.tsx
+++ b/packages/diagram/src/context/IconRenderer.spec.tsx
@@ -82,6 +82,23 @@ describe('IconRenderer', () => {
     expect(html).not.toContain('<img')
   })
 
+  it('detects currentColor case-insensitively in SVG data URLs', () => {
+    const svgDataUrl =
+      'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg"%3E%3Cpath stroke="currentcolor"/%3E%3C/svg%3E'
+
+    const html = renderToStaticMarkup(
+      <IconRenderer
+        element={{
+          id: 'test',
+          title: 'Test',
+          icon: svgDataUrl,
+        }} />,
+    )
+
+    expect(html).toContain('mask-image:url(')
+    expect(html).not.toContain('<img')
+  })
+
   it('keeps non-currentColor SVG data URLs as images to preserve original SVG colors', () => {
     const svgDataUrl = `data:image/svg+xml,${
       encodeURIComponent('<svg xmlns="http://www.w3.org/2000/svg"><path fill="red"/></svg>')

--- a/packages/diagram/src/context/IconRenderer.spec.tsx
+++ b/packages/diagram/src/context/IconRenderer.spec.tsx
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it } from 'vitest'
 import { IconRenderer } from './IconRenderer'

--- a/packages/diagram/src/context/IconRenderer.tsx
+++ b/packages/diagram/src/context/IconRenderer.tsx
@@ -184,7 +184,7 @@ function SvgDataUrlIcon({ dataUrl, alt }: { dataUrl: string; alt?: string }) {
 }
 
 function hasCurrentColorReference(dataUrl: string): boolean {
-  return decodeSvgDataUrl(dataUrl)?.includes('currentColor') ?? false
+  return /currentcolor/i.test(decodeSvgDataUrl(dataUrl) ?? '')
 }
 
 function decodeSvgDataUrl(dataUrl: string): string | null {

--- a/packages/diagram/src/context/IconRenderer.tsx
+++ b/packages/diagram/src/context/IconRenderer.tsx
@@ -78,7 +78,7 @@ function decodeSvgDataUrl(dataUrl: string): string | null {
       }
     }
   } catch {
-    // If decoding fails, return null to fall back to img tag
+    // If decoding fails, return null so the caller falls back to an img tag.
   }
   return null
 }
@@ -186,7 +186,7 @@ export function IconOrShapeRenderer({
 function SvgDataUrlIcon({ dataUrl, ...props }: { dataUrl: string; alt?: string }) {
   const svgContent = useMemo(() => decodeSvgDataUrl(dataUrl), [dataUrl])
   if (!svgContent) {
-    return null
+    return <img src={dataUrl} {...props} />
   }
   // Inline the SVG content directly
   // This allows CSS `color` property to affect `currentColor` in the SVG

--- a/packages/diagram/src/context/IconRenderer.tsx
+++ b/packages/diagram/src/context/IconRenderer.tsx
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import type { ElementShape } from '@likec4/core'
 import { cx as clsx } from '@likec4/styles/css'
 import {

--- a/packages/diagram/src/context/IconRenderer.tsx
+++ b/packages/diagram/src/context/IconRenderer.tsx
@@ -53,36 +53,6 @@ export function IconRendererProvider({
   )
 }
 
-/**
- * Attempts to extract and decode SVG content from a data URL.
- * Returns the decoded SVG string if successful, or null if not an SVG data URL.
- */
-function decodeSvgDataUrl(dataUrl: string): string | null {
-  // Check if it's an SVG data URL
-  if (!dataUrl.startsWith('data:image/svg+xml')) {
-    return null
-  }
-
-  try {
-    // Handle both base64 and URL-encoded SVG data URLs
-    if (dataUrl.includes(';base64,')) {
-      const base64Content = dataUrl.split(';base64,')[1]
-      if (base64Content) {
-        return atob(base64Content)
-      }
-    } else {
-      // URL-encoded format: data:image/svg+xml,%3csvg...
-      const encodedContent = dataUrl.split(',')[1]
-      if (encodedContent) {
-        return decodeURIComponent(encodedContent)
-      }
-    }
-  } catch {
-    // If decoding fails, return null so the caller falls back to an img tag.
-  }
-  return null
-}
-
 export function IconRenderer({
   element,
   className,
@@ -183,13 +153,62 @@ export function IconOrShapeRenderer({
   return <IconRenderer element={element} className={className} style={style} />
 }
 
-function SvgDataUrlIcon({ dataUrl, ...props }: { dataUrl: string; alt?: string }) {
-  const svgContent = useMemo(() => decodeSvgDataUrl(dataUrl), [dataUrl])
-  if (!svgContent) {
-    return <img src={dataUrl} {...props} />
+function SvgDataUrlIcon({ dataUrl, alt }: { dataUrl: string; alt?: string }) {
+  const shouldUseMask = useMemo(() => hasCurrentColorReference(dataUrl), [dataUrl])
+
+  if (!shouldUseMask) {
+    return <img src={dataUrl} alt={alt} />
   }
-  // Inline the SVG content directly
-  // This allows CSS `color` property to affect `currentColor` in the SVG
-  // Using display: contents so the span doesn't affect flexbox layout
-  return <span {...props} style={{ display: 'contents' }} dangerouslySetInnerHTML={{ __html: svgContent }} />
+
+  const maskUrl = `url(${JSON.stringify(dataUrl)})`
+  return (
+    <span
+      role={alt ? 'img' : undefined}
+      aria-label={alt}
+      style={{
+        display: 'inline-block',
+        width: '100%',
+        height: '100%',
+        backgroundColor: 'currentColor',
+        maskImage: maskUrl,
+        maskRepeat: 'no-repeat',
+        maskPosition: 'center',
+        maskSize: 'contain',
+        WebkitMaskImage: maskUrl,
+        WebkitMaskRepeat: 'no-repeat',
+        WebkitMaskPosition: 'center',
+        WebkitMaskSize: 'contain',
+      }}
+    />
+  )
+}
+
+function hasCurrentColorReference(dataUrl: string): boolean {
+  return decodeSvgDataUrl(dataUrl)?.includes('currentColor') ?? false
+}
+
+function decodeSvgDataUrl(dataUrl: string): string | null {
+  if (!dataUrl.startsWith('data:image/svg+xml')) {
+    return null
+  }
+
+  try {
+    const comma = dataUrl.indexOf(',')
+    if (comma === -1) {
+      return null
+    }
+
+    const payload = dataUrl.slice(comma + 1)
+    if (dataUrl.slice(0, comma).endsWith(';base64')) {
+      return new TextDecoder().decode(Uint8Array.from(atob(payload), c => c.charCodeAt(0)))
+    }
+
+    try {
+      return decodeURIComponent(payload)
+    } catch {
+      return payload
+    }
+  } catch {
+    return null
+  }
 }

--- a/packages/vite-plugin/src/virtuals/icons.spec.ts
+++ b/packages/vite-plugin/src/virtuals/icons.spec.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
+import { hardenJsonStringLiteralForEmbeddedScript } from './hardenJsonStringLiteralForEmbeddedScript'
 import { generateIconRendererCode } from './icons'
+
+const jsStringLiteral = (value: string) => hardenJsonStringLiteralForEmbeddedScript(JSON.stringify(value))
 
 describe('generateIconRendererCode', () => {
   it('includes model-level icons not present in any computed view', () => {
@@ -17,8 +20,9 @@ describe('generateIconRendererCode', () => {
       },
     })
 
-    expect(code).toContain('import Icon00 from \'file:///workspace/icons/component.svg?raw\'')
-    expect(code).toContain('\'file:///workspace/icons/component.svg\': props => jsx(InlineSvgIcon')
+    expect(code).toContain(`import Icon00Raw from ${jsStringLiteral('file:///workspace/icons/component.svg?raw')}`)
+    expect(code).toContain(`import Icon00 from ${jsStringLiteral('file:///workspace/icons/component.svg?inline')}`)
+    expect(code).toContain(`${jsStringLiteral('file:///workspace/icons/component.svg')}: props => jsx(LocalSvgIcon`)
   })
 
   it('keeps local bitmap icons as image assets', () => {
@@ -36,8 +40,8 @@ describe('generateIconRendererCode', () => {
       },
     })
 
-    expect(code).toContain('import Icon00 from \'file:///workspace/icons/component.png?inline\'')
-    expect(code).toContain('\'file:///workspace/icons/component.png\': props => jsx(\'img\'')
+    expect(code).toContain(`import Icon00 from ${jsStringLiteral('file:///workspace/icons/component.png?inline')}`)
+    expect(code).toContain(`${jsStringLiteral('file:///workspace/icons/component.png')}: props => jsx('img'`)
   })
 
   it('includes deployment element icons', () => {
@@ -55,6 +59,52 @@ describe('generateIconRendererCode', () => {
       },
     })
 
-    expect(code).toContain('import Icon00 from \'file:///workspace/icons/node.svg?raw\'')
+    expect(code).toContain(`import Icon00Raw from ${jsStringLiteral('file:///workspace/icons/node.svg?raw')}`)
+    expect(code).toContain(`import Icon00 from ${jsStringLiteral('file:///workspace/icons/node.svg?inline')}`)
+  })
+
+  it('escapes icon references before embedding them into generated code', () => {
+    const icon = 'file:///workspace/icons/icon\';\nthrow new Error("pwned")//.svg'
+    const code = generateIconRendererCode({
+      views: {},
+      elements: {
+        component: {
+          style: {
+            icon,
+          },
+        },
+      },
+      deployments: {
+        elements: {},
+      },
+    })
+
+    expect(code).toContain(`import Icon00Raw from ${jsStringLiteral(`${icon}?raw`)}`)
+    expect(code).toContain(`import Icon00 from ${jsStringLiteral(`${icon}?inline`)}`)
+    expect(code).toContain(`${jsStringLiteral(icon)}: props => jsx(LocalSvgIcon`)
+    expect(code).not.toContain(`from '${icon}?raw'`)
+    expect(code).not.toContain(`from '${icon}?inline'`)
+  })
+
+  it('renders currentColor local SVG assets as masks without injecting raw SVG markup', () => {
+    const code = generateIconRendererCode({
+      views: {},
+      elements: {
+        component: {
+          style: {
+            icon: 'file:///workspace/icons/component.svg',
+          },
+        },
+      },
+      deployments: {
+        elements: {},
+      },
+    })
+
+    expect(code).toContain('function MaskedSvgIcon')
+    expect(code).toContain('function LocalSvgIcon')
+    expect(code).toContain('raw.includes(\'currentColor\')')
+    expect(code).toContain('backgroundColor: \'currentColor\'')
+    expect(code).not.toContain('dangerouslySetInnerHTML')
   })
 })

--- a/packages/vite-plugin/src/virtuals/icons.spec.ts
+++ b/packages/vite-plugin/src/virtuals/icons.spec.ts
@@ -63,6 +63,66 @@ describe('generateIconRendererCode', () => {
     expect(code).toContain(`import Icon00 from ${jsStringLiteral('file:///workspace/icons/node.svg?inline')}`)
   })
 
+  it('includes supported bundled icon groups', () => {
+    const code = generateIconRendererCode({
+      views: {
+        index: {
+          nodes: [{
+            icon: 'bootstrap:file-earmark-code',
+          }],
+        },
+      },
+      elements: {
+        component: {
+          style: {
+            icon: 'tech:react',
+          },
+        },
+      },
+      deployments: {
+        elements: {},
+      },
+    })
+
+    expect(code).toContain(
+      `import Icon00 from ${jsStringLiteral('likec4:icon-bundle/bootstrap/file-earmark-code.jsx')}`,
+    )
+    expect(code).toContain(`import Icon01 from ${jsStringLiteral('likec4:icon-bundle/tech/react.jsx')}`)
+    expect(code).toContain(`${jsStringLiteral('bootstrap:file-earmark-code')}: Icon00`)
+    expect(code).toContain(`${jsStringLiteral('tech:react')}: Icon01`)
+  })
+
+  it('ignores unsupported non-local icon references instead of emitting invalid bundle imports', () => {
+    const code = generateIconRendererCode({
+      views: {
+        index: {
+          nodes: [
+            {
+              icon: 'none',
+            },
+            {
+              icon: 'data:image/svg+xml,<svg />',
+            },
+            {
+              icon: 'mdi:server',
+            },
+          ],
+        },
+      },
+      elements: {},
+      deployments: {
+        elements: {},
+      },
+    })
+
+    expect(code).not.toContain('likec4:icon-bundle/none/')
+    expect(code).not.toContain('likec4:icon-bundle/data/')
+    expect(code).not.toContain('likec4:icon-bundle/mdi/')
+    expect(code).not.toContain(`${jsStringLiteral('none')}:`)
+    expect(code).not.toContain(`${jsStringLiteral('data:image/svg+xml,<svg />')}:`)
+    expect(code).not.toContain(`${jsStringLiteral('mdi:server')}:`)
+  })
+
   it('escapes icon references before embedding them into generated code', () => {
     const icon = 'file:///workspace/icons/icon\';\nthrow new Error("pwned")//.svg'
     const code = generateIconRendererCode({
@@ -86,6 +146,29 @@ describe('generateIconRendererCode', () => {
     expect(code).not.toContain(`from '${icon}?inline'`)
   })
 
+  it('escapes supported bundled icon references before embedding them into generated code', () => {
+    const icon = 'tech:react\';\nthrow new Error("pwned")//'
+    const code = generateIconRendererCode({
+      views: {
+        index: {
+          nodes: [{
+            icon,
+          }],
+        },
+      },
+      elements: {},
+      deployments: {
+        elements: {},
+      },
+    })
+
+    expect(code).toContain(
+      `import Icon00 from ${jsStringLiteral('likec4:icon-bundle/tech/react\';\nthrow new Error("pwned")//.jsx')}`,
+    )
+    expect(code).toContain(`${jsStringLiteral(icon)}: Icon00`)
+    expect(code).not.toContain(`from 'likec4:icon-bundle/tech/react';`)
+  })
+
   it('renders currentColor local SVG assets as masks without injecting raw SVG markup', () => {
     const code = generateIconRendererCode({
       views: {},
@@ -103,7 +186,7 @@ describe('generateIconRendererCode', () => {
 
     expect(code).toContain('function MaskedSvgIcon')
     expect(code).toContain('function LocalSvgIcon')
-    expect(code).toContain('raw.includes(\'currentColor\')')
+    expect(code).toContain('/currentcolor/i.test(raw)')
     expect(code).toContain('backgroundColor: \'currentColor\'')
     expect(code).not.toContain('dangerouslySetInnerHTML')
   })

--- a/packages/vite-plugin/src/virtuals/icons.spec.ts
+++ b/packages/vite-plugin/src/virtuals/icons.spec.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import { generateIconRendererCode } from './icons'
+
+describe('generateIconRendererCode', () => {
+  it('includes model-level icons not present in any computed view', () => {
+    const code = generateIconRendererCode({
+      views: {},
+      elements: {
+        component: {
+          style: {
+            icon: 'file:///workspace/icons/component.svg',
+          },
+        },
+      },
+      deployments: {
+        elements: {},
+      },
+    })
+
+    expect(code).toContain('import Icon00 from \'file:///workspace/icons/component.svg?raw\'')
+    expect(code).toContain('\'file:///workspace/icons/component.svg\': props => jsx(InlineSvgIcon')
+  })
+
+  it('keeps local bitmap icons as image assets', () => {
+    const code = generateIconRendererCode({
+      views: {
+        index: {
+          nodes: [{
+            icon: 'file:///workspace/icons/component.png',
+          }],
+        },
+      },
+      elements: {},
+      deployments: {
+        elements: {},
+      },
+    })
+
+    expect(code).toContain('import Icon00 from \'file:///workspace/icons/component.png?inline\'')
+    expect(code).toContain('\'file:///workspace/icons/component.png\': props => jsx(\'img\'')
+  })
+
+  it('includes deployment element icons', () => {
+    const code = generateIconRendererCode({
+      views: {},
+      elements: {},
+      deployments: {
+        elements: {
+          node: {
+            style: {
+              icon: 'file:///workspace/icons/node.svg',
+            },
+          },
+        },
+      },
+    })
+
+    expect(code).toContain('import Icon00 from \'file:///workspace/icons/node.svg?raw\'')
+  })
+})

--- a/packages/vite-plugin/src/virtuals/icons.spec.ts
+++ b/packages/vite-plugin/src/virtuals/icons.spec.ts
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
 import { describe, expect, it } from 'vitest'
 import { hardenJsonStringLiteralForEmbeddedScript } from './hardenJsonStringLiteralForEmbeddedScript'
 import { generateIconRendererCode } from './icons'

--- a/packages/vite-plugin/src/virtuals/icons.ts
+++ b/packages/vite-plugin/src/virtuals/icons.ts
@@ -8,15 +8,52 @@ import { hardenJsonStringLiteralForEmbeddedScript } from './hardenJsonStringLite
 
 const startsWithHttp = /^(https?:)?\/\//i
 
-function code<V extends { nodes: ReadonlyArray<{ icon?: string | null }> }>(views: V[]) {
+type IconRef = {
+  icon?: string | null
+}
+
+type ViewWithIcons = {
+  nodes: ReadonlyArray<IconRef>
+}
+
+type ModelDataWithIcons = {
+  views: Record<string, ViewWithIcons>
+  manualLayouts?: Record<string, ViewWithIcons>
+  elements: Record<string, { style?: IconRef }>
+  deployments: {
+    elements: Record<string, { style?: IconRef }>
+  }
+}
+
+const iconRef = (icon: string | null | undefined) => isTruthy(icon) && !startsWithHttp.test(icon) ? icon : undefined
+
+function iconRefsFromModelData(data: ModelDataWithIcons) {
   const icons = pipe(
-    views,
-    flatMap(v => v.nodes),
-    map(n => n.icon ?? undefined),
-    filter((s): s is string => isTruthy(s) && !startsWithHttp.test(s)),
+    [
+      ...values(data.views),
+      ...values(data.manualLayouts ?? {}),
+      ...values(data.elements),
+      ...values(data.deployments.elements),
+    ],
+    flatMap(item => 'nodes' in item ? item.nodes.map(n => n.icon) : [item.style?.icon]),
+    map(iconRef),
+    filter(isTruthy),
     unique(),
     sort(compareNatural),
   )
+
+  return icons
+}
+
+const isLocalSvg = (icon: string) => {
+  if (!icon.startsWith('file:')) {
+    return false
+  }
+  return icon.toLowerCase().split(/[?#]/)[0]?.endsWith('.svg') ?? false
+}
+
+export function generateIconRendererCode(data: ModelDataWithIcons) {
+  const icons = iconRefsFromModelData(data)
 
   const {
     imports,
@@ -26,8 +63,13 @@ function code<V extends { nodes: ReadonlyArray<{ icon?: string | null }> }>(view
     const Component = 'Icon' + i.toString().padStart(2, '0')
 
     if (isLocalImage) {
-      acc.imports.push(`import ${Component} from '${s}?inline'`)
-      acc.cases.push(`  '${s}': () => jsx('img', { src: ${Component} })`)
+      if (isLocalSvg(s)) {
+        acc.imports.push(`import ${Component} from '${s}?raw'`)
+        acc.cases.push(`  '${s}': props => jsx(InlineSvgIcon, { ...props, svg: ${Component} })`)
+      } else {
+        acc.imports.push(`import ${Component} from '${s}?inline'`)
+        acc.cases.push(`  '${s}': props => jsx('img', { ...props, src: ${Component} })`)
+      }
 
       return acc
     }
@@ -48,6 +90,15 @@ ${imports.join('\n')}
 const Icons = {
 ${cases.join(',\n')}
 }
+
+function InlineSvgIcon({ svg, style, ...props }) {
+  return jsx('span', {
+    ...props,
+    style: { ...style, display: 'contents' },
+    dangerouslySetInnerHTML: { __html: svg }
+  })
+}
+
 export function IconRenderer({ node, ...props }) {
   const IconComponent = Icons[node.icon ?? '']
   if (!IconComponent) {
@@ -63,13 +114,9 @@ export const projectIconsModule: ProjectVirtualModule = {
   async load({ likec4, project }) {
     logGenerating('icons', project.id)
     const model = await likec4.computedModel(project.id)
-    const views = [
-      ...values(model.$data.views),
-      ...values(model.$data.manualLayouts ?? {}),
-    ]
     return {
       moduleType: 'jsx',
-      code: code(views),
+      code: generateIconRendererCode(model.$data),
     }
   },
 }

--- a/packages/vite-plugin/src/virtuals/icons.ts
+++ b/packages/vite-plugin/src/virtuals/icons.ts
@@ -25,12 +25,32 @@ type ModelDataWithIcons = {
   }
 }
 
-const iconRef = (icon: string | null | undefined) => isTruthy(icon) && !startsWithHttp.test(icon) ? icon : undefined
+type BundledIconGroup = 'aws' | 'azure' | 'gcp' | 'tech' | 'bootstrap'
 
-function iconRefsFromModelData(data: ModelDataWithIcons) {
-  const iconsFromViews = (views: Record<string, ViewWithIcons>) =>
+type BundledIconRef = {
+  group: BundledIconGroup
+  icon: string
+}
+
+type GeneratedIconRendererParts = {
+  imports: string[]
+  cases: string[]
+}
+
+const bundledIconGroups: ReadonlySet<string> = new Set(['aws', 'azure', 'gcp', 'tech', 'bootstrap'])
+
+function iconRef(icon: string | null | undefined): string | undefined {
+  if (!isTruthy(icon) || startsWithHttp.test(icon) || icon === 'none' || icon.startsWith('data:image')) {
+    return undefined
+  }
+  return icon.startsWith('file:') || parseBundledIconRef(icon) ? icon : undefined
+}
+
+function iconRefsFromModelData(data: ModelDataWithIcons): string[] {
+  const iconsFromViews = (views: Record<string, ViewWithIcons>): Array<string | null | undefined> =>
     values(views).flatMap(view => view.nodes.map(node => node.icon))
-  const iconsFromStyled = (items: Record<string, { style?: IconRef }>) => values(items).map(item => item.style?.icon)
+  const iconsFromStyled = (items: Record<string, { style?: IconRef }>): Array<string | null | undefined> =>
+    values(items).map(item => item.style?.icon)
 
   return pipe(
     [
@@ -46,22 +66,43 @@ function iconRefsFromModelData(data: ModelDataWithIcons) {
   )
 }
 
-const isLocalSvg = (icon: string) => {
+const isLocalSvg = (icon: string): boolean => {
   if (!icon.startsWith('file:')) {
     return false
   }
   return icon.toLowerCase().split(/[?#]/)[0]?.endsWith('.svg') ?? false
 }
 
-const jsStringLiteral = (value: string) => hardenJsonStringLiteralForEmbeddedScript(JSON.stringify(value))
+const jsStringLiteral = (value: string): string => hardenJsonStringLiteralForEmbeddedScript(JSON.stringify(value))
 
-export function generateIconRendererCode(data: ModelDataWithIcons) {
+function isBundledIconGroup(group: string): group is BundledIconGroup {
+  return bundledIconGroups.has(group)
+}
+
+function parseBundledIconRef(iconRef: string): BundledIconRef | null {
+  const separator = iconRef.indexOf(':')
+  if (separator <= 0 || separator === iconRef.length - 1) {
+    return null
+  }
+
+  const group = iconRef.slice(0, separator)
+  if (!isBundledIconGroup(group)) {
+    return null
+  }
+
+  return {
+    group,
+    icon: iconRef.slice(separator + 1),
+  }
+}
+
+export function generateIconRendererCode(data: ModelDataWithIcons): string {
   const icons = iconRefsFromModelData(data)
 
   const {
     imports,
     cases,
-  } = icons.reduce((acc, s, i) => {
+  } = icons.reduce<GeneratedIconRendererParts>((acc, s, i) => {
     const isLocalImage = s.startsWith('file:')
     const Component = 'Icon' + i.toString().padStart(2, '0')
     const iconLiteral = jsStringLiteral(s)
@@ -82,14 +123,18 @@ export function generateIconRendererCode(data: ModelDataWithIcons) {
       return acc
     }
 
-    const [group, icon] = s.split(':') as ['aws' | 'azure' | 'gcp' | 'tech', string]
+    const bundledIcon = parseBundledIconRef(s)
+    if (!bundledIcon) {
+      return acc
+    }
+    const { group, icon } = bundledIcon
     const url = `likec4:icon-bundle/${group}/${icon}.jsx`
     acc.imports.push(`import ${Component} from ${jsStringLiteral(url)}`)
     acc.cases.push(`  ${iconLiteral}: ${Component}`)
     return acc
   }, {
-    imports: [] as string[],
-    cases: [] as string[],
+    imports: [],
+    cases: [],
   })
   return `
 import { jsx } from 'react/jsx-runtime'
@@ -122,7 +167,7 @@ function MaskedSvgIcon({ src, style, ...props }) {
 }
 
 function LocalSvgIcon({ src, raw, ...props }) {
-  if (typeof raw === 'string' && raw.includes('currentColor')) {
+  if (typeof raw === 'string' && /currentcolor/i.test(raw)) {
     return jsx(MaskedSvgIcon, { ...props, src })
   }
   return jsx('img', { ...props, src })

--- a/packages/vite-plugin/src/virtuals/icons.ts
+++ b/packages/vite-plugin/src/virtuals/icons.ts
@@ -1,5 +1,5 @@
 import { compareNatural } from '@likec4/core/utils'
-import { filter, flatMap, isTruthy, map, pipe, sort, unique, values } from 'remeda'
+import { filter, isTruthy, map, pipe, sort, unique, values } from 'remeda'
 import k from 'tinyrainbow'
 import { joinURL } from 'ufo'
 import { logGenerating } from '../logger'
@@ -28,21 +28,22 @@ type ModelDataWithIcons = {
 const iconRef = (icon: string | null | undefined) => isTruthy(icon) && !startsWithHttp.test(icon) ? icon : undefined
 
 function iconRefsFromModelData(data: ModelDataWithIcons) {
-  const icons = pipe(
+  const iconsFromViews = (views: Record<string, ViewWithIcons>) =>
+    values(views).flatMap(view => view.nodes.map(node => node.icon))
+  const iconsFromStyled = (items: Record<string, { style?: IconRef }>) => values(items).map(item => item.style?.icon)
+
+  return pipe(
     [
-      ...values(data.views),
-      ...values(data.manualLayouts ?? {}),
-      ...values(data.elements),
-      ...values(data.deployments.elements),
+      ...iconsFromViews(data.views),
+      ...iconsFromViews(data.manualLayouts ?? {}),
+      ...iconsFromStyled(data.elements),
+      ...iconsFromStyled(data.deployments.elements),
     ],
-    flatMap(item => 'nodes' in item ? item.nodes.map(n => n.icon) : [item.style?.icon]),
     map(iconRef),
     filter(isTruthy),
     unique(),
     sort(compareNatural),
   )
-
-  return icons
 }
 
 const isLocalSvg = (icon: string) => {
@@ -51,6 +52,8 @@ const isLocalSvg = (icon: string) => {
   }
   return icon.toLowerCase().split(/[?#]/)[0]?.endsWith('.svg') ?? false
 }
+
+const jsStringLiteral = (value: string) => hardenJsonStringLiteralForEmbeddedScript(JSON.stringify(value))
 
 export function generateIconRendererCode(data: ModelDataWithIcons) {
   const icons = iconRefsFromModelData(data)
@@ -61,14 +64,19 @@ export function generateIconRendererCode(data: ModelDataWithIcons) {
   } = icons.reduce((acc, s, i) => {
     const isLocalImage = s.startsWith('file:')
     const Component = 'Icon' + i.toString().padStart(2, '0')
+    const iconLiteral = jsStringLiteral(s)
 
     if (isLocalImage) {
       if (isLocalSvg(s)) {
-        acc.imports.push(`import ${Component} from '${s}?raw'`)
-        acc.cases.push(`  '${s}': props => jsx(InlineSvgIcon, { ...props, svg: ${Component} })`)
+        const RawComponent = `${Component}Raw`
+        acc.imports.push(`import ${RawComponent} from ${jsStringLiteral(`${s}?raw`)}`)
+        acc.imports.push(`import ${Component} from ${jsStringLiteral(`${s}?inline`)}`)
+        acc.cases.push(
+          `  ${iconLiteral}: props => jsx(LocalSvgIcon, { ...props, src: ${Component}, raw: ${RawComponent} })`,
+        )
       } else {
-        acc.imports.push(`import ${Component} from '${s}?inline'`)
-        acc.cases.push(`  '${s}': props => jsx('img', { ...props, src: ${Component} })`)
+        acc.imports.push(`import ${Component} from ${jsStringLiteral(`${s}?inline`)}`)
+        acc.cases.push(`  ${iconLiteral}: props => jsx('img', { ...props, src: ${Component} })`)
       }
 
       return acc
@@ -76,8 +84,8 @@ export function generateIconRendererCode(data: ModelDataWithIcons) {
 
     const [group, icon] = s.split(':') as ['aws' | 'azure' | 'gcp' | 'tech', string]
     const url = `likec4:icon-bundle/${group}/${icon}.jsx`
-    acc.imports.push(`import ${Component} from '${url}'`)
-    acc.cases.push(`  '${group}:${icon}': ${Component}`)
+    acc.imports.push(`import ${Component} from ${jsStringLiteral(url)}`)
+    acc.cases.push(`  ${iconLiteral}: ${Component}`)
     return acc
   }, {
     imports: [] as string[],
@@ -91,12 +99,33 @@ const Icons = {
 ${cases.join(',\n')}
 }
 
-function InlineSvgIcon({ svg, style, ...props }) {
+function MaskedSvgIcon({ src, style, ...props }) {
+  const maskUrl = 'url(' + JSON.stringify(src) + ')'
   return jsx('span', {
     ...props,
-    style: { ...style, display: 'contents' },
-    dangerouslySetInnerHTML: { __html: svg }
+    style: {
+      ...style,
+      display: 'inline-block',
+      width: '100%',
+      height: '100%',
+      backgroundColor: 'currentColor',
+      maskImage: maskUrl,
+      maskRepeat: 'no-repeat',
+      maskPosition: 'center',
+      maskSize: 'contain',
+      WebkitMaskImage: maskUrl,
+      WebkitMaskRepeat: 'no-repeat',
+      WebkitMaskPosition: 'center',
+      WebkitMaskSize: 'contain'
+    }
   })
+}
+
+function LocalSvgIcon({ src, raw, ...props }) {
+  if (typeof raw === 'string' && raw.includes('currentColor')) {
+    return jsx(MaskedSvgIcon, { ...props, src })
+  }
+  return jsx('img', { ...props, src })
 }
 
 export function IconRenderer({ node, ...props }) {

--- a/packages/vite-plugin/src/virtuals/icons.ts
+++ b/packages/vite-plugin/src/virtuals/icons.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { compareNatural } from '@likec4/core/utils'
 import { filter, isTruthy, map, pipe, sort, unique, values } from 'remeda'
 import k from 'tinyrainbow'

--- a/packages/vscode-preview/src/IconRenderer.spec.tsx
+++ b/packages/vscode-preview/src/IconRenderer.spec.tsx
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it, vi } from 'vitest'
 import { IconRenderer, localIconRendererFromDataUrl } from './IconRenderer'

--- a/packages/vscode-preview/src/IconRenderer.spec.tsx
+++ b/packages/vscode-preview/src/IconRenderer.spec.tsx
@@ -79,6 +79,24 @@ describe('IconRenderer', () => {
     expect(html).not.toContain('<img')
   })
 
+  it('detects currentColor case-insensitively in local SVG data URLs', () => {
+    const dataUrl =
+      'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg"%3E%3Cpath stroke="currentcolor"/%3E%3C/svg%3E'
+    const LocalIcon = localIconRendererFromDataUrl(dataUrl)
+
+    const html = renderToStaticMarkup(
+      <LocalIcon
+        node={{
+          id: 'test',
+          title: 'Test',
+          icon: 'file:///workspace/icons/component.svg',
+        }} />,
+    )
+
+    expect(html).toContain('mask-image:url(')
+    expect(html).not.toContain('<img')
+  })
+
   it('keeps local SVG data URLs without currentColor as images', () => {
     const dataUrl = `data:image/svg+xml,${
       encodeURIComponent('<svg xmlns="http://www.w3.org/2000/svg"><path fill="red"/></svg>')

--- a/packages/vscode-preview/src/IconRenderer.spec.tsx
+++ b/packages/vscode-preview/src/IconRenderer.spec.tsx
@@ -1,6 +1,6 @@
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it, vi } from 'vitest'
-import { IconRenderer } from './IconRenderer'
+import { decodeSvgDataUrl, IconRenderer } from './IconRenderer'
 
 vi.mock('./vscode', () => ({
   ExtensionApi: {
@@ -36,5 +36,11 @@ describe('IconRenderer', () => {
 
     expect(html).toContain('<img')
     expect(html).toContain('src="https://icons.like-c4.dev/tech/react.svg"')
+  })
+
+  it('decodes SVG data URLs so local SVG icons can inherit currentColor', () => {
+    const svg = '<svg xmlns="http://www.w3.org/2000/svg"><path stroke="currentColor"/></svg>'
+
+    expect(decodeSvgDataUrl(`data:image/svg+xml;base64,${btoa(svg)}`)).toBe(svg)
   })
 })

--- a/packages/vscode-preview/src/IconRenderer.spec.tsx
+++ b/packages/vscode-preview/src/IconRenderer.spec.tsx
@@ -1,6 +1,6 @@
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it, vi } from 'vitest'
-import { decodeSvgDataUrl, IconRenderer } from './IconRenderer'
+import { IconRenderer, localIconRendererFromDataUrl } from './IconRenderer'
 
 vi.mock('./vscode', () => ({
   ExtensionApi: {
@@ -38,9 +38,96 @@ describe('IconRenderer', () => {
     expect(html).toContain('src="https://icons.like-c4.dev/tech/react.svg"')
   })
 
-  it('decodes SVG data URLs so local SVG icons can inherit currentColor', () => {
-    const svg = '<svg xmlns="http://www.w3.org/2000/svg"><path stroke="currentColor"/></svg>'
+  it('renders local SVG data URLs as colorable masks', () => {
+    const dataUrl = `data:image/svg+xml,${
+      encodeURIComponent(
+        '<svg xmlns="http://www.w3.org/2000/svg"><path d="M1,2" stroke="currentColor"/></svg>',
+      )
+    }`
+    const LocalIcon = localIconRendererFromDataUrl(dataUrl)
 
-    expect(decodeSvgDataUrl(`data:image/svg+xml;base64,${btoa(svg)}`)).toBe(svg)
+    const html = renderToStaticMarkup(
+      <LocalIcon
+        node={{
+          id: 'test',
+          title: 'Test',
+          icon: 'file:///workspace/icons/component.svg',
+        }} />,
+    )
+
+    expect(html).toContain('background-color:currentColor')
+    expect(html).toContain('mask-image:url(')
+    expect(html).not.toContain('<svg')
+    expect(html).not.toContain('<img')
+  })
+
+  it('detects currentColor in raw local SVG data URLs with commas and percent characters', () => {
+    const dataUrl =
+      'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="100%"><path d="M1,2" stroke="currentColor"/></svg>'
+    const LocalIcon = localIconRendererFromDataUrl(dataUrl)
+
+    const html = renderToStaticMarkup(
+      <LocalIcon
+        node={{
+          id: 'test',
+          title: 'Test',
+          icon: 'file:///workspace/icons/component.svg',
+        }} />,
+    )
+
+    expect(html).toContain('mask-image:url(')
+    expect(html).not.toContain('<img')
+  })
+
+  it('keeps local SVG data URLs without currentColor as images', () => {
+    const dataUrl = `data:image/svg+xml,${
+      encodeURIComponent('<svg xmlns="http://www.w3.org/2000/svg"><path fill="red"/></svg>')
+    }`
+    const LocalIcon = localIconRendererFromDataUrl(dataUrl)
+
+    const html = renderToStaticMarkup(
+      <LocalIcon
+        node={{
+          id: 'test',
+          title: 'Test',
+          icon: 'file:///workspace/icons/component.svg',
+        }} />,
+    )
+
+    expect(html).toContain('<img')
+    expect(html).toContain('src="data:image/svg+xml,')
+    expect(html).not.toContain('mask-image:url(')
+  })
+
+  it('keeps local bitmap data URLs as images', () => {
+    const dataUrl = 'data:image/png;base64,aW1hZ2U='
+    const LocalIcon = localIconRendererFromDataUrl(dataUrl)
+
+    const html = renderToStaticMarkup(
+      <LocalIcon
+        node={{
+          id: 'test',
+          title: 'Test',
+          icon: 'file:///workspace/icons/component.png',
+        }} />,
+    )
+
+    expect(html).toContain('<img')
+    expect(html).toContain('src="data:image/png;base64,aW1hZ2U="')
+  })
+
+  it('renders nothing when a local icon cannot be read', () => {
+    const LocalIcon = localIconRendererFromDataUrl(null)
+
+    const html = renderToStaticMarkup(
+      <LocalIcon
+        node={{
+          id: 'test',
+          title: 'Test',
+          icon: 'file:///workspace/icons/missing.svg',
+        }} />,
+    )
+
+    expect(html).toBe('')
   })
 })

--- a/packages/vscode-preview/src/IconRenderer.tsx
+++ b/packages/vscode-preview/src/IconRenderer.tsx
@@ -5,32 +5,28 @@ import { ExtensionApi as extensionApi } from './vscode'
 
 const iconUrl = (group: string, name: string) => `https://icons.like-c4.dev/${group}/${name}.svg`
 
-export function decodeSvgDataUrl(dataUrl: string): string | null {
-  if (!dataUrl.startsWith('data:image/svg+xml')) {
-    return null
-  }
-
-  try {
-    if (dataUrl.includes(';base64,')) {
-      const base64Content = dataUrl.split(';base64,')[1]
-      if (base64Content) {
-        return atob(base64Content)
-      }
-    } else {
-      const encodedContent = dataUrl.split(',')[1]
-      if (encodedContent) {
-        return decodeURIComponent(encodedContent)
-      }
-    }
-  } catch {
-    // Fall back to rendering the data URL as an image.
-  }
-
-  return null
-}
-
-function InlineSvgIcon({ svg }: { svg: string }) {
-  return <span style={{ display: 'contents' }} dangerouslySetInnerHTML={{ __html: svg }} />
+function SvgMask({ src, ...props }: Omit<ElementIconRendererProps, 'node'> & { src: string }) {
+  const maskUrl = `url(${JSON.stringify(src)})`
+  return (
+    <span
+      {...props}
+      aria-hidden="true"
+      style={{
+        display: 'inline-block',
+        width: '100%',
+        height: '100%',
+        backgroundColor: 'currentColor',
+        maskImage: maskUrl,
+        maskRepeat: 'no-repeat',
+        maskPosition: 'center',
+        maskSize: 'contain',
+        WebkitMaskImage: maskUrl,
+        WebkitMaskRepeat: 'no-repeat',
+        WebkitMaskPosition: 'center',
+        WebkitMaskSize: 'contain',
+      }}
+    />
+  )
 }
 
 function BootstrapIconMask({ name, ...props }: Omit<ElementIconRendererProps, 'node'> & { name: string }) {
@@ -68,28 +64,62 @@ const DefaultIconRenderer: ElementIconRenderer = ({ node, ...props }) => {
   return <img {...props} src={iconUrl(group, name)} />
 }
 
+export function localIconRendererFromDataUrl(base64data: string | null): ElementIconRenderer {
+  if (!base64data) {
+    return () => null
+  }
+
+  if (hasCurrentColorReference(base64data)) {
+    return ({ node: _node, ...props }) => <SvgMask {...props} src={base64data} />
+  }
+
+  return ({ node: _node, ...props }) => <img {...props} src={base64data} alt="" />
+}
+
+function hasCurrentColorReference(dataUrl: string): boolean {
+  return decodeSvgDataUrl(dataUrl)?.includes('currentColor') ?? false
+}
+
+function decodeSvgDataUrl(dataUrl: string): string | null {
+  if (!dataUrl.startsWith('data:image/svg+xml')) {
+    return null
+  }
+
+  try {
+    const comma = dataUrl.indexOf(',')
+    if (comma === -1) {
+      return null
+    }
+
+    const payload = dataUrl.slice(comma + 1)
+    if (dataUrl.slice(0, comma).endsWith(';base64')) {
+      return new TextDecoder().decode(Uint8Array.from(atob(payload), c => c.charCodeAt(0)))
+    }
+
+    try {
+      return decodeURIComponent(payload)
+    } catch {
+      return payload
+    }
+  } catch {
+    return null
+  }
+}
+
 const icons = new DefaultMap<string, ElementIconRenderer>(icon => {
   // For local files, use lazy loading with custom loader
   return lazy(async () => {
     try {
       const { base64data } = await extensionApi.readLocalIcon(icon)
 
-      if (!base64data) {
-        // Fallback to default renderer if file cannot be read
-        return {
-          default: DefaultIconRenderer,
-        }
-      }
-
-      const svg = decodeSvgDataUrl(base64data)
       return {
-        default: svg ? () => <InlineSvgIcon svg={svg} /> : () => <img src={base64data} alt="" />,
+        default: localIconRendererFromDataUrl(base64data),
       }
     } catch (error) {
       console.error(error)
-      // Fallback to default renderer on any error
+      // Local files should not be routed through the bundled-icon CDN fallback.
       return {
-        default: DefaultIconRenderer,
+        default: () => null,
       }
     }
   })

--- a/packages/vscode-preview/src/IconRenderer.tsx
+++ b/packages/vscode-preview/src/IconRenderer.tsx
@@ -5,6 +5,34 @@ import { ExtensionApi as extensionApi } from './vscode'
 
 const iconUrl = (group: string, name: string) => `https://icons.like-c4.dev/${group}/${name}.svg`
 
+export function decodeSvgDataUrl(dataUrl: string): string | null {
+  if (!dataUrl.startsWith('data:image/svg+xml')) {
+    return null
+  }
+
+  try {
+    if (dataUrl.includes(';base64,')) {
+      const base64Content = dataUrl.split(';base64,')[1]
+      if (base64Content) {
+        return atob(base64Content)
+      }
+    } else {
+      const encodedContent = dataUrl.split(',')[1]
+      if (encodedContent) {
+        return decodeURIComponent(encodedContent)
+      }
+    }
+  } catch {
+    // Fall back to rendering the data URL as an image.
+  }
+
+  return null
+}
+
+function InlineSvgIcon({ svg }: { svg: string }) {
+  return <span style={{ display: 'contents' }} dangerouslySetInnerHTML={{ __html: svg }} />
+}
+
 function BootstrapIconMask({ name, ...props }: Omit<ElementIconRendererProps, 'node'> & { name: string }) {
   const url = iconUrl('bootstrap', name)
   const style = {
@@ -53,8 +81,9 @@ const icons = new DefaultMap<string, ElementIconRenderer>(icon => {
         }
       }
 
+      const svg = decodeSvgDataUrl(base64data)
       return {
-        default: (_: ElementIconRendererProps) => <img src={base64data} alt="" />,
+        default: svg ? () => <InlineSvgIcon svg={svg} /> : () => <img src={base64data} alt="" />,
       }
     } catch (error) {
       console.error(error)

--- a/packages/vscode-preview/src/IconRenderer.tsx
+++ b/packages/vscode-preview/src/IconRenderer.tsx
@@ -77,7 +77,7 @@ export function localIconRendererFromDataUrl(base64data: string | null): Element
 }
 
 function hasCurrentColorReference(dataUrl: string): boolean {
-  return decodeSvgDataUrl(dataUrl)?.includes('currentColor') ?? false
+  return /currentcolor/i.test(decodeSvgDataUrl(dataUrl) ?? '')
 }
 
 function decodeSvgDataUrl(dataUrl: string): string | null {

--- a/packages/vscode-preview/src/IconRenderer.tsx
+++ b/packages/vscode-preview/src/IconRenderer.tsx
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { DefaultMap } from '@likec4/core/utils'
 import { type ElementIconRenderer, type ElementIconRendererProps, IconRendererProvider } from '@likec4/diagram'
 import { type CSSProperties, lazy, memo, Suspense } from 'react'


### PR DESCRIPTION
Fixes #3098
Fixes #2626

## Summary
- include model-level and deployment-level icons in generated project icon renderers so relationship views can render icons for related elements outside the current view
- render local SVGs that use `currentColor` as colorable CSS masks so `iconColor` is visible in built apps and VSCode preview
- keep non-`currentColor` SVGs and bitmap icons on the `<img>` path so fixed-color SVG artwork is preserved
- avoid injecting decoded SVG markup with `dangerouslySetInnerHTML`

## Before / after screenshots

Real Playwright screenshots from the same temporary LikeC4 static build fixture. The left icon is a local SVG using `currentColor` with `iconColor green`; the right icon is a fixed-color local SVG regression guard.

Before (`origin/main`): `currentColor` SVG rendered black, fixed-color SVG stayed red.

![Before: currentColor local SVG ignores iconColor](https://gist.githubusercontent.com/ckeller42/c1780760e9960b848bcbf186fefd8907/raw/likec4-pr3155-before.svg)

After (this PR): `currentColor` SVG renders green from `iconColor`, fixed-color SVG still stays red.

![After: currentColor local SVG follows iconColor](https://gist.githubusercontent.com/ckeller42/c1780760e9960b848bcbf186fefd8907/raw/likec4-pr3155-after.svg)

## Validation
- `pnpm exec vitest run --no-isolate packages/diagram/src/context/IconRenderer.spec.tsx packages/vite-plugin/src/virtuals/icons.spec.ts packages/vscode-preview/src/IconRenderer.spec.tsx`
- `pnpm exec oxlint packages/diagram/src/context/IconRenderer.tsx packages/diagram/src/context/IconRenderer.spec.tsx packages/vite-plugin/src/virtuals/icons.ts packages/vite-plugin/src/virtuals/icons.spec.ts packages/vscode-preview/src/IconRenderer.tsx packages/vscode-preview/src/IconRenderer.spec.tsx`
- `pnpm --filter @likec4/diagram typecheck`
- `pnpm --filter @likec4/vscode-preview typecheck`
- Real Playwright screenshots captured from static builds at `/view/index/`:
  - before: `origin/main` detached worktree at `d7847b80e`
  - after: PR branch screenshot captured at `989a48fd`; current head `a0855c45d` adds non-visual CodeRabbit hardening

Note: `pnpm --filter @likec4/vite-plugin typecheck` still fails in the existing unrelated `packages/vite-plugin/src/ai/detect-ai.ts` Gemini adapter typing (`GeminiTextAdapter` missing `model` / `~types`).
