### PR TITLE
feat(diagram): allow custom node connection boundaries

### DIFF
--- a/.changeset/custom-node-connection-boundaries.md
+++ b/.changeset/custom-node-connection-boundaries.md
@@ -1,0 +1,5 @@
+---
+'@likec4/diagram': patch
+---
+
+Allow custom node renderers to define where relationships attach to their visible boundary.

--- a/packages/diagram/README.md
+++ b/packages/diagram/README.md
@@ -329,6 +329,62 @@ function App() {
 > [!IMPORTANT]
 > Try to keep node renderers referentially stable.
 
+#### Custom relationship attachment points
+
+If a custom renderer's visible shape differs from its rectangular node bounds,
+wrap the diagram in `NodeConnectionBoundaryProvider`. The resolver receives the
+measured node bounds and the adjacent route point, and may return the point where
+the relationship should attach. Return `undefined` to keep the default boundary.
+
+```tsx
+import {
+  type NodeConnectionBoundaryResolver,
+  LikeC4Diagram,
+  NodeConnectionBoundaryProvider,
+} from '@likec4/diagram'
+
+const circularNodes = new Set(['customer'])
+
+const resolveConnectionBoundary: NodeConnectionBoundaryResolver = ({
+  nodeId,
+  nodeBounds,
+  toward,
+}) => {
+  if (!circularNodes.has(nodeId)) {
+    return undefined
+  }
+
+  const center = {
+    x: nodeBounds.x + nodeBounds.width / 2,
+    y: nodeBounds.y + nodeBounds.height / 2,
+  }
+  const direction = {
+    x: toward.x - center.x,
+    y: toward.y - center.y,
+  }
+  const length = Math.hypot(direction.x, direction.y)
+  if (length === 0) {
+    return undefined
+  }
+  const radius = Math.min(nodeBounds.width, nodeBounds.height) / 2
+  return {
+    x: center.x + direction.x / length * radius,
+    y: center.y + direction.y / length * radius,
+  }
+}
+
+function App() {
+  return (
+    <NodeConnectionBoundaryProvider resolver={resolveConnectionBoundary}>
+      <LikeC4Diagram view={view} renderNodes={renderNodes} />
+    </NodeConnectionBoundaryProvider>
+  )
+}
+```
+
+The resolver applies to auto-layout paths and manually edited relationship
+routes, including while a waypoint is being moved.
+
 ### Custom styles
 
 LikeC4Diagram uses [PandaCSS](https://panda-css.com) for styling. You can use it to customize the styles.

--- a/packages/diagram/src/context/NodeConnectionBoundary.public.spec.ts
+++ b/packages/diagram/src/context/NodeConnectionBoundary.public.spec.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest'
+import { useNodeConnectionBoundaryResolver as publicHook } from '../index'
+import { useNodeConnectionBoundaryResolver as internalHook } from './NodeConnectionBoundary'
+
+describe('useNodeConnectionBoundaryResolver public API', () => {
+  it('exports the boundary resolver hook from the package root', () => {
+    expect(publicHook).toBe(internalHook)
+  })
+})

--- a/packages/diagram/src/context/NodeConnectionBoundary.tsx
+++ b/packages/diagram/src/context/NodeConnectionBoundary.tsx
@@ -1,0 +1,57 @@
+import type { PropsWithChildren } from 'react'
+import { createContext, useContext } from 'react'
+
+export type NodeConnectionBoundaryEnd = 'source' | 'target'
+
+export interface NodeConnectionBoundaryRequest {
+  /** React Flow id of the node whose boundary is being resolved. */
+  nodeId: string
+  /** Measured node bounds in diagram coordinates. */
+  nodeBounds: Readonly<{
+    x: number
+    y: number
+    width: number
+    height: number
+  }>
+  /** Adjacent route point that the relationship travels toward. */
+  toward: Readonly<{
+    x: number
+    y: number
+  }>
+  /** Whether the node is the relationship's source or target. */
+  end: NodeConnectionBoundaryEnd
+}
+
+/**
+ * Resolves where a relationship attaches to a custom-rendered node.
+ *
+ * Return `null` or `undefined` to use LikeC4's default node boundary.
+ */
+export type NodeConnectionBoundaryResolver = (
+  request: NodeConnectionBoundaryRequest,
+) => { x: number; y: number } | null | undefined
+
+const NodeConnectionBoundaryContext = createContext<NodeConnectionBoundaryResolver | null>(null)
+
+/**
+ * Provides custom relationship attachment points for descendant diagrams.
+ *
+ * Use this with custom node renderers whose visible boundary differs from the
+ * node's measured rectangular bounds.
+ */
+export function NodeConnectionBoundaryProvider({
+  children,
+  resolver,
+}: PropsWithChildren<{
+  resolver: NodeConnectionBoundaryResolver | null
+}>) {
+  return (
+    <NodeConnectionBoundaryContext.Provider value={resolver}>
+      {children}
+    </NodeConnectionBoundaryContext.Provider>
+  )
+}
+
+export function useNodeConnectionBoundaryResolver(): NodeConnectionBoundaryResolver | null {
+  return useContext(NodeConnectionBoundaryContext)
+}

--- a/packages/diagram/src/context/index.ts
+++ b/packages/diagram/src/context/index.ts
@@ -10,4 +10,13 @@ export type { EnabledFeatures } from './DiagramFeatures'
 export { EnsureMantine } from './EnsureMantine'
 export { FramerMotionConfig } from './FramerMotionConfig'
 export { IconRenderer, IconRendererProvider } from './IconRenderer'
+export {
+  NodeConnectionBoundaryProvider,
+  useNodeConnectionBoundaryResolver,
+} from './NodeConnectionBoundary'
+export type {
+  NodeConnectionBoundaryEnd,
+  NodeConnectionBoundaryRequest,
+  NodeConnectionBoundaryResolver,
+} from './NodeConnectionBoundary'
 export { useRootContainer, useRootContainerElement, useRootContainerRef } from './RootContainerContext'

--- a/packages/diagram/src/index.ts
+++ b/packages/diagram/src/index.ts
@@ -12,6 +12,7 @@ export {
   NodeConnectionBoundaryProvider,
   type NodeConnectionBoundaryRequest,
   type NodeConnectionBoundaryResolver,
+  useNodeConnectionBoundaryResolver,
 } from './context/NodeConnectionBoundary'
 
 export {

--- a/packages/diagram/src/index.ts
+++ b/packages/diagram/src/index.ts
@@ -8,6 +8,13 @@
 export { IconRendererProvider } from './context/IconRenderer'
 
 export {
+  type NodeConnectionBoundaryEnd,
+  NodeConnectionBoundaryProvider,
+  type NodeConnectionBoundaryRequest,
+  type NodeConnectionBoundaryResolver,
+} from './context/NodeConnectionBoundary'
+
+export {
   LikeC4Diagram,
   type LikeC4DiagramProps,
 } from './LikeC4Diagram'

--- a/packages/diagram/src/likec4diagram/custom/edges/relationshipEdgePath.ts
+++ b/packages/diagram/src/likec4diagram/custom/edges/relationshipEdgePath.ts
@@ -1,0 +1,153 @@
+import { nonNullable } from '@likec4/core/utils'
+import type { XYPosition } from '@xyflow/react'
+import { first, last } from 'remeda'
+import type {
+  NodeConnectionBoundaryEnd,
+  NodeConnectionBoundaryRequest,
+  NodeConnectionBoundaryResolver,
+} from '../../../context/NodeConnectionBoundary'
+import { getNodeIntersectionFromCenterToPoint } from '../../../utils/xyflow'
+import type { Types } from '../../types'
+
+type NodeBounds = NodeConnectionBoundaryRequest['nodeBounds']
+
+export function resolveNodeConnectionPoint(
+  resolver: NodeConnectionBoundaryResolver | null,
+  nodeId: string,
+  nodeBounds: NodeBounds,
+  toward: XYPosition,
+  end: NodeConnectionBoundaryEnd,
+): XYPosition | null {
+  if (!resolver) {
+    return null
+  }
+  const point = resolver({
+    nodeId,
+    nodeBounds,
+    toward,
+    end,
+  })
+  return point && Number.isFinite(point.x) && Number.isFinite(point.y) ? point : null
+}
+
+export function resolvePersistedPathEndpoints(
+  points: Types.RelationshipEdgeData['points'],
+  resolver: NodeConnectionBoundaryResolver | null,
+  sourceId: string,
+  sourceBounds: NodeBounds,
+  targetId: string,
+  targetBounds: NodeBounds,
+  direction: Types.RelationshipEdgeData['dir'],
+): Types.RelationshipEdgeData['points'] {
+  if (!resolver || points.length < 2) {
+    return points
+  }
+
+  const lastIndex = points.length - 1
+  const sourceIndex = direction === 'back' ? lastIndex : 0
+  const targetIndex = direction === 'back' ? 0 : lastIndex
+  const sourceAdjacentIndex = sourceIndex === 0 ? 1 : lastIndex - 1
+  const targetAdjacentIndex = targetIndex === 0 ? 1 : lastIndex - 1
+  const sourceAdjacent = nonNullable(points[sourceAdjacentIndex])
+  const targetAdjacent = nonNullable(points[targetAdjacentIndex])
+
+  const sourcePoint = resolveNodeConnectionPoint(
+    resolver,
+    sourceId,
+    sourceBounds,
+    { x: sourceAdjacent[0], y: sourceAdjacent[1] },
+    'source',
+  )
+  const targetPoint = resolveNodeConnectionPoint(
+    resolver,
+    targetId,
+    targetBounds,
+    { x: targetAdjacent[0], y: targetAdjacent[1] },
+    'target',
+  )
+
+  if (!sourcePoint && !targetPoint) {
+    return points
+  }
+
+  const resolvedPoints = [...points] as Types.RelationshipEdgeData['points']
+  if (sourcePoint) {
+    const current = nonNullable(points[sourceIndex])
+    const dx = sourcePoint.x - current[0]
+    const dy = sourcePoint.y - current[1]
+    resolvedPoints[sourceIndex] = [sourcePoint.x, sourcePoint.y]
+    resolvedPoints[sourceAdjacentIndex] = [sourceAdjacent[0] + dx, sourceAdjacent[1] + dy]
+  }
+  if (targetPoint) {
+    const current = nonNullable(points[targetIndex])
+    const dx = targetPoint.x - current[0]
+    const dy = targetPoint.y - current[1]
+    resolvedPoints[targetIndex] = [targetPoint.x, targetPoint.y]
+    resolvedPoints[targetAdjacentIndex] = [targetAdjacent[0] + dx, targetAdjacent[1] + dy]
+  }
+  return resolvedPoints
+}
+
+export function resolveControlPointRoute({
+  resolver,
+  sourceId,
+  sourceBounds,
+  sourceDefaultBounds = sourceBounds,
+  sourceCenter,
+  targetId,
+  targetBounds,
+  targetDefaultBounds = targetBounds,
+  targetCenter,
+  controlPoints,
+  direction,
+}: {
+  resolver: NodeConnectionBoundaryResolver | null
+  sourceId: string
+  sourceBounds: NodeBounds
+  sourceDefaultBounds?: NodeBounds
+  sourceCenter: XYPosition
+  targetId: string
+  targetBounds: NodeBounds
+  targetDefaultBounds?: NodeBounds
+  targetCenter: XYPosition
+  controlPoints: XYPosition[]
+  direction: Types.RelationshipEdgeData['dir']
+}): XYPosition[] {
+  const sourceToward = direction === 'back'
+    ? last(controlPoints) ?? targetCenter
+    : first(controlPoints) ?? targetCenter
+  const targetToward = direction === 'back'
+    ? first(controlPoints) ?? sourceCenter
+    : last(controlPoints) ?? sourceCenter
+  const nodeMargin = 6
+  const sourceRoutePoint = resolveNodeConnectionPoint(
+    resolver,
+    sourceId,
+    sourceBounds,
+    sourceToward,
+    'source',
+  ) ?? getNodeIntersectionFromCenterToPoint(sourceDefaultBounds, sourceToward, nodeMargin)
+  const targetRoutePoint = resolveNodeConnectionPoint(
+    resolver,
+    targetId,
+    targetBounds,
+    targetToward,
+    'target',
+  ) ?? getNodeIntersectionFromCenterToPoint(targetDefaultBounds, targetToward, nodeMargin)
+
+  return direction === 'back'
+    ? [
+      targetCenter,
+      targetRoutePoint,
+      ...controlPoints,
+      sourceRoutePoint,
+      sourceCenter,
+    ]
+    : [
+      sourceCenter,
+      sourceRoutePoint,
+      ...controlPoints,
+      targetRoutePoint,
+      targetCenter,
+    ]
+}

--- a/packages/diagram/src/likec4diagram/custom/edges/useRelationshipEdgePath.spec.ts
+++ b/packages/diagram/src/likec4diagram/custom/edges/useRelationshipEdgePath.spec.ts
@@ -1,0 +1,247 @@
+import type { XYPosition } from '@xyflow/react'
+import { describe, expect, it, vi } from 'vitest'
+import type {
+  NodeConnectionBoundaryResolver,
+} from '../../../context/NodeConnectionBoundary'
+import type { Types } from '../../types'
+import {
+  resolveControlPointRoute,
+  resolveNodeConnectionPoint,
+  resolvePersistedPathEndpoints,
+} from './relationshipEdgePath'
+
+const sourceBounds = { x: 0, y: 0, width: 100, height: 100 }
+const targetBounds = { x: 200, y: 0, width: 100, height: 100 }
+
+const forwardPoints = [
+  [100, 50],
+  [130, 50],
+  [170, 50],
+  [200, 50],
+] as Types.RelationshipEdgeData['points']
+
+const boundaryResolver: NodeConnectionBoundaryResolver = ({ end }) =>
+  end === 'source' ? { x: 90, y: 40 } : { x: 210, y: 60 }
+
+describe('resolveNodeConnectionPoint', () => {
+  it('returns a finite custom boundary point', () => {
+    expect(resolveNodeConnectionPoint(
+      boundaryResolver,
+      'source',
+      sourceBounds,
+      { x: 200, y: 50 },
+      'source',
+    )).toEqual({ x: 90, y: 40 })
+  })
+
+  it.each([
+    undefined,
+    null,
+    { x: Number.NaN, y: 0 },
+    { x: 0, y: Number.POSITIVE_INFINITY },
+  ])('falls back for an unusable resolver result: %j', (result) => {
+    const resolver = vi.fn<NodeConnectionBoundaryResolver>(() => result)
+    expect(resolveNodeConnectionPoint(
+      resolver,
+      'source',
+      sourceBounds,
+      { x: 200, y: 50 },
+      'source',
+    )).toBeNull()
+  })
+})
+
+describe('resolvePersistedPathEndpoints', () => {
+  it('preserves the existing path when no custom boundary is resolved', () => {
+    const resolver = vi.fn<NodeConnectionBoundaryResolver>(() => undefined)
+    const resolved = resolvePersistedPathEndpoints(
+      forwardPoints,
+      resolver,
+      'source',
+      sourceBounds,
+      'target',
+      targetBounds,
+      'forward',
+    )
+
+    expect(resolved).toBe(forwardPoints)
+  })
+
+  it('moves forward endpoints and adjacent controls together', () => {
+    const resolver = vi.fn<NodeConnectionBoundaryResolver>(boundaryResolver)
+    const resolved = resolvePersistedPathEndpoints(
+      forwardPoints,
+      resolver,
+      'source',
+      sourceBounds,
+      'target',
+      targetBounds,
+      'forward',
+    )
+
+    expect(resolved).toEqual([
+      [90, 40],
+      [120, 40],
+      [180, 60],
+      [210, 60],
+    ])
+    expect(resolver).toHaveBeenNthCalledWith(1, {
+      nodeId: 'source',
+      nodeBounds: sourceBounds,
+      toward: { x: 130, y: 50 },
+      end: 'source',
+    })
+    expect(resolver).toHaveBeenNthCalledWith(2, {
+      nodeId: 'target',
+      nodeBounds: targetBounds,
+      toward: { x: 170, y: 50 },
+      end: 'target',
+    })
+  })
+
+  it('maps source and target to the correct ends of a backward path', () => {
+    const backwardPoints = [...forwardPoints].reverse() as Types.RelationshipEdgeData['points']
+    const resolver = vi.fn<NodeConnectionBoundaryResolver>(boundaryResolver)
+    const resolved = resolvePersistedPathEndpoints(
+      backwardPoints,
+      resolver,
+      'source',
+      sourceBounds,
+      'target',
+      targetBounds,
+      'back',
+    )
+
+    expect(resolved).toEqual([
+      [210, 60],
+      [180, 60],
+      [120, 40],
+      [90, 40],
+    ])
+    expect(resolver.mock.calls.map(([request]) => request.end)).toEqual(['source', 'target'])
+  })
+})
+
+describe('resolveControlPointRoute', () => {
+  const sourceCenter: XYPosition = { x: 50, y: 50 }
+  const targetCenter: XYPosition = { x: 250, y: 50 }
+
+  it('uses custom boundaries while editing a forward route', () => {
+    const resolver = vi.fn<NodeConnectionBoundaryResolver>(boundaryResolver)
+    const route = resolveControlPointRoute({
+      resolver,
+      sourceId: 'source',
+      sourceBounds,
+      sourceCenter,
+      targetId: 'target',
+      targetBounds,
+      targetCenter,
+      controlPoints: [{ x: 125, y: 20 }, { x: 175, y: 80 }],
+      direction: 'forward',
+    })
+
+    expect(route).toEqual([
+      sourceCenter,
+      { x: 90, y: 40 },
+      { x: 125, y: 20 },
+      { x: 175, y: 80 },
+      { x: 210, y: 60 },
+      targetCenter,
+    ])
+    expect(resolver).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        nodeId: 'source',
+        toward: { x: 125, y: 20 },
+        end: 'source',
+      }),
+    )
+    expect(resolver).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        nodeId: 'target',
+        toward: { x: 175, y: 80 },
+        end: 'target',
+      }),
+    )
+  })
+
+  it('uses the route points adjacent to each node for a backward route', () => {
+    const resolver = vi.fn<NodeConnectionBoundaryResolver>(boundaryResolver)
+    resolveControlPointRoute({
+      resolver,
+      sourceId: 'source',
+      sourceBounds,
+      sourceCenter,
+      targetId: 'target',
+      targetBounds,
+      targetCenter,
+      controlPoints: [{ x: 175, y: 20 }, { x: 125, y: 80 }],
+      direction: 'back',
+    })
+
+    expect(resolver).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        nodeId: 'source',
+        toward: { x: 125, y: 80 },
+        end: 'source',
+      }),
+    )
+    expect(resolver).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        nodeId: 'target',
+        toward: { x: 175, y: 20 },
+        end: 'target',
+      }),
+    )
+  })
+
+  it('uses the standard rectangular boundary when the resolver opts out', () => {
+    const route = resolveControlPointRoute({
+      resolver: () => undefined,
+      sourceId: 'source',
+      sourceBounds,
+      sourceCenter,
+      targetId: 'target',
+      targetBounds,
+      targetCenter,
+      controlPoints: [{ x: 150, y: 50 }],
+      direction: 'forward',
+    })
+
+    expect(route).toEqual([
+      sourceCenter,
+      { x: 106, y: 50 },
+      { x: 150, y: 50 },
+      { x: 194, y: 50 },
+      targetCenter,
+    ])
+  })
+
+  it('passes exact measured bounds while preserving the existing fallback geometry', () => {
+    const resolver = vi.fn<NodeConnectionBoundaryResolver>(() => undefined)
+    const measuredSourceBounds = { x: 0.25, y: 0.5, width: 99.5, height: 100.25 }
+    const route = resolveControlPointRoute({
+      resolver,
+      sourceId: 'source',
+      sourceBounds: measuredSourceBounds,
+      sourceDefaultBounds: sourceBounds,
+      sourceCenter,
+      targetId: 'target',
+      targetBounds,
+      targetCenter,
+      controlPoints: [{ x: 150, y: 50 }],
+      direction: 'forward',
+    })
+
+    expect(resolver).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        nodeBounds: measuredSourceBounds,
+      }),
+    )
+    expect(route[1]).toEqual({ x: 106, y: 50 })
+  })
+})

--- a/packages/diagram/src/likec4diagram/custom/edges/useRelationshipEdgePath.ts
+++ b/packages/diagram/src/likec4diagram/custom/edges/useRelationshipEdgePath.ts
@@ -6,13 +6,19 @@ import { getNodeDimensions } from '@xyflow/system'
 import { curveCatmullRomOpen, line as d3line } from 'd3-shape'
 import { shallowEqual } from 'fast-equals'
 import { useCallback } from 'react'
-import { first, isTruthy, last } from 'remeda'
+import { isTruthy } from 'remeda'
+import {
+  useNodeConnectionBoundaryResolver,
+} from '../../../context/NodeConnectionBoundary'
 import { useXYStore } from '../../../hooks/useXYFlow'
 import {
   bezierPath,
-  getNodeIntersectionFromCenterToPoint,
 } from '../../../utils/xyflow'
 import type { Types } from '../../types'
+import {
+  resolveControlPointRoute,
+  resolvePersistedPathEndpoints,
+} from './relationshipEdgePath'
 
 const curve = d3line<XYPosition>()
   .curve(curveCatmullRomOpen.alpha(0.7))
@@ -39,70 +45,102 @@ export function useRelationshipEdgePath({
   controlPoints: XYPosition[]
   isControlPointDragging: boolean
 }): string {
+  const boundaryResolver = useNodeConnectionBoundaryResolver()
   // Subscribe to mimimal node changes to update edge path when nodes move
   const [
     sourceNodeWidth,
     sourceNodeHeight,
+    sourceNodeX,
+    sourceNodeY,
     targetNodeWidth,
     targetNodeHeight,
+    targetNodeX,
+    targetNodeY,
   ] = useXYStore(
     useCallback(({ nodeLookup }) => {
-      const sourceNode = getNodeDimensions(nonNullable(nodeLookup.get(source), `source node ${source} not found`))
-      const targetNode = getNodeDimensions(nonNullable(nodeLookup.get(target), `target node ${target} not found`))
+      const sourceNode = nonNullable(nodeLookup.get(source), `source node ${source} not found`)
+      const targetNode = nonNullable(nodeLookup.get(target), `target node ${target} not found`)
+      const sourceNodeDimensions = getNodeDimensions(sourceNode)
+      const targetNodeDimensions = getNodeDimensions(targetNode)
       return [
-        Math.ceil(sourceNode.width),
-        Math.ceil(sourceNode.height),
-        Math.ceil(targetNode.width),
-        Math.ceil(targetNode.height),
+        sourceNodeDimensions.width,
+        sourceNodeDimensions.height,
+        sourceNode.internals.positionAbsolute.x,
+        sourceNode.internals.positionAbsolute.y,
+        targetNodeDimensions.width,
+        targetNodeDimensions.height,
+        targetNode.internals.positionAbsolute.x,
+        targetNode.internals.positionAbsolute.y,
       ] as const
     }, [source, target]),
     shallowEqual,
   )
 
-  const isModified = isTruthy(data.controlPoints) || isControlPointDragging
-
-  if (!isModified) {
-    return bezierPath(data.points)
-  }
-
   const sourceCenterPos = vector(sourceX, sourceY).trunc()
   const targetCenterPos = vector(targetX, targetY).trunc()
-
-  const sourceNd = {
-    // Calculate node top-left from center position
-    ...sourceCenterPos
-      .subtract(vector(sourceNodeWidth, sourceNodeHeight).divide(2))
-      .trunc()
-      .toObject(),
+  const sourceBounds = {
+    x: sourceNodeX,
+    y: sourceNodeY,
     width: sourceNodeWidth,
     height: sourceNodeHeight,
   }
-  const targetNd = {
-    // Calculate node top-left from center position
-    ...targetCenterPos
-      .subtract(vector(targetNodeWidth, targetNodeHeight).divide(2))
-      .trunc()
-      .toObject(),
+  const targetBounds = {
+    x: targetNodeX,
+    y: targetNodeY,
     width: targetNodeWidth,
     height: targetNodeHeight,
   }
+  const isModified = isTruthy(data.controlPoints) || isControlPointDragging
 
-  const nodeMargin = 6
-  const points = data.dir === 'back'
-    ? [
-      targetCenterPos,
-      getNodeIntersectionFromCenterToPoint(targetNd, first(controlPoints) ?? sourceCenterPos, nodeMargin),
-      ...controlPoints,
-      getNodeIntersectionFromCenterToPoint(sourceNd, last(controlPoints) ?? targetCenterPos, nodeMargin),
-      sourceCenterPos,
-    ]
-    : [
-      sourceCenterPos,
-      getNodeIntersectionFromCenterToPoint(sourceNd, first(controlPoints) ?? targetCenterPos, nodeMargin),
-      ...controlPoints,
-      getNodeIntersectionFromCenterToPoint(targetNd, last(controlPoints) ?? sourceCenterPos, nodeMargin),
-      targetCenterPos,
-    ]
+  if (!isModified) {
+    if (boundaryResolver) {
+      const resolvedPoints = resolvePersistedPathEndpoints(
+        data.points,
+        boundaryResolver,
+        source,
+        sourceBounds,
+        target,
+        targetBounds,
+        data.dir,
+      )
+      if (resolvedPoints !== data.points) {
+        return bezierPath(resolvedPoints)
+      }
+    }
+    return bezierPath(data.points)
+  }
+
+  // Preserve the existing rectangular fallback, including its rounding.
+  const sourceDefaultBounds = {
+    ...sourceCenterPos
+      .subtract(vector(Math.ceil(sourceNodeWidth), Math.ceil(sourceNodeHeight)).divide(2))
+      .trunc()
+      .toObject(),
+    width: Math.ceil(sourceNodeWidth),
+    height: Math.ceil(sourceNodeHeight),
+  }
+  const targetDefaultBounds = {
+    ...targetCenterPos
+      .subtract(vector(Math.ceil(targetNodeWidth), Math.ceil(targetNodeHeight)).divide(2))
+      .trunc()
+      .toObject(),
+    width: Math.ceil(targetNodeWidth),
+    height: Math.ceil(targetNodeHeight),
+  }
+
+  const points = resolveControlPointRoute({
+    resolver: boundaryResolver,
+    sourceId: source,
+    sourceBounds,
+    sourceDefaultBounds,
+    sourceCenter: sourceCenterPos,
+    targetId: target,
+    targetBounds,
+    targetDefaultBounds,
+    targetCenter: targetCenterPos,
+    controlPoints,
+    direction: data.dir,
+  })
 
   return nonNullable(curve(points))
 }


### PR DESCRIPTION
Fixes #3185

## Summary

- add a public `NodeConnectionBoundaryProvider` and resolver API for custom node renderers
- apply custom attachment points to generated paths and manually edited routes, including waypoint movement
- preserve existing rectangular routing when the resolver opts out or returns an invalid point
- document the API with a circular-node example

## Checklist

- [x] I have thoroughly read the latest [contribution guidelines](https://github.com/likec4/likec4/blob/main/CONTRIBUTING.md).
- [x] I have rebased my branch onto `main` **before** creating this PR.
- [x] I have added tests to cover my changes.
- [x] I have verified `pnpm typecheck` and `pnpm test`.
- [x] I have added a changeset.
- [x] My change requires documentation updates.
- [x] I have updated the documentation accordingly.