### PR TITLE
Allow editor callbacks to skip waiting for view synchronization

### DIFF
--- a/.changeset/allow-editor-callbacks-to-skip-view-sync.md
+++ b/.changeset/allow-editor-callbacks-to-skip-view-sync.md
@@ -1,0 +1,5 @@
+---
+'@likec4/diagram': patch
+---
+
+Allow embedded editors to skip waiting for a refreshed view after applying a change locally.

--- a/packages/diagram/src/editor/LikeC4EditorCallbacks.tsx
+++ b/packages/diagram/src/editor/LikeC4EditorCallbacks.tsx
@@ -16,7 +16,7 @@ export interface LikeC4EditorChangeResult {
 }
 
 export function shouldWaitForViewSync(
-  result: void | LikeC4EditorChangeResult,
+  result?: void | LikeC4EditorChangeResult,
 ): boolean {
   return result?.waitForViewSync ?? true
 }

--- a/packages/diagram/src/editor/LikeC4EditorCallbacks.tsx
+++ b/packages/diagram/src/editor/LikeC4EditorCallbacks.tsx
@@ -1,6 +1,27 @@
 import type * as t from '@likec4/core/types'
 
 /**
+ * Result of applying a change from the LikeC4 Editor.
+ */
+export interface LikeC4EditorChangeResult {
+  /**
+   * Whether applying the change will publish a refreshed view to the diagram
+   * that the editor should wait for.
+   *
+   * Returning no result from `handleChange` defaults this to `true`,
+   * preserving the existing behavior for integrations that persist changes
+   * through an external model service.
+   */
+  waitForViewSync: boolean
+}
+
+export function shouldWaitForViewSync(
+  result: void | LikeC4EditorChangeResult,
+): boolean {
+  return result?.waitForViewSync ?? true
+}
+
+/**
  * Callbacks from LikeC4 Editor.
  */
 export interface LikeC4EditorCallbacks {
@@ -20,8 +41,15 @@ export interface LikeC4EditorCallbacks {
 
   /**
    * Callback invoked when the view changes.
+   *
+   * Return `{ waitForViewSync: false }` when the integration applies the
+   * change locally and will not publish a refreshed view. When changes are
+   * batched, the editor waits if any callback invocation expects a refresh.
    */
-  handleChange(viewId: t.ViewId, change: t.ViewChange): void | Promise<void>
+  handleChange(
+    viewId: t.ViewId,
+    change: t.ViewChange,
+  ): void | LikeC4EditorChangeResult | Promise<void | LikeC4EditorChangeResult>
 }
 
 export function createLikeC4Editor(callbacks: LikeC4EditorCallbacks): LikeC4EditorCallbacks {

--- a/packages/diagram/src/editor/actor/setup.ts
+++ b/packages/diagram/src/editor/actor/setup.ts
@@ -45,7 +45,11 @@ export namespace EditorCalls {
     /**
      * Returns the changes that were applied to the view
      */
-    export type Output = { requested: t.ViewChange[]; applied: t.ViewChange[] }
+    export type Output = {
+      requested: t.ViewChange[]
+      applied: t.ViewChange[]
+      waitForViewSync: boolean
+    }
   }
 }
 

--- a/packages/diagram/src/editor/actor/state.sync-queue.spec.ts
+++ b/packages/diagram/src/editor/actor/state.sync-queue.spec.ts
@@ -1,0 +1,80 @@
+import { scalar } from '@likec4/core/types'
+import { describe, expect, it, vi } from 'vitest'
+import { createActor, fromPromise, waitFor } from 'xstate'
+import { shouldWaitForViewSync } from '../LikeC4EditorCallbacks'
+import { editorActorLogic } from './machine'
+import type { EditorCalls } from './setup'
+
+const change = {
+  op: 'change-autolayout' as const,
+  layout: {
+    direction: 'LR' as const,
+  },
+}
+
+function createTestActor(executeChange: EditorCalls.ExecuteChange) {
+  const actor = createActor(
+    editorActorLogic.provide({
+      actors: {
+        executeChange: fromPromise(executeChange),
+      },
+    }),
+    {
+      input: {
+        viewId: scalar.ViewId('test'),
+      },
+    },
+  )
+  actor.start()
+  return actor
+}
+
+describe('editor sync queue', () => {
+  it('preserves synchronization unless a callback explicitly opts out', () => {
+    expect(shouldWaitForViewSync()).toBe(true)
+    expect(shouldWaitForViewSync({ waitForViewSync: false })).toBe(false)
+  })
+
+  it('returns to idle without waiting when the callback does not publish a refreshed view', async () => {
+    const executeChange = vi.fn<EditorCalls.ExecuteChange>(async ({ input }) => ({
+      requested: input.changes,
+      applied: input.changes,
+      waitForViewSync: false,
+    }))
+    const actor = createTestActor(executeChange)
+
+    actor.send({ type: 'change.view', change })
+
+    await waitFor(
+      actor,
+      snapshot => executeChange.mock.calls.length === 1 && !snapshot.hasTag('busy'),
+      { timeout: 500 },
+    )
+    expect(actor.getSnapshot().matches({ syncQueue: 'idle' })).toBe(true)
+    actor.stop()
+  })
+
+  it('waits until the refreshed view arrives when synchronization is expected', async () => {
+    const executeChange = vi.fn<EditorCalls.ExecuteChange>(async ({ input }) => ({
+      requested: input.changes,
+      applied: input.changes,
+      waitForViewSync: true,
+    }))
+    const actor = createTestActor(executeChange)
+
+    actor.send({ type: 'change.view', change })
+
+    await waitFor(
+      actor,
+      snapshot =>
+        (snapshot.value as unknown as { syncQueue: { process: string } }).syncQueue.process === 'waitViewSynced',
+      { timeout: 500 },
+    )
+    expect(actor.getSnapshot().hasTag('busy')).toBe(true)
+
+    actor.send({ type: 'view.synched' })
+    await waitFor(actor, snapshot => !snapshot.hasTag('busy'), { timeout: 500 })
+    expect(actor.getSnapshot().matches({ syncQueue: 'idle' })).toBe(true)
+    actor.stop()
+  })
+})

--- a/packages/diagram/src/editor/actor/state.sync-queue.spec.ts
+++ b/packages/diagram/src/editor/actor/state.sync-queue.spec.ts
@@ -32,6 +32,7 @@ function createTestActor(executeChange: EditorCalls.ExecuteChange) {
 describe('editor sync queue', () => {
   it('preserves synchronization unless a callback explicitly opts out', () => {
     expect(shouldWaitForViewSync()).toBe(true)
+    expect(shouldWaitForViewSync({ waitForViewSync: true })).toBe(true)
     expect(shouldWaitForViewSync({ waitForViewSync: false })).toBe(false)
   })
 

--- a/packages/diagram/src/editor/actor/state.sync-queue.ts
+++ b/packages/diagram/src/editor/actor/state.sync-queue.ts
@@ -314,6 +314,9 @@ const process = machine.createStateConfig({
                 },
               )
             }
+            if (!event.output.waitForViewSync) {
+              enqueue.raise({ type: 'view.synched' })
+            }
           }),
           target: 'waitViewSynced',
         },

--- a/packages/diagram/src/editor/index.ts
+++ b/packages/diagram/src/editor/index.ts
@@ -1,7 +1,10 @@
 export type * from './actor/machine'
 export type * from './actor/types'
 export { createLikeC4Editor } from './LikeC4EditorCallbacks'
-export type { LikeC4EditorCallbacks } from './LikeC4EditorCallbacks'
+export type {
+  LikeC4EditorCallbacks,
+  LikeC4EditorChangeResult,
+} from './LikeC4EditorCallbacks'
 export {
   EnsureEditorContext,
   LikeC4EditorProvider,

--- a/packages/diagram/src/editor/useEditorActorLogic.ts
+++ b/packages/diagram/src/editor/useEditorActorLogic.ts
@@ -5,6 +5,7 @@ import { useCallbackRef } from '../hooks'
 import { type EditorActorLogic, editorActorLogic } from './actor/machine'
 import type { EditorCalls } from './actor/setup'
 import { applyChangesToManualLayout } from './applyChangesToManualLayout'
+import { shouldWaitForViewSync } from './LikeC4EditorCallbacks'
 import { useOptionalLikeC4Editor } from './LikeC4EditorProvider'
 
 const promisify = <T>(fn: () => T | Promise<T>): Promise<T> => {
@@ -46,15 +47,17 @@ export function useEditorActorLogic(): EditorActorLogic & {
         console.debug('Executing change', { input })
       }
       const applied = [] as typeof input.changes
+      let waitForViewSync = false
       for (const change of input.changes) {
         try {
-          await promisify(() => port.handleChange(input.viewId, change))
+          const result = await promisify(() => port.handleChange(input.viewId, change))
           applied.push(change)
+          waitForViewSync ||= shouldWaitForViewSync(result)
         } catch (error) {
           console.error('Failed to execute change', { change, error })
         }
       }
-      return { requested: input.changes, applied }
+      return { requested: input.changes, applied, waitForViewSync }
     },
   )
 

--- a/packages/diagram/src/editor/useEditorActorLogic.ts
+++ b/packages/diagram/src/editor/useEditorActorLogic.ts
@@ -55,6 +55,7 @@ export function useEditorActorLogic(): EditorActorLogic & {
           waitForViewSync ||= shouldWaitForViewSync(result)
         } catch (error) {
           console.error('Failed to execute change', { change, error })
+          waitForViewSync ||= shouldWaitForViewSync()
         }
       }
       return { requested: input.changes, applied, waitForViewSync }

--- a/packages/diagram/src/index.ts
+++ b/packages/diagram/src/index.ts
@@ -42,6 +42,7 @@ export {
 export {
   createLikeC4Editor,
   type LikeC4EditorCallbacks,
+  type LikeC4EditorChangeResult,
 } from './editor/LikeC4EditorCallbacks'
 
 export {


### PR DESCRIPTION
Fixes #3165.

Allows embedded LikeC4 editors to indicate that applying a change will not publish a refreshed view, avoiding an unnecessary synchronization wait.

## Problem

Custom integrations may apply changes locally without publishing a replacement view. For example, my own custom viewer keeps layout edits browser-local until the user explicitly saves them. When a user drags a node, `handleChange` records the pending snapshot locally but does not update the model or publish a replacement view. LikeC4 therefore waits for a refresh that intentionally will not arrive, blocking additional edits until the two-second fallback expires. The editor currently assumes every successful `handleChange` callback will produce a refreshed view, so it remains busy until that refresh arrives or the two-second fallback expires.

For integrations that intentionally do not publish a refreshed view, this wait cannot complete normally and unnecessarily blocks further editing.

## Solution in this PR

`handleChange` may now return:

`{ waitForViewSync: false }`

Returning nothing preserves the existing behavior and waits for view synchronization. When multiple changes are processed together, the editor waits if any callback invocation expects a refreshed view.

## Implementation

- Add and publicly export `LikeC4EditorChangeResult`.
- Collect the synchronization expectation returned by `handleChange`.
- When no refreshed view is expected, raise the editor’s existing `view.synched` event immediately.
- Reuse the existing synchronization state machine without adding another persistent state field.
- Preserve the existing behavior for all current callback implementations.

The built-in LikeC4 viewer is unaffected because its callbacks continue returning no result.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask, and propose improvements. We're here to help. -->

- [x] I've thoroughly read the latest [contribution guidelines](https://github.com/likec4/likec4/blob/main/CONTRIBUTING.md).
- [x] I've rebased my branch onto `main` **before** creating this PR.
- [x] I've added tests to cover my changes (if applicable).
- [x] I've verified `pnpm typecheck` and `pnpm test`.
- [x] I've added [changesets](https://changesets-docs.vercel.app/) (you can use `/changeset-generator` SKILL).
- [x] My change requires documentation updates.
- [x] I've updated the documentation accordingly.

Docs via API JSDoc
