### PR TITLE
feat(vite-plugin): add webcomponents virtual module

### DIFF
--- a/.changeset/add-vite-webcomponents.md
+++ b/.changeset/add-vite-webcomponents.md
@@ -1,0 +1,5 @@
+---
+"@likec4/vite-plugin": patch
+---
+
+Define project-scoped LikeC4 web components directly from the Vite plugin with `likec4:webcomponents/<project-id>`.

--- a/apps/docs/src/content/docs/tooling/vite-plugin.mdx
+++ b/apps/docs/src/content/docs/tooling/vite-plugin.mdx
@@ -232,6 +232,32 @@ const example = () => (
 ```
 <br />
 
+### Web components
+
+Use a project-scoped `likec4:webcomponents/*` virtual module to render a LikeC4 view in HTML without adding
+React components to your application code:
+
+```ts
+import { defineWebcomponent } from 'likec4:webcomponents/project-a'
+
+defineWebcomponent('likec4-view-project-a')
+```
+
+The custom element supports the same attributes as generated LikeC4 web components:
+
+```html
+<likec4-view-project-a
+  view-id="index"
+  browser="true"
+  dynamic-variant="sequence"
+  color-scheme="dark">
+</likec4-view-project-a>
+```
+
+The project id in the import must match a project from your LikeC4 workspace. The custom element name must follow the
+[custom element naming rules](https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry/define#valid_custom_element_names),
+including at least one hyphen.
+
 ### Usage with API
 
 It is also possible to initiate using [LikeC4 API](/tooling/model-api):

--- a/packages/vite-plugin/src/modules.d.ts
+++ b/packages/vite-plugin/src/modules.d.ts
@@ -171,6 +171,15 @@ declare module 'likec4:react/*' {
   export function ReactLikeC4({ viewId, ...props }: ReactLikeC4Props<Types>): JSX.Element
 }
 
+declare module 'likec4:webcomponents/*' {
+  /**
+   * Defines a custom element that renders views from this LikeC4 project.
+   *
+   * Calling this function repeatedly with the same name is safe.
+   */
+  export function defineWebcomponent(name: string): CustomElementConstructor
+}
+
 declare module 'likec4:rpc' {
   import type { LikeC4VitePluginRpc } from 'likec4/vite-plugin/internal'
 

--- a/packages/vite-plugin/src/plugin.ts
+++ b/packages/vite-plugin/src/plugin.ts
@@ -28,6 +28,7 @@ import { projectPumlModule, pumlModule } from './virtuals/puml'
 import { projectReactModule, singleProjectReactModule } from './virtuals/react'
 import { rpcModule } from './virtuals/rpc'
 import { singleProjectModule } from './virtuals/single-project'
+import { projectWebcomponentsModule } from './virtuals/webcomponents'
 
 export interface AIOptions<TAdapter extends AnyTextAdapter = AnyTextAdapter> {
   /**
@@ -166,6 +167,7 @@ const hmrProjectVirtuals = [
 const projectVirtuals = [
   ...hmrProjectVirtuals,
   projectReactModule,
+  projectWebcomponentsModule,
 ]
 
 const _virtuals = [

--- a/packages/vite-plugin/src/virtuals/webcomponents.spec.ts
+++ b/packages/vite-plugin/src/virtuals/webcomponents.spec.ts
@@ -1,0 +1,40 @@
+import type { ProjectId } from '@likec4/core/types'
+import { describe, expect, it } from 'vitest'
+import { hardenJsonStringLiteralForEmbeddedScript } from './hardenJsonStringLiteralForEmbeddedScript'
+import { generateWebcomponentsCode, projectWebcomponentsModule } from './webcomponents'
+
+const jsStringLiteral = (value: string) => hardenJsonStringLiteralForEmbeddedScript(JSON.stringify(value))
+
+describe('projectWebcomponentsModule', () => {
+  it('matches project-scoped webcomponent module ids', () => {
+    expect(projectWebcomponentsModule.matches('likec4:webcomponents/project-a')).toBe('project-a')
+    expect(projectWebcomponentsModule.matches('likec4:plugin/project-a/webcomponents.js')).toBe('project-a')
+    expect(projectWebcomponentsModule.matches('likec4:webcomponents')).toBeNull()
+    expect(projectWebcomponentsModule.virtualId('project-a' as ProjectId)).toBe(
+      'likec4:plugin/project-a/webcomponents.js',
+    )
+  })
+})
+
+describe('generateWebcomponentsCode', () => {
+  it('generates a custom element backed by the project React module', () => {
+    const code = generateWebcomponentsCode('project-a' as ProjectId)
+
+    expect(code).toContain(`import { LikeC4View } from ${jsStringLiteral('likec4:react/project-a')}`)
+    expect(code).toContain('export function defineWebcomponent(name)')
+    expect(code).toContain(
+      `static observedAttributes = ['view-id', 'browser', 'dynamic-variant', 'color-scheme']`,
+    )
+    expect(code).toContain(`viewId: element.getAttribute('view-id') ?? 'index'`)
+    expect(code).toContain(`customElements.define(name, LikeC4ViewElement)`)
+  })
+
+  it('hardens project ids embedded in generated JavaScript', () => {
+    const projectId = 'project-a";\nthrow new Error("injected")//' as ProjectId
+    const code = generateWebcomponentsCode(projectId)
+
+    expect(code).toContain(`const projectId = ${jsStringLiteral(projectId)}`)
+    expect(code).toContain(`from ${jsStringLiteral(`likec4:react/${projectId}`)}`)
+    expect(code).not.toContain(`from 'likec4:react/${projectId}'`)
+  })
+})

--- a/packages/vite-plugin/src/virtuals/webcomponents.ts
+++ b/packages/vite-plugin/src/virtuals/webcomponents.ts
@@ -1,0 +1,108 @@
+import type { ProjectId } from '@likec4/core/types'
+import { logGenerating } from '../logger'
+import { type ProjectVirtualModule, generateMatches } from './_shared'
+import { hardenJsonStringLiteralForEmbeddedScript } from './hardenJsonStringLiteralForEmbeddedScript'
+
+const jsStringLiteral = (value: string) => hardenJsonStringLiteralForEmbeddedScript(JSON.stringify(value))
+
+export const generateWebcomponentsCode = (projectId: ProjectId): string => {
+  const projectIdLiteral = jsStringLiteral(projectId)
+  const reactModuleLiteral = jsStringLiteral(`likec4:react/${projectId}`)
+
+  return `
+import { createElement } from 'react'
+import { createRoot } from 'react-dom/client'
+import { LikeC4View } from ${reactModuleLiteral}
+
+const projectId = ${projectIdLiteral}
+const projectIdSymbol = Symbol.for('likec4.webcomponent.projectId')
+
+function booleanAttribute(element, name, fallback) {
+  const value = element.getAttribute(name)
+  return value === null ? fallback : value.toLowerCase() !== 'false'
+}
+
+function enumAttribute(element, name, values) {
+  const value = element.getAttribute(name)
+  return value !== null && values.includes(value) ? value : undefined
+}
+
+function propsFrom(element) {
+  const props = {
+    viewId: element.getAttribute('view-id') ?? 'index',
+    browser: booleanAttribute(element, 'browser', true),
+  }
+  const dynamicViewVariant = enumAttribute(element, 'dynamic-variant', ['diagram', 'sequence'])
+  const colorScheme = enumAttribute(element, 'color-scheme', ['light', 'dark'])
+  if (dynamicViewVariant) {
+    props.dynamicViewVariant = dynamicViewVariant
+  }
+  if (colorScheme) {
+    props.colorScheme = colorScheme
+  }
+  return props
+}
+
+function createLikeC4ViewElement() {
+  return class LikeC4ViewElement extends HTMLElement {
+    static observedAttributes = ['view-id', 'browser', 'dynamic-variant', 'color-scheme']
+
+    constructor() {
+      super()
+      this.shadow = this.attachShadow({ mode: 'open', delegatesFocus: true })
+      const style = document.createElement('style')
+      style.textContent = ':host { display: contents; background-color: transparent; margin: 0; padding: 0; }'
+      this.mount = document.createElement('div')
+      this.mount.style.display = 'contents'
+      this.shadow.append(style, this.mount)
+    }
+
+    connectedCallback() {
+      this.root ??= createRoot(this.mount)
+      this.render()
+    }
+
+    disconnectedCallback() {
+      this.root?.unmount()
+      this.root = undefined
+    }
+
+    attributeChangedCallback() {
+      if (this.root) {
+        this.render()
+      }
+    }
+
+    render() {
+      this.root.render(createElement(LikeC4View, propsFrom(this)))
+    }
+  }
+}
+
+export function defineWebcomponent(name) {
+  const existing = customElements.get(name)
+  if (existing) {
+    if (existing[projectIdSymbol] === projectId) {
+      return existing
+    }
+    throw new Error('Custom element "' + name + '" is already defined')
+  }
+
+  const LikeC4ViewElement = createLikeC4ViewElement()
+  Object.defineProperty(LikeC4ViewElement, projectIdSymbol, { value: projectId })
+  customElements.define(name, LikeC4ViewElement)
+  return LikeC4ViewElement
+}
+`
+}
+
+export const projectWebcomponentsModule: ProjectVirtualModule = {
+  ...generateMatches('webcomponents'),
+  async load({ project }) {
+    logGenerating('webcomponents', project.id)
+    return {
+      code: generateWebcomponentsCode(project.id),
+      moduleType: 'js',
+    }
+  },
+}


### PR DESCRIPTION
## Summary

- add a project-scoped `likec4:webcomponents/<project-id>` virtual module to the Vite plugin
- expose a typed, idempotent `defineWebcomponent(name)` API backed by the existing project React module
- support `view-id`, `browser`, `dynamic-variant`, and `color-scheme` attributes
- document usage and add a patch changeset

This lets Vite consumers register a LikeC4 custom element directly from their workspace project:

```ts
import { defineWebcomponent } from 'likec4:webcomponents/project-a'

defineWebcomponent('likec4-view-project-a')
```

Closes #1973.

## Validation

- `pnpm --filter @likec4/vite-plugin test`
- `pnpm --filter @likec4/vite-plugin typecheck`
- `pnpm --filter @likec4/vite-plugin lint`
- `pnpm ci:typecheck`
- `pnpm ci:test`
- `pnpm ci:build`
- `pnpm lint:package`
- docs and playground typecheck/build
- agent-instruction validation on Linux (9 tests)
- Playwright E2E on Linux (60 tests)

## Checklist

- [x] I've thoroughly read the latest [contribution guidelines](https://github.com/likec4/likec4/blob/main/CONTRIBUTING.md).
- [x] I've rebased my branch onto `main` **before** creating this PR.
- [x] I've added tests to cover my changes (if applicable).
- [x] I've verified `pnpm typecheck` and `pnpm test`.
- [x] I've added [changesets](https://changesets-docs.vercel.app/) (you can use `/changeset-generator` SKILL).
- [x] My change requires documentation updates.
- [x] I've updated the documentation accordingly (or will do in follow-up PR).
