### PR TITLE
fix: allow manual layouts for implicit views

### DIFF
--- a/.changeset/save-implicit-view-layouts.md
+++ b/.changeset/save-implicit-view-layouts.md
@@ -1,0 +1,5 @@
+---
+'@likec4/language-server': patch
+---
+
+Allow saving and resetting manual layouts for implicit element views.

--- a/packages/language-server/src/model-change/ModelChanges.ts
+++ b/packages/language-server/src/model-change/ModelChanges.ts
@@ -52,14 +52,16 @@ export class LikeC4ModelChanges {
       const project = workspace.ProjectsManager.ensureProject(_projectId as ProjectId)
       logger.debug`Applying model change ${change.op} to view ${viewId} in project ${project.id}`
       const lookup = this.locator.locateViewAst(viewId, project.id)
-      if (!lookup) {
-        throw new Error(`View ${viewId} not found in project ${project.id}`)
+      if (
+        !lookup
+        && (change.op === 'save-view-snapshot' || change.op === 'reset-manual-layout')
+      ) {
+        const model = await this.services.likec4.ModelBuilder.computeModel(project.id)
+        if (!model.findView(viewId)) {
+          throw new Error(`View ${viewId} not found in project ${project.id}`)
+        }
       }
-      const textDocument = {
-        uri: lookup.doc.textDocument.uri,
-        version: lookup.doc.textDocument.version,
-      }
-      // TODO refactor to use separate methods for save/reset operations
+
       if (change.op === 'save-view-snapshot') {
         invariant(
           viewId === change.layout.id,
@@ -78,6 +80,14 @@ export class LikeC4ModelChanges {
           success: true,
           location,
         }
+      }
+
+      if (!lookup) {
+        throw new Error(`View ${viewId} not found in project ${project.id}`)
+      }
+      const textDocument = {
+        uri: lookup.doc.textDocument.uri,
+        version: lookup.doc.textDocument.version,
       }
 
       // Convert the view change to text edits

--- a/packages/language-server/src/model-change/viewChange.spec.ts
+++ b/packages/language-server/src/model-change/viewChange.spec.ts
@@ -1,9 +1,10 @@
+import type { LayoutedView, ViewId } from '@likec4/core'
 import { UriUtils } from 'langium'
 import { vol } from 'memfs'
 import stripIndent from 'strip-indent'
 import { type ExpectStatic, describe, it, vi } from 'vitest'
 import { URI } from 'vscode-uri'
-import { WithFileSystem } from '../filesystem'
+import { WithFileSystem, WithLikeC4ManualLayouts } from '../filesystem'
 import type { ChangeView } from '../protocol'
 import { createTestServices } from '../test'
 
@@ -65,6 +66,102 @@ async function testDoc(expect: ExpectStatic, document: string) {
 }
 
 describe('viewChange', () => {
+  describe('implicit views', () => {
+    async function implicitViewTest(expect: ExpectStatic) {
+      const test = createTestServices({
+        projectConfig: { implicitViews: true },
+        context: {
+          ...WithFileSystem(),
+          ...WithLikeC4ManualLayouts,
+        },
+      })
+      const { errors } = await test.validate(`
+        specification {
+          element component
+        }
+        model {
+          component sys1
+        }
+      `)
+      expect(errors).toEqual([])
+      return test
+    }
+
+    const implicitViewId = '__sys1' as ViewId
+    const layout = {
+      id: implicitViewId,
+      _type: 'element',
+      _stage: 'layouted',
+      _layout: 'manual',
+      title: 'sys1',
+      description: null,
+      hash: 'test-hash',
+      autoLayout: { direction: 'TB' },
+      nodes: [],
+      edges: [],
+      bounds: { x: 0, y: 0, width: 0, height: 0 },
+    } satisfies LayoutedView
+
+    it('saves and resets manual layouts', async ({ expect }) => {
+      const { services } = await implicitViewTest(expect)
+      const manualLayouts = services.shared.workspace.ManualLayouts
+      const location = {
+        uri: 'file:///test/workspace/src/.likec4/__sys1.likec4.snap',
+        range: {
+          start: { line: 0, character: 0 },
+          end: { line: 0, character: 0 },
+        },
+      }
+      const write = vi.spyOn(manualLayouts, 'write').mockResolvedValue(location)
+      const remove = vi.spyOn(manualLayouts, 'remove').mockResolvedValue(location)
+
+      await expect(services.likec4.ModelChanges.applyChange({
+        viewId: implicitViewId,
+        change: {
+          op: 'save-view-snapshot',
+          layout,
+        },
+      })).resolves.toEqual({ success: true, location })
+      expect(write).toHaveBeenCalledOnce()
+
+      await expect(services.likec4.ModelChanges.applyChange({
+        viewId: implicitViewId,
+        change: { op: 'reset-manual-layout' },
+      })).resolves.toEqual({ success: true, location })
+      expect(remove).toHaveBeenCalledOnce()
+    })
+
+    it('rejects layouts for unknown views', async ({ expect }) => {
+      const { services } = await implicitViewTest(expect)
+      const write = vi.spyOn(services.shared.workspace.ManualLayouts, 'write')
+
+      const result = await services.likec4.ModelChanges.applyChange({
+        viewId: '__unknown' as ViewId,
+        change: {
+          op: 'save-view-snapshot',
+          layout: { ...layout, id: '__unknown' as ViewId },
+        },
+      })
+
+      expect(result.success).toBe(false)
+      expect(write).not.toHaveBeenCalled()
+    })
+
+    it('continues to reject source edits', async ({ expect }) => {
+      const { services } = await implicitViewTest(expect)
+
+      const result = await services.likec4.ModelChanges.applyChange({
+        viewId: implicitViewId,
+        change: {
+          op: 'change-autolayout',
+          layout: { direction: 'LR' },
+        },
+      })
+
+      expect(result.success).toBe(false)
+    })
+  })
+
   describe('change-property', () => {
     it('should update view title', async ({ expect }) => {
       const { change, read } = await testDoc(


### PR DESCRIPTION
Fixes #3183.

## Summary

- Allow manual layout snapshots to be saved and reset for implicit generated views.
- Validate AST-less layout operations against the computed model, so unknown view IDs still fail.
- Keep semantic source edits restricted to explicit source-backed views.

## Testing

- `pnpm generate`
- `pnpm typecheck`
- `ulimit -n 65536 && CI=true pnpm test` (2,765 passed; repository expected fail/skips/todos unchanged)
- Type-aware oxlint on the changed TypeScript files
- Focused implicit-view save/reset regression tests

## Checklist

- [x] I have thoroughly read the latest [contribution guidelines](https://github.com/likec4/likec4/blob/main/CONTRIBUTING.md).
- [x] I have rebased my branch onto `main` **before** creating this PR.
- [x] I have added tests to cover my changes.
- [x] I have verified `pnpm typecheck` and `pnpm test`.
- [x] I have added a [changeset](https://changesets-docs.vercel.app/).
- [ ] My change requires documentation updates.
- [ ] I have updated the documentation accordingly (or will do in a follow-up PR).