### PR TITLE
fix: suppress shared include overlap warnings

### DIFF
--- a/.changeset/fix-shared-include-overlap-warning.md
+++ b/.changeset/fix-shared-include-overlap-warning.md
@@ -1,0 +1,5 @@
+---
+"@likec4/language-server": patch
+---
+
+Avoid overlapping-area warnings when multiple projects intentionally include the same shared folder. Nested or partially overlapping include paths still warn because those can make file ownership ambiguous. Fixes [#2973](https://github.com/likec4/likec4/issues/2973).

--- a/packages/language-server/src/workspace/ProjectsManager.spec.ts
+++ b/packages/language-server/src/workspace/ProjectsManager.spec.ts
@@ -7,8 +7,9 @@
 
 import type { LikeC4ProjectJsonConfig } from '@likec4/config'
 import type { ProjectId } from '@likec4/core'
+import { type LogRecord, configureLogger } from '@likec4/log'
 import { UriUtils } from 'langium'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { URI } from 'vscode-uri'
 import { createMultiProjectTestServices } from '../test'
 import { ProjectFolder } from './ProjectsManager'
@@ -22,7 +23,38 @@ const folderAt = (path: string) => ({
   folderUri: UriUtils.joinPath(URI.file(`/test/workspace/src`), path),
 })
 
+let shouldResetLogger = false
+
+function captureLogRecords(): LogRecord[] {
+  const records = [] as LogRecord[]
+  shouldResetLogger = true
+  configureLogger({
+    sinks: {
+      capture: record => records.push(record),
+    },
+    loggers: [
+      {
+        category: 'likec4',
+        sinks: ['capture'],
+        lowestLevel: 'warning',
+      },
+    ],
+  })
+  return records
+}
+
+function overlappingAreaWarnings(records: LogRecord[]): LogRecord[] {
+  return records.filter(record => String(record.rawMessage).includes('Files in overlapping areas'))
+}
+
 describe('ProjectsManager', () => {
+  afterEach(() => {
+    if (shouldResetLogger) {
+      shouldResetLogger = false
+      configureLogger({ loggers: [] })
+    }
+  })
+
   it('should assign likec4ProjectId to docs', async ({ expect }) => {
     const { projects, addDocumentOutside, validateAll } = await createMultiProjectTestServices({
       project1: {
@@ -549,6 +581,52 @@ describe('ProjectsManager', () => {
   })
 
   describe('include paths', () => {
+    it('should not warn when multiple projects share the same include path', async ({ expect }) => {
+      const records = captureLogRecords()
+      const { projectsManager } = await createMultiProjectTestServices({})
+
+      await projectsManager.registerProject({
+        config: {
+          name: 'a-project1',
+          include: { paths: ['../shared'] },
+        },
+        folderUri: URI.parse('file:///test/workspace/src/a-project1'),
+      })
+
+      await projectsManager.registerProject({
+        config: {
+          name: 'a-project2',
+          include: { paths: ['../shared'] },
+        },
+        folderUri: URI.parse('file:///test/workspace/src/a-project2'),
+      })
+
+      expect(overlappingAreaWarnings(records)).toHaveLength(0)
+    })
+
+    it('should keep warning when include paths partially overlap', async ({ expect }) => {
+      const records = captureLogRecords()
+      const { projectsManager } = await createMultiProjectTestServices({})
+
+      await projectsManager.registerProject({
+        config: {
+          name: 'a-project1',
+          include: { paths: ['../shared'] },
+        },
+        folderUri: URI.parse('file:///test/workspace/src/a-project1'),
+      })
+
+      await projectsManager.registerProject({
+        config: {
+          name: 'a-project2',
+          include: { paths: ['../shared/common'] },
+        },
+        folderUri: URI.parse('file:///test/workspace/src/a-project2'),
+      })
+
+      expect(overlappingAreaWarnings(records)).toHaveLength(1)
+    })
+
     it('should resolve include paths relative to project folder', async ({ expect }) => {
       const { projectsManager } = await createMultiProjectTestServices({})
 

--- a/packages/language-server/src/workspace/ProjectsManager.spec.ts
+++ b/packages/language-server/src/workspace/ProjectsManager.spec.ts
@@ -7,7 +7,8 @@
 
 import type { LikeC4ProjectJsonConfig } from '@likec4/config'
 import type { ProjectId } from '@likec4/core'
-import { type LogRecord, configureLogger } from '@likec4/log'
+import type { LogRecord } from '@likec4/log'
+import { configureLogger } from '@likec4/log'
 import { UriUtils } from 'langium'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { URI } from 'vscode-uri'
@@ -51,7 +52,7 @@ describe('ProjectsManager', () => {
   afterEach(() => {
     if (shouldResetLogger) {
       shouldResetLogger = false
-      configureLogger({ loggers: [] })
+      configureLogger()
     }
   })
 

--- a/packages/language-server/src/workspace/ProjectsManager.ts
+++ b/packages/language-server/src/workspace/ProjectsManager.ts
@@ -107,6 +107,19 @@ function _overlaps(folderA: WithFolder, folderB: WithFolder): boolean {
   return a === b || a.startsWith(b) || b.startsWith(a)
 }
 
+function sameFolder(folderA: WithFolder, folderB: WithFolder): boolean {
+  const a = isString(folderA) ? folderA : folderA.folder
+  const b = isString(folderB) ? folderB : folderB.folder
+  return a === b
+}
+
+function hasAmbiguousIncludePathOverlap(
+  includePath: { folder: ProjectFolder },
+  otherIncludePath: { folder: ProjectFolder },
+): boolean {
+  return _overlaps(includePath, otherIncludePath) && !sameFolder(includePath, otherIncludePath)
+}
+
 function overlaps(folderA: WithFolder, folderB: WithFolder): boolean
 function overlaps(folderA: WithFolder): (folderB: WithFolder) => boolean
 function overlaps(...args: unknown[]) {
@@ -961,7 +974,7 @@ export class ProjectsManager extends ADisposable {
 
         // Check if this include path overlaps with another project's include paths
         otherProject.includePaths?.forEach((otherIncludePath) => {
-          if (overlaps(includePath, otherIncludePath)) {
+          if (hasAmbiguousIncludePathOverlap(includePath, otherIncludePath)) {
             logger.warn(
               'Project "{projectId}" include path "{includePath}" overlaps with project "{otherProjectId}" ' +
                 'include path "{otherIncludePath}". Files in overlapping areas will only belong to one project.',


### PR DESCRIPTION
## Summary
- suppress the overlapping-area warning when multiple projects include the exact same shared folder
- keep the warning for nested or partially overlapping include paths where ownership can still be ambiguous
- add regression coverage that captures the actual warning logs

Fixes #2973

## Validation
- `pnpm exec vitest run --no-isolate packages/language-server/src/workspace/ProjectsManager.spec.ts`
- `pnpm --filter @likec4/language-server typecheck`
- `pnpm exec oxlint packages/language-server/src/workspace/ProjectsManager.spec.ts`
  - exits 0; reports existing warnings in untouched lines of the spec file
