### PR TITLE
fix: preserve automatic edge routing when moving a node

### DIFF
--- a/.changeset/preserve-generated-edge-routing.md
+++ b/.changeset/preserve-generated-edge-routing.md
@@ -1,0 +1,5 @@
+---
+'@likec4/diagram': patch
+---
+
+Keep automatically routed relationships automatic when moving connected nodes in the layout editor. Fixes [#3184](https://github.com/likec4/likec4/issues/3184).

--- a/packages/diagram/src/likec4diagram/state/createViewChange.spec.ts
+++ b/packages/diagram/src/likec4diagram/state/createViewChange.spec.ts
@@ -1,0 +1,105 @@
+import type { DiagramEdge, DiagramNode, LayoutedElementView } from '@likec4/core'
+import { scalar } from '@likec4/core/types'
+import type { InternalNode } from '@xyflow/react'
+import { describe, expect, it } from 'vitest'
+import type { XYStoreApi } from '../../hooks'
+import { diagramToXY } from '../xyflow-diagram/diagram-view'
+import { createViewChange } from './createViewChange'
+
+const source = {
+  id: scalar.NodeId('source'),
+  parent: null,
+  children: [],
+  inEdges: [],
+  outEdges: [scalar.EdgeId('source-target')],
+  x: 0,
+  y: 0,
+  width: 100,
+  height: 100,
+  labelBBox: { x: 0, y: 0, width: 100, height: 24 },
+  kind: 'component',
+  modelRef: scalar.Fqn('source'),
+  title: 'Source',
+  description: null,
+  technology: null,
+  color: 'primary',
+  shape: 'rectangle',
+  style: {},
+  level: 0,
+  tags: [],
+} satisfies DiagramNode
+
+const target = {
+  ...source,
+  id: scalar.NodeId('target'),
+  modelRef: scalar.Fqn('target'),
+  title: 'Target',
+  x: 400,
+  inEdges: [scalar.EdgeId('source-target')],
+  outEdges: [],
+} satisfies DiagramNode
+
+const relationship = {
+  id: scalar.EdgeId('source-target'),
+  parent: null,
+  source: source.id,
+  target: target.id,
+  label: null,
+  technology: null,
+  relations: [],
+  color: 'primary',
+  line: 'solid',
+  points: [
+    [50, 50],
+    [183, 50],
+    [317, 50],
+    [450, 50],
+  ],
+} satisfies DiagramEdge
+
+const view = {
+  _type: 'element',
+  _stage: 'layouted',
+  _layout: 'auto',
+  id: scalar.ViewId('index'),
+  title: 'Index',
+  description: null,
+  tags: null,
+  links: null,
+  hash: 'view-hash',
+  autoLayout: { direction: 'LR' },
+  nodes: [source, target],
+  edges: [relationship],
+  bounds: { x: 0, y: 0, width: 500, height: 100 },
+} satisfies LayoutedElementView
+
+describe('createViewChange', () => {
+  it('does not persist generated routing as authored control points after a node moves', () => {
+    const { xynodes, xyedges } = diagramToXY({
+      view,
+      currentViewId: undefined,
+      where: null,
+    })
+    const nodeLookup = new Map(xynodes.map(node => {
+      const positionAbsolute = node.id === source.id ? { x: 100, y: 0 } : node.position
+      return [
+        node.id,
+        {
+          ...node,
+          measured: { width: node.initialWidth, height: node.initialHeight },
+          internals: { positionAbsolute },
+        } as InternalNode<typeof node>,
+      ]
+    }))
+    const xystore = {
+      getState: () => ({
+        nodeLookup,
+        edgeLookup: new Map(xyedges.map(edge => [edge.id, edge])),
+      }),
+    } as unknown as XYStoreApi
+
+    const change = createViewChange({ view, xynodes, xyedges, xystore })
+
+    expect(change.layout.edges[0]?.controlPoints).toBeNull()
+  })
+})

--- a/packages/diagram/src/likec4diagram/state/createViewChange.ts
+++ b/packages/diagram/src/likec4diagram/state/createViewChange.ts
@@ -7,7 +7,6 @@ import type {
 import { getNodeDimensions } from '@xyflow/system'
 import { hasAtLeast, map } from 'remeda'
 import { calcViewBounds } from '../../utils/view-bounds'
-import { bezierControlPoints, isSamePoint } from '../../utils/xyflow'
 import type { DiagramContext } from './types'
 
 export function createViewChange(
@@ -24,7 +23,6 @@ export function createViewChange(
   } = parentContext
 
   const { nodeLookup, edgeLookup } = xystore.getState()
-  const movedNodes = new Set<string>()
 
   const nodes = map(view.nodes, (node): DiagramNode => {
     const internal = nodeLookup.get(node.id)
@@ -35,14 +33,6 @@ export function createViewChange(
     const xynodedata = xynodes.find(n => n.data.id === node.id)?.data ?? internal.data
     const position = internal.internals.positionAbsolute
     const { width, height } = getNodeDimensions(internal)
-
-    const isChanged = !isSamePoint(position, node)
-      || node.width !== width
-      || node.height !== height
-
-    if (isChanged) {
-      movedNodes.add(node.id)
-    }
 
     return {
       ...node,
@@ -65,12 +55,7 @@ export function createViewChange(
       return edge
     }
     const data = xyedge.data
-    let controlPoints = data.controlPoints ?? []
-    const sourceOrTargetMoved = movedNodes.has(xyedge.source) || movedNodes.has(xyedge.target)
-    // If edge control points are not set, but the source or target node was moved
-    if (controlPoints.length === 0 && sourceOrTargetMoved) {
-      controlPoints = bezierControlPoints(data.points)
-    }
+    const controlPoints = data.controlPoints ?? []
     const _updated: DiagramEdge = {
       ...edge,
       points: data.points,

--- a/packages/diagram/src/likec4diagram/useLayoutConstraints.spec.ts
+++ b/packages/diagram/src/likec4diagram/useLayoutConstraints.spec.ts
@@ -1,0 +1,122 @@
+import type { NonEmptyArray } from '@likec4/core'
+import type { EdgeReplaceChange, InternalNode } from '@xyflow/react'
+import { describe, expect, it } from 'vitest'
+import type { XYStoreApi } from '../hooks'
+import type { Types } from './types'
+import { createLayoutConstraints } from './useLayoutConstraints'
+
+type Position = { x: number; y: number }
+
+function testNode(id: string, { x, y }: Position): InternalNode<Types.AnyNode> {
+  return {
+    id,
+    position: { x, y },
+    measured: { width: 100, height: 100 },
+    internals: {
+      positionAbsolute: { x, y },
+    },
+  } as InternalNode<Types.AnyNode>
+}
+
+function testEdge(controlPoints: Types.RelationshipEdgeData['controlPoints']): Types.RelationshipEdge {
+  return {
+    id: 'source-target',
+    type: 'relationship',
+    source: 'source',
+    target: 'target',
+    data: {
+      points: [
+        [50, 50],
+        [183, 50],
+        [317, 50],
+        [450, 50],
+      ],
+      controlPoints,
+    },
+  } as unknown as Types.RelationshipEdge
+}
+
+function moveSource(
+  edge: Types.RelationshipEdge,
+  movedPosition: Position = { x: 100, y: 0 },
+  sourcePosition: Position = { x: 0, y: 0 },
+  targetPosition: Position = { x: 400, y: 0 },
+): Types.RelationshipEdge {
+  const source = testNode('source', sourcePosition)
+  const target = testNode('target', targetPosition)
+  const nodeLookup = new Map([
+    [source.id, source],
+    [target.id, target],
+  ])
+  const edgeLookup = new Map([[edge.id, edge]])
+  let edgeChange: EdgeReplaceChange<Types.AnyEdge> | undefined
+
+  const xyflowApi = {
+    getState: () => ({
+      parentLookup: new Map(),
+      nodeLookup,
+      edges: [edge],
+      edgeLookup,
+      triggerNodeChanges: () => {},
+      triggerEdgeChanges: (changes: EdgeReplaceChange<Types.AnyEdge>[]) => {
+        edgeChange = changes[0]
+      },
+    }),
+  } as unknown as XYStoreApi
+
+  const constraints = createLayoutConstraints(xyflowApi, ['source'])
+  constraints.rects.get('source')!.positionAbsolute = movedPosition
+  constraints.updateXYFlow()
+
+  return edgeChange!.item as Types.RelationshipEdge
+}
+
+function expectPointInsideNode([x, y]: readonly [number, number], position: Position) {
+  expect(x).toBeGreaterThanOrEqual(position.x)
+  expect(x).toBeLessThanOrEqual(position.x + 100)
+  expect(y).toBeGreaterThanOrEqual(position.y)
+  expect(y).toBeLessThanOrEqual(position.y + 100)
+}
+
+describe('createLayoutConstraints', () => {
+  it('keeps generated edge routing generated when one endpoint crosses the other', () => {
+    const movedSource = { x: 600, y: 100 }
+    const target = { x: 400, y: 0 }
+    const edge = moveSource(testEdge(null), movedSource)
+    const sourceHandle = edge.data.points[0]
+    const targetHandle = edge.data.points.at(-1)!
+
+    expect(edge.data.controlPoints).toBeNull()
+    expectPointInsideNode(sourceHandle, movedSource)
+    expectPointInsideNode(targetHandle, target)
+    expect(sourceHandle[0]).toBeGreaterThan(targetHandle[0])
+    expect(sourceHandle[1]).toBeGreaterThan(targetHandle[1])
+  })
+
+  it('keeps generated edge points finite when endpoints overlap', () => {
+    const edge = moveSource(
+      testEdge(null),
+      { x: 100, y: 0 },
+      { x: 0, y: 0 },
+      { x: 0, y: 0 },
+    )
+
+    expect(edge.data.controlPoints).toBeNull()
+    expect(edge.data.points.flat().every(Number.isFinite)).toBe(true)
+  })
+
+  it('moves explicitly authored control points with the endpoint', () => {
+    const controlPoints = [
+      { x: 200, y: 50 },
+      { x: 300, y: 50 },
+    ] satisfies NonEmptyArray<{ x: number; y: number }>
+
+    const edge = moveSource(testEdge(controlPoints))
+
+    expect(edge.data.controlPoints).toEqual([
+      { x: 262, y: 50 },
+      { x: 337, y: 50 },
+    ])
+    expect(edge.data.points).toEqual(testEdge(controlPoints).data.points)
+  })
+})

--- a/packages/diagram/src/likec4diagram/useLayoutConstraints.ts
+++ b/packages/diagram/src/likec4diagram/useLayoutConstraints.ts
@@ -14,7 +14,7 @@ import { useMemo, useRef } from 'react'
 import { clamp, difference, filter, flatMap, hasAtLeast, map, pipe, unique } from 'remeda'
 import { type XYStoreApi, useXYStoreApi } from '../hooks'
 import { useDiagram } from '../hooks/useDiagram'
-import { bezierControlPoints, vector } from '../utils'
+import { vector } from '../utils'
 import { nodeToRect } from '../utils/xyflow'
 import type { Types } from './types'
 
@@ -195,7 +195,7 @@ function makeRelativeEdgeModifier(
   anchorNode: BBox,
   staticNode: BBox,
 ): EdgeModifier {
-  const controlPoints = edge.data.controlPoints ?? bezierControlPoints(edge.data.points)
+  const controlPoints = edge.data.controlPoints
   const anchorV = vector(BBox.center(anchorNode))
   const staticV = vector(BBox.center(staticNode))
 
@@ -219,6 +219,9 @@ function makeRelativeEdgeModifier(
     const d = vector(dx, dy)
 
     const relativePoint = (pt: { x: number; y: number }) => {
+      if (staticToAnchorLength === 0) {
+        return { x: pt.x, y: pt.y }
+      }
       const point = vector(pt)
       const staticToP = point.subtract(staticV)
       const projLength = staticToP.dot(staticToAnchor)
@@ -243,7 +246,15 @@ function makeRelativeEdgeModifier(
       id: edge.id,
       type: 'replace',
       item: produce(current, draft => {
-        draft.data.controlPoints = controlPoints.map(relativePoint)
+        if (controlPoints) {
+          draft.data.controlPoints = controlPoints.map(relativePoint)
+        } else {
+          draft.data.points = map(edge.data.points, ([x, y]) => {
+            const point = relativePoint({ x, y })
+            return [point.x, point.y] satisfies [number, number]
+          })
+          draft.data.controlPoints = controlPoints
+        }
 
         if (edge.data.labelBBox) {
           draft.data.labelBBox ??= edge.data.labelBBox


### PR DESCRIPTION
Fixes #3184.

## What changed

- Keep automatically routed relationships represented by generated path points when a connected node moves.
- Continue moving explicitly authored control points relative to the dragged endpoint.
- Stop snapshot serialization from promoting generated Bézier handles into authored waypoints.
- Keep generated edge coordinates finite when connected nodes have the same center.

This prevents ordinary node moves from silently freezing generated curves into manual routing that can later produce large, unexpected bends.

## Validation

- `pnpm generate`
- `pnpm typecheck`
- `ulimit -n 65536 && CI=true pnpm test` (2,766 passed, 1 expected failure, 23 skipped, 4 todo)
- Focused diagram regression tests
- Type-aware oxlint on all changed TypeScript files

## Checklist

- [x] I have thoroughly read the latest [contribution guidelines](https://github.com/likec4/likec4/blob/main/CONTRIBUTING.md).
- [x] I have rebased my branch onto `main` **before** creating this PR.
- [x] I have added tests to cover my changes.
- [x] I have verified `pnpm typecheck` and `pnpm test`.
- [x] I have added a [changeset](https://changesets-docs.vercel.app/).
- [ ] My change requires documentation updates.
- [ ] I have updated the documentation accordingly (or will do in a follow-up PR).