### PR TITLE
fix: hide manual layout tooltip while tools are open

### DIFF
--- a/.changeset/hide-open-layout-tooltip.md
+++ b/.changeset/hide-open-layout-tooltip.md
@@ -1,0 +1,5 @@
+---
+"@likec4/diagram": patch
+---
+
+Hide the manual layout tools tooltip while its popover is open.

--- a/packages/diagram/src/navigationpanel/editorpanel/ManualLayoutToolsButton.spec.ts
+++ b/packages/diagram/src/navigationpanel/editorpanel/ManualLayoutToolsButton.spec.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+import { manualLayoutTooltipProps } from './ManualLayoutToolsButton'
+
+describe('manualLayoutTooltipProps', () => {
+  it('leaves the tooltip uncontrolled while the tools are closed', () => {
+    expect(manualLayoutTooltipProps(false)).toEqual({})
+  })
+
+  it('forces the tooltip closed while the tools are open', () => {
+    expect(manualLayoutTooltipProps(true)).toEqual({ opened: false })
+  })
+})

--- a/packages/diagram/src/navigationpanel/editorpanel/ManualLayoutToolsButton.tsx
+++ b/packages/diagram/src/navigationpanel/editorpanel/ManualLayoutToolsButton.tsx
@@ -1,6 +1,7 @@
 import { css } from '@likec4/styles/css'
 import { hstack } from '@likec4/styles/patterns'
 import {
+  type TooltipProps,
   Popover,
   PopoverDropdown,
   PopoverTarget,
@@ -50,7 +51,7 @@ const Action = ({
   </Tooltip>
 )
 
-export function manualLayoutTooltipProps(isPopoverOpen: boolean): { opened?: false } {
+export function manualLayoutTooltipProps(isPopoverOpen: boolean): Pick<TooltipProps, 'opened'> {
   return isPopoverOpen ? { opened: false } : {}
 }
 
@@ -60,6 +61,8 @@ export const ManualLayoutToolsButton = memo(() => {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false)
   return (
     <Popover
+      opened={isPopoverOpen}
+      onChange={setIsPopoverOpen}
       position="right"
       offset={{
         mainAxis: 12,
@@ -67,8 +70,6 @@ export const ManualLayoutToolsButton = memo(() => {
       clickOutsideEvents={[
         'pointerdown',
       ]}
-      onOpen={() => setIsPopoverOpen(true)}
-      onClose={() => setIsPopoverOpen(false)}
       {...portalProps}>
       <PopoverTarget>
         <Tooltip label="Manual layouting tools" {...manualLayoutTooltipProps(isPopoverOpen)}>

--- a/packages/diagram/src/navigationpanel/editorpanel/ManualLayoutToolsButton.tsx
+++ b/packages/diagram/src/navigationpanel/editorpanel/ManualLayoutToolsButton.tsx
@@ -17,7 +17,7 @@ import {
   IconLayoutCollage,
   IconRouteOff,
 } from '@tabler/icons-react'
-import { memo } from 'react'
+import { memo, useState } from 'react'
 import type { MouseEventHandler, ReactNode } from 'react'
 import { useDiagram } from '../../hooks/useDiagram'
 import { useMantinePortalProps } from '../../hooks/useMantinePortalProps'
@@ -50,9 +50,14 @@ const Action = ({
   </Tooltip>
 )
 
+export function manualLayoutTooltipProps(isPopoverOpen: boolean) {
+  return isPopoverOpen ? { opened: false as const } : {}
+}
+
 export const ManualLayoutToolsButton = memo(() => {
   const diagram = useDiagram()
   const portalProps = useMantinePortalProps()
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false)
   return (
     <Popover
       position="right"
@@ -62,9 +67,11 @@ export const ManualLayoutToolsButton = memo(() => {
       clickOutsideEvents={[
         'pointerdown',
       ]}
+      onOpen={() => setIsPopoverOpen(true)}
+      onClose={() => setIsPopoverOpen(false)}
       {...portalProps}>
       <PopoverTarget>
-        <Tooltip label="Manual layouting tools">
+        <Tooltip label="Manual layouting tools" {...manualLayoutTooltipProps(isPopoverOpen)}>
           <PanelActionIcon>
             <IconLayoutCollage />
           </PanelActionIcon>

--- a/packages/diagram/src/navigationpanel/editorpanel/ManualLayoutToolsButton.tsx
+++ b/packages/diagram/src/navigationpanel/editorpanel/ManualLayoutToolsButton.tsx
@@ -50,8 +50,8 @@ const Action = ({
   </Tooltip>
 )
 
-export function manualLayoutTooltipProps(isPopoverOpen: boolean) {
-  return isPopoverOpen ? { opened: false as const } : {}
+export function manualLayoutTooltipProps(isPopoverOpen: boolean): { opened?: false } {
+  return isPopoverOpen ? { opened: false } : {}
 }
 
 export const ManualLayoutToolsButton = memo(() => {


### PR DESCRIPTION
## Summary

- hide the Manual layouting tools tooltip while its popover is open
- preserve the normal hover tooltip after the popover closes
- add regression coverage for the tooltip visibility contract

Closes #3175

## Testing

- `pnpm typecheck`
- `pnpm --filter @likec4/diagram test` (123 tests passed)
- `pnpm exec vitest run packages/diagram/src/navigationpanel/editorpanel/ManualLayoutToolsButton.spec.ts --no-isolate`
- `pnpm test` (2,744 tests passed)

## Checklist

- [x] I've thoroughly read the latest [contribution guidelines](https://github.com/likec4/likec4/blob/main/CONTRIBUTING.md).
- [x] I've rebased my branch onto `main` **before** creating this PR.
- [x] I've added tests to cover my changes (if applicable).
- [x] I've verified `pnpm typecheck` and `pnpm test`.
- [x] I've added [changesets](https://changesets-docs.vercel.app/) (you can use `/changeset-generator` SKILL).
- [ ] My change requires documentation updates.
- [ ] I've updated the documentation accordingly (or will do in follow-up PR).
