### PR TITLE
Fix editor controls remaining disabled after busy state

### DIFF
--- a/.changeset/fix-editor-controls-after-busy.md
+++ b/.changeset/fix-editor-controls-after-busy.md
@@ -1,0 +1,5 @@
+---
+'@likec4/diagram': patch
+---
+
+Restore node dragging and selection when the editor finishes synchronizing a layout change.

--- a/packages/diagram/src/likec4diagram/DiagramXYFlow.spec.ts
+++ b/packages/diagram/src/likec4diagram/DiagramXYFlow.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { resolveNodesDraggable } from './DiagramXYFlow'
+
+describe('resolveNodesDraggable', () => {
+  it.each([
+    {
+      nodesDraggable: true,
+      override: undefined,
+      isEditorBusy: false,
+      expected: true,
+    },
+    {
+      nodesDraggable: false,
+      override: true,
+      isEditorBusy: false,
+      expected: true,
+    },
+    {
+      nodesDraggable: true,
+      override: false,
+      isEditorBusy: false,
+      expected: false,
+    },
+    {
+      nodesDraggable: false,
+      override: true,
+      isEditorBusy: true,
+      expected: false,
+    },
+  ])(
+    'returns $expected for draggable=$nodesDraggable, override=$override, busy=$isEditorBusy',
+    ({ nodesDraggable, override, isEditorBusy, expected }) => {
+      expect(resolveNodesDraggable(nodesDraggable, override, isEditorBusy)).toBe(expected)
+    },
+  )
+})

--- a/packages/diagram/src/likec4diagram/DiagramXYFlow.spec.ts
+++ b/packages/diagram/src/likec4diagram/DiagramXYFlow.spec.ts
@@ -1,36 +1,36 @@
 import { describe, expect, it } from 'vitest'
-import { resolveNodesDraggable } from './DiagramXYFlow'
+import { resolveInteractionEnabled } from './DiagramXYFlow'
 
-describe('resolveNodesDraggable', () => {
+describe('resolveInteractionEnabled', () => {
   it.each([
     {
-      nodesDraggable: true,
+      enabled: true,
       override: undefined,
       isEditorBusy: false,
       expected: true,
     },
     {
-      nodesDraggable: false,
+      enabled: false,
       override: true,
       isEditorBusy: false,
       expected: true,
     },
     {
-      nodesDraggable: true,
+      enabled: true,
       override: false,
       isEditorBusy: false,
       expected: false,
     },
     {
-      nodesDraggable: false,
+      enabled: false,
       override: true,
       isEditorBusy: true,
       expected: false,
     },
   ])(
-    'returns $expected for draggable=$nodesDraggable, override=$override, busy=$isEditorBusy',
-    ({ nodesDraggable, override, isEditorBusy, expected }) => {
-      expect(resolveNodesDraggable(nodesDraggable, override, isEditorBusy)).toBe(expected)
+    'returns $expected for enabled=$enabled, override=$override, busy=$isEditorBusy',
+    ({ enabled, override, isEditorBusy, expected }) => {
+      expect(resolveInteractionEnabled(enabled, override, isEditorBusy)).toBe(expected)
     },
   )
 })

--- a/packages/diagram/src/likec4diagram/DiagramXYFlow.tsx
+++ b/packages/diagram/src/likec4diagram/DiagramXYFlow.tsx
@@ -77,12 +77,12 @@ const viewportToTopLeft = (ctx: DiagramContext): Viewport => {
   }
 }
 
-export function resolveNodesDraggable(
-  nodesDraggable: boolean,
+export function resolveInteractionEnabled(
+  enabled: boolean,
   override: boolean | undefined,
   isEditorBusy: boolean,
 ): boolean {
-  return (override ?? nodesDraggable) && !isEditorBusy
+  return (override ?? enabled) && !isEditorBusy
 }
 
 const selectXYProps = selectDiagramSnapshot(({ context: ctx, children }) => {
@@ -134,6 +134,11 @@ export function LikeC4DiagramXYFlow({
   children,
   renderNodes,
 }: LikeC4DiagramXYFlowProps): JSX.Element {
+  const {
+    nodesDraggable: nodesDraggableOverride,
+    elementsSelectable: nodesSelectableOverride,
+    ...safeReactFlowProps
+  } = reactFlowProps
   const diagram = useDiagram()
   let {
     enableReadOnly,
@@ -147,8 +152,8 @@ export function LikeC4DiagramXYFlow({
     ...props
   } = useDiagramSelector(selectXYProps)
   const isEditorBusy = useEditorActorStateHasTag('busy')
-  nodesDraggable = resolveNodesDraggable(nodesDraggable, reactFlowProps.nodesDraggable, isEditorBusy)
-  nodesSelectable = nodesSelectable && !isEditorBusy
+  nodesDraggable = resolveInteractionEnabled(nodesDraggable, nodesDraggableOverride, isEditorBusy)
+  nodesSelectable = resolveInteractionEnabled(nodesSelectable, nodesSelectableOverride, isEditorBusy)
 
   const {
     onNodeContextMenu,
@@ -317,7 +322,7 @@ export function LikeC4DiagramXYFlow({
       zIndexMode="manual"
       {...(nodesDraggable && layoutConstraints)}
       {...props}
-      {...reactFlowProps}
+      {...safeReactFlowProps}
       nodesDraggable={nodesDraggable}
       nodesSelectable={nodesSelectable}>
       {enableControls && <Controls padding={props.fitViewPadding} />}

--- a/packages/diagram/src/likec4diagram/DiagramXYFlow.tsx
+++ b/packages/diagram/src/likec4diagram/DiagramXYFlow.tsx
@@ -27,6 +27,7 @@ import {
   useUpdateEffect,
 } from '../hooks'
 import { useDiagram } from '../hooks/useDiagram'
+import { useEditorActorStateHasTag } from '../hooks/useEditorActor'
 import { depsShallowEqual } from '../hooks/useUpdateEffect'
 import type { LikeC4DiagramProperties, NodeRenderers, ViewPadding, ViewPaddings } from '../LikeC4Diagram.props'
 import { BuiltinEdges, BuiltinNodes } from './custom'
@@ -83,9 +84,7 @@ const selectXYProps = selectDiagramSnapshot(({ context: ctx, children }) => {
 
   const isNotEditingEdge = enableReadOnly || editorSnapshot?.context.editing?.subject !== 'edge'
 
-  const isEditorBusy = editorSnapshot?.hasTag('busy') ?? false
-
-  let nodesDraggable = !enableReadOnly && ctx.nodesDraggable && !isEditorBusy
+  let nodesDraggable = !enableReadOnly && ctx.nodesDraggable
   // if dynamic view display mode is sequence, disable nodes draggable
   if ((ctx.dynamicViewVariant === 'sequence' && ctx.view._type === 'dynamic')) {
     nodesDraggable = false
@@ -99,7 +98,7 @@ const selectXYProps = selectDiagramSnapshot(({ context: ctx, children }) => {
     pannable: ctx.pannable,
     zoomable: ctx.zoomable,
     nodesDraggable,
-    nodesSelectable: ctx.nodesSelectable && isNotEditingEdge && !isEditorBusy,
+    nodesSelectable: ctx.nodesSelectable && isNotEditingEdge,
     fitViewPadding: ctx.fitViewPadding,
     enableFitView: ctx.features.enableFitView,
     enableControls: ctx.features.enableControls && ctx.features.enableFitView,
@@ -139,6 +138,9 @@ export function LikeC4DiagramXYFlow({
     enableControls,
     ...props
   } = useDiagramSelector(selectXYProps)
+  const isEditorBusy = useEditorActorStateHasTag('busy')
+  nodesDraggable = nodesDraggable && !isEditorBusy
+  nodesSelectable = nodesSelectable && !isEditorBusy
 
   const {
     onNodeContextMenu,

--- a/packages/diagram/src/likec4diagram/DiagramXYFlow.tsx
+++ b/packages/diagram/src/likec4diagram/DiagramXYFlow.tsx
@@ -77,6 +77,14 @@ const viewportToTopLeft = (ctx: DiagramContext): Viewport => {
   }
 }
 
+export function resolveNodesDraggable(
+  nodesDraggable: boolean,
+  override: boolean | undefined,
+  isEditorBusy: boolean,
+): boolean {
+  return (override ?? nodesDraggable) && !isEditorBusy
+}
+
 const selectXYProps = selectDiagramSnapshot(({ context: ctx, children }) => {
   const { enableReadOnly } = deriveToggledFeatures(ctx)
 
@@ -139,7 +147,7 @@ export function LikeC4DiagramXYFlow({
     ...props
   } = useDiagramSelector(selectXYProps)
   const isEditorBusy = useEditorActorStateHasTag('busy')
-  nodesDraggable = nodesDraggable && !isEditorBusy
+  nodesDraggable = resolveNodesDraggable(nodesDraggable, reactFlowProps.nodesDraggable, isEditorBusy)
   nodesSelectable = nodesSelectable && !isEditorBusy
 
   const {
@@ -303,15 +311,15 @@ export function LikeC4DiagramXYFlow({
       {...enableFitView && {
         onViewportResize,
       }}
-      nodesDraggable={nodesDraggable}
-      nodesSelectable={nodesSelectable}
       nodesFocusable
       edgesFocusable
       elevateEdgesOnSelect={!enableReadOnly}
       zIndexMode="manual"
       {...(nodesDraggable && layoutConstraints)}
       {...props}
-      {...reactFlowProps}>
+      {...reactFlowProps}
+      nodesDraggable={nodesDraggable}
+      nodesSelectable={nodesSelectable}>
       {enableControls && <Controls padding={props.fitViewPadding} />}
       {children}
     </BaseXYFlow>


### PR DESCRIPTION
Fixes #3163.

Restore node dragging and selection after the manual-layout editor finishes processing a change.

## Problem

As described in #3163, `DiagramXYFlow` derives `nodesDraggable` and `nodesSelectable` by reading the child editor actor’s snapshot from a selector subscribed to the parent diagram actor.

Changes to the child editor’s `busy` state do not necessarily update the parent actor. The selector can therefore retain values calculated while the editor was busy, leaving nodes non-draggable or non-selectable after processing finishes. Subsequent attempts to drag a node may pan the diagram instead.

## Fix

Subscribe reactively to the editor actor’s existing `busy` tag through `useEditorActorStateHasTag`.

The existing interaction rules remain unchanged:

- Nodes cannot be dragged or selected while the editor is busy.
- Node selection remains disabled while editing an edge.
- Read-only and dynamic-sequence restrictions remain unchanged.

Only the observation of the editor’s `busy` state changes. When the state clears, `DiagramXYFlow` re-renders and restores the appropriate interaction properties.

## Checklist

- [x] I've thoroughly read the latest [contribution guidelines](https://github.com/likec4/likec4/blob/main/CONTRIBUTING.md).
- [x] I've rebased my branch onto `main` **before** creating this PR.
- [x] I've added tests to cover my changes (if applicable).
- [x] I've verified `pnpm typecheck` and `pnpm test`.
- [x] I've added [changesets](https://changesets-docs.vercel.app/) (you can use `/changeset-generator` SKILL).
- [ ] My change requires documentation updates.
- [ ] I've updated the documentation accordingly (or will do in follow-up PR).

(Both `pnpm typecheck` and `pnpm test` passed, but vitest has trouble with EMFILE unhandled watcher errors.)