### PR TITLE
fix(cli): count files matched by validate --file, not only files with errors

### DIFF
--- a/.changeset/fix-validate-filtered-files-count.md
+++ b/.changeset/fix-validate-filtered-files-count.md
@@ -1,0 +1,6 @@
+---
+'likec4': patch
+'@likec4/language-services': patch
+---
+
+`likec4 validate --file` now counts every file matched by the filter in `filteredFiles`, including files with no diagnostics. It previously counted only files that carried errors, so a clean matched file reported `filteredFiles: 0`.

--- a/packages/language-services/src/common/LikeC4.ts
+++ b/packages/language-services/src/common/LikeC4.ts
@@ -332,6 +332,13 @@ Please specify a project folder`)
   }
 
   /**
+   * Returns the file system paths of the parsed documents in the workspace
+   */
+  documentPaths(): string[] {
+    return [...this.LangiumDocuments.userDocuments].map(doc => doc.uri.fsPath)
+  }
+
+  /**
    * Subscribe to model updates
    * @param listener Function called when the model is updated - receives the project ID that was updated
    * @returns A function to dispose the listener

--- a/packages/likec4/src/cli/validate/index.ts
+++ b/packages/likec4/src/cli/validate/index.ts
@@ -4,27 +4,8 @@ import k from 'tinyrainbow'
 import type * as yargs from 'yargs'
 import { createLikeC4Logger, startTimer } from '../../logger'
 import { path, project } from '../options'
-
-interface DiagnosticItem {
-  message: string
-  file: string
-  line: number
-  range: {
-    start: { line: number; character: number }
-    end: { line: number; character: number }
-  } | null
-}
-
-interface ValidateResult {
-  valid: boolean
-  errors: DiagnosticItem[]
-  stats: {
-    totalFiles: number
-    totalErrors: number
-    filteredFiles: number
-    filteredErrors: number
-  }
-}
+import type { DiagnosticItem } from './result'
+import { buildValidateResult } from './result'
 
 const validateCmd = (yargs: yargs.Argv) => {
   return yargs
@@ -127,31 +108,16 @@ const validateCmd = (yargs: yargs.Argv) => {
         }
 
         const allErrors = [...allModelErrors, ...layoutErrors]
-        const totalFiles = languageServices.documentCount()
-        const totalErrors = allErrors.length
 
-        // Apply file filter
-        const filteredErrors = fileFilter
-          ? allErrors.filter(e =>
-            fileFilter.some(f => e.file === f || e.file.endsWith('/' + f) || e.file.endsWith('\\' + f))
-          )
-          : allErrors
+        const result = buildValidateResult({
+          documents: languageServices.documentPaths(),
+          errors: allErrors,
+          fileFilter,
+        })
+        const { valid, errors: filteredErrors } = result
+        const { totalFiles, totalErrors } = result.stats
 
-        const filteredFileSet = new Set(filteredErrors.map(e => e.file))
-
-        const valid = filteredErrors.length === 0
         process.exitCode = valid ? 0 : 1
-
-        const result: ValidateResult = {
-          valid,
-          errors: filteredErrors,
-          stats: {
-            totalFiles,
-            totalErrors,
-            filteredFiles: fileFilter ? filteredFileSet.size : totalFiles,
-            filteredErrors: filteredErrors.length,
-          },
-        }
 
         // Output
         if (isJson) {

--- a/packages/likec4/src/cli/validate/result.spec.ts
+++ b/packages/likec4/src/cli/validate/result.spec.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+import type { DiagnosticItem } from './result'
+import { buildValidateResult } from './result'
+
+const error = (file: string): DiagnosticItem => ({
+  message: 'something is wrong',
+  file,
+  line: 0,
+  range: null,
+})
+
+describe('buildValidateResult', () => {
+  it('counts a matched file with no errors', () => {
+    const result = buildValidateResult({
+      documents: ['/repro/model.c4'],
+      errors: [],
+      fileFilter: ['/repro/model.c4'],
+    })
+
+    expect(result.stats).toEqual({
+      totalFiles: 1,
+      totalErrors: 0,
+      filteredFiles: 1,
+      filteredErrors: 0,
+    })
+    expect(result.valid).toBe(true)
+  })
+
+  it('counts every matched file, not only the ones carrying errors', () => {
+    const result = buildValidateResult({
+      documents: ['/repro/model.c4', '/repro/views.c4', '/repro/spec.c4'],
+      errors: [error('/repro/views.c4')],
+      fileFilter: ['/repro/model.c4', '/repro/views.c4'],
+    })
+
+    expect(result.stats.filteredFiles).toBe(2)
+    expect(result.stats.filteredErrors).toBe(1)
+    expect(result.valid).toBe(false)
+  })
+
+  it('does not count a file left out by the filter', () => {
+    const result = buildValidateResult({
+      documents: ['/repro/model.c4', '/repro/views.c4'],
+      errors: [error('/repro/views.c4')],
+      fileFilter: ['/repro/model.c4'],
+    })
+
+    expect(result.stats.filteredFiles).toBe(1)
+    expect(result.stats.filteredErrors).toBe(0)
+    expect(result.errors).toEqual([])
+    expect(result.valid).toBe(true)
+  })
+
+  it('matches a filter given as a relative path', () => {
+    const result = buildValidateResult({
+      documents: ['/repro/src/model.c4'],
+      errors: [],
+      fileFilter: ['src/model.c4'],
+    })
+
+    expect(result.stats.filteredFiles).toBe(1)
+  })
+
+  it('reports every document when no filter is given', () => {
+    const result = buildValidateResult({
+      documents: ['/repro/model.c4', '/repro/views.c4'],
+      errors: [error('/repro/views.c4')],
+      fileFilter: null,
+    })
+
+    expect(result.stats).toEqual({
+      totalFiles: 2,
+      totalErrors: 1,
+      filteredFiles: 2,
+      filteredErrors: 1,
+    })
+  })
+})

--- a/packages/likec4/src/cli/validate/result.ts
+++ b/packages/likec4/src/cli/validate/result.ts
@@ -1,0 +1,57 @@
+export interface DiagnosticItem {
+  message: string
+  file: string
+  line: number
+  range: {
+    start: { line: number; character: number }
+    end: { line: number; character: number }
+  } | null
+}
+
+export interface ValidateResult {
+  valid: boolean
+  errors: DiagnosticItem[]
+  stats: {
+    totalFiles: number
+    totalErrors: number
+    filteredFiles: number
+    filteredErrors: number
+  }
+}
+
+export interface ValidateInput {
+  /**
+   * File system paths of the parsed documents in the workspace
+   */
+  documents: readonly string[]
+  errors: readonly DiagnosticItem[]
+  /**
+   * Resolved paths given with `--file`, or `null` when the flag was not used
+   */
+  fileFilter: readonly string[] | null
+}
+
+/**
+ * A document is selected by `--file` when its path is one of the given paths,
+ * or ends with one of them.
+ */
+function matchesFilter(file: string, fileFilter: readonly string[]): boolean {
+  return fileFilter.some(f => file === f || file.endsWith('/' + f) || file.endsWith('\\' + f))
+}
+
+export function buildValidateResult({ documents, errors, fileFilter }: ValidateInput): ValidateResult {
+  const filteredErrors = fileFilter ? errors.filter(e => matchesFilter(e.file, fileFilter)) : [...errors]
+  // Counted over the documents, so that a matched file with no diagnostics is still counted
+  const filteredFiles = fileFilter ? documents.filter(doc => matchesFilter(doc, fileFilter)).length : documents.length
+
+  return {
+    valid: filteredErrors.length === 0,
+    errors: [...filteredErrors],
+    stats: {
+      totalFiles: documents.length,
+      totalErrors: errors.length,
+      filteredFiles,
+      filteredErrors: filteredErrors.length,
+    },
+  }
+}


### PR DESCRIPTION
## Checklist

- [x] I've thoroughly read the latest [contribution guidelines](https://github.com/likec4/likec4/blob/main/CONTRIBUTING.md).
- [x] I've rebased my branch onto `main` **before** creating this PR.
- [x] I've added tests to cover my changes (if applicable).
- [x] I've verified `pnpm typecheck` and `pnpm test`.
- [x] I've added [changesets](https://changesets-docs.vercel.app/) (you can use `/changeset-generator` SKILL).
- [ ] My change requires documentation updates.
- [ ] I've updated the documentation accordingly (or will do in follow-up PR).

Fixes #3180.

`validate --file` built `filteredFiles` out of the diagnostics that survived the filter:

```ts
const filteredErrors = fileFilter ? allErrors.filter(e => fileFilter.some(...)) : allErrors
const filteredFileSet = new Set(filteredErrors.map(e => e.file))
...
filteredFiles: fileFilter ? filteredFileSet.size : totalFiles,
```

A file that matched `--file` but carried no diagnostics contributed nothing to that set, so it reported `0`. The match predicate was only ever applied to errors, never to the documents.

No documentation change is needed, because the docs already describe the behaviour this PR implements. `skills/likec4-dsl/SKILL.md` says `"filteredFiles": 1, // Number of files that match the --file filter` and, a few lines below, "Selfcheck that `filteredFiles` matches the number of files you passed to `--file`". This brings the code to the documented contract rather than changing it.

### What changed

`LikeC4.documentPaths()` in `packages/language-services/src/common/LikeC4.ts`, right next to `documentCount()` that this same stats block already calls. There was no public way to reach the document paths, only their count.

The stats computation moved out of the yargs handler into `packages/likec4/src/cli/validate/result.ts` as a pure `buildValidateResult`, following the shape of `cli/codegen/handler.ts`, so it can be tested without spinning up a workspace. `filteredFiles` is now counted over the documents.

I left `documentCount()` alone instead of folding it into the new method, to keep the diff narrow. Happy to collapse the two if you prefer.

### Against the reproduction in the issue

Same workspace and same command as the issue, run from the workspace folder:

```
likec4 validate --json --no-layout --file model.c4 .
```

Before, `"filteredFiles": 0`. After, `"filteredFiles": 1`, with the rest of the payload unchanged.

I also checked the edge case the skill documents. Passing `--file model.c4 --file views.c4 --file likec4.config.json` still reports `filteredFiles: 2`, because the config file is not a parsed document, so that note stays accurate.

### Testing

`packages/likec4/src/cli/validate/result.spec.ts`, five cases: a matched clean file, a mixed set where only some files carry errors, a file left out by the filter, a filter given as a relative path, and the no-filter path. Four of the five fail on `main` and all five pass with the change. The no-filter case passes on both, which is the point: that path was already right.

Ran in a Linux container on Node 22.23.1 with pnpm 11.15.0, so the `.tool-versions` toolchain: `pnpm install`, `pnpm generate`, `pnpm exec tsc --build`, then `pnpm typecheck` (26 tasks, all successful) and `pnpm test` (274 files, 2767 passed, 1 expected fail, 23 skipped, 4 todo). `dprint check` and `oxlint` are clean on the four touched files.

I did not run `pnpm test:e2e`.

Disclosure: I used an AI coding assistant while working on this. Every command and result reported above I ran and checked myself.
