### PR TITLE
Add MiniMax auto-detection to the Vite plugin

### DIFF
--- a/packages/vite-plugin/src/ai/detect-ai.spec.ts
+++ b/packages/vite-plugin/src/ai/detect-ai.spec.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  ensurePackage: vi.fn(async () => undefined),
+  createOpenaiChat: vi.fn((model: string, apiKey: string, config: { baseURL?: string }) => ({
+    name: 'openai',
+    model,
+    apiKey,
+    config,
+  })),
+}))
+
+vi.mock('../ensurePackage', () => ({
+  ensurePackage: mocks.ensurePackage,
+}))
+
+vi.mock('@tanstack/ai-openai', () => ({
+  createOpenaiChat: mocks.createOpenaiChat,
+}))
+
+const resetEnv = () => {
+  delete process.env['OPENAI_API_KEY']
+  delete process.env['OPENROUTER_API_KEY']
+  delete process.env['ANTHROPIC_API_KEY']
+  delete process.env['GEMINI_API_KEY']
+  delete process.env['OLLAMA_HOST']
+  delete process.env['MINIMAX_API_KEY']
+  delete process.env['MINIMAX_CHAT_MODEL']
+  delete process.env['MINIMAX_REGION']
+}
+
+describe('detectAI', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    mocks.ensurePackage.mockClear()
+    mocks.createOpenaiChat.mockClear()
+    resetEnv()
+  })
+
+  it('loads MiniMax with the global endpoint and default model', async () => {
+    process.env['MINIMAX_API_KEY'] = 'mm-test-key'
+
+    const { detectAI } = await import('./detect-ai')
+    const options = await detectAI()
+
+    expect(mocks.ensurePackage).toHaveBeenCalledWith('@tanstack/ai')
+    expect(mocks.createOpenaiChat).toHaveBeenCalledWith('MiniMax-M3', 'mm-test-key', {
+      baseURL: 'https://api.minimax.io/v1',
+    })
+    expect(options).toMatchObject({
+      maxTokens: 16000,
+      adapter: {
+        name: 'openai',
+        model: 'MiniMax-M3',
+        apiKey: 'mm-test-key',
+        config: {
+          baseURL: 'https://api.minimax.io/v1',
+        },
+      },
+    })
+  })
+
+  it('switches to the CN endpoint and alternate model when configured', async () => {
+    process.env['MINIMAX_API_KEY'] = 'mm-test-key'
+    process.env['MINIMAX_CHAT_MODEL'] = 'MiniMax-M2.7'
+    process.env['MINIMAX_REGION'] = 'cn_zh'
+
+    const { detectAI } = await import('./detect-ai')
+    await detectAI()
+
+    expect(mocks.createOpenaiChat).toHaveBeenCalledWith('MiniMax-M2.7', 'mm-test-key', {
+      baseURL: 'https://api.minimaxi.com/v1',
+    })
+  })
+})

--- a/packages/vite-plugin/src/ai/detect-ai.ts
+++ b/packages/vite-plugin/src/ai/detect-ai.ts
@@ -1,3 +1,4 @@
+import type { AnyTextAdapter } from '@tanstack/ai'
 import type { AnthropicTextAdapter } from '@tanstack/ai-anthropic'
 import type { GeminiTextAdapter } from '@tanstack/ai-gemini'
 import type { OllamaTextAdapter } from '@tanstack/ai-ollama'
@@ -111,6 +112,42 @@ async function loadOllama(): Promise<AIOptions<OllamaTextAdapter<typeof ollamaDe
   }
 }
 
+const minimaxDefaultModel = 'MiniMax-M3' as const
+const minimaxBaseURLs = {
+  global_en: 'https://api.minimax.io/v1',
+  cn_zh: 'https://api.minimaxi.com/v1',
+} as const
+
+function chooseMiniMaxBaseURL(): string {
+  const region = env['MINIMAX_REGION']?.trim().toLowerCase()
+  if (region === 'cn_zh' || region === 'cn' || region === 'cn-zh' || region === 'china') {
+    return minimaxBaseURLs.cn_zh
+  }
+  return minimaxBaseURLs.global_en
+}
+
+async function loadMiniMax(): Promise<AIOptions> {
+  const baseURL = chooseMiniMaxBaseURL()
+  logger.info(
+    'Found ' +
+      k.yellow('MINIMAX_API_KEY') +
+      k.dim(', loading OpenAI-compatible adapter on ') +
+      k.green(baseURL),
+  )
+  await ensurePackage('@tanstack/ai-openai')
+  const { createOpenaiChat } = await import('@tanstack/ai-openai')
+  const apiKey = env['MINIMAX_API_KEY'] as string
+  const model = chooseModel('MINIMAX_CHAT_MODEL', minimaxDefaultModel)
+  return {
+    adapter: createOpenaiChat(
+      model as never,
+      apiKey,
+      { baseURL },
+    ) as unknown as AnyTextAdapter,
+    maxTokens,
+  }
+}
+
 /**
  * Picks the appropriate AI loader based on available environment variables.
  * Returns undefined if no AI provider is configured.
@@ -134,6 +171,10 @@ function pickLoader(): undefined | (() => Promise<AIOptions>) {
 
   if (isTruthy(env['OLLAMA_HOST'])) {
     return loadOllama
+  }
+
+  if (isTruthy(env['MINIMAX_API_KEY'])) {
+    return loadMiniMax
   }
 
   return undefined


### PR DESCRIPTION
Reason: Add MiniMax auto-detection through the OpenAI-compatible adapter path.

Implemented MiniMax detection in `packages/vite-plugin/src/ai/detect-ai.ts` with the `MiniMax-M3` default model, `MiniMax-M2.7` override, and global/CN endpoint selection.
Added focused Vitest coverage for the default endpoint, alternate model, and CN endpoint selection.

Checks:
- pnpm vitest run packages/vite-plugin/src/ai/detect-ai.spec.ts --no-isolate
- pnpm exec tsc -p packages/vite-plugin/tsconfig.json --noEmit --pretty false --skipLibCheck
