### PR TITLE
feat(diagram): expose manual layout controller

### DIFF
--- a/.changeset/expose-manual-layout-controller.md
+++ b/.changeset/expose-manual-layout-controller.md
@@ -1,0 +1,5 @@
+---
+'@likec4/diagram': patch
+---
+
+Expose the built-in manual-layout comparison state and actions to custom viewers.

--- a/packages/diagram/README.md
+++ b/packages/diagram/README.md
@@ -296,7 +296,10 @@ function LayoutControls() {
         {state.isActive ? 'Stop comparing' : 'Compare with latest'}
       </button>
       <button
-        disabled={state.layout === 'auto' || !state.canApplyLatest}
+        disabled={state.layout === 'auto' ||
+          !state.canApplyLatest ||
+          !state.hasEditor ||
+          !state.isEditable}
         onClick={actions.applyLatestToManual}
       >
         Apply latest

--- a/packages/diagram/README.md
+++ b/packages/diagram/README.md
@@ -272,6 +272,56 @@ function App() {
 }
 ```
 
+### Manual layout controls
+
+Use `useDiagramCompareLayout` in a component rendered inside `LikeC4Diagram`
+to place the built-in manual-layout behavior in custom application chrome. The
+hook provides comparison availability and activity, drift reasons, the current
+layout type, whether the latest model can be applied, and the corresponding
+actions.
+
+```tsx
+import { LikeC4Diagram, useDiagramCompareLayout } from '@likec4/diagram'
+
+function LayoutControls() {
+  const [state, actions] = useDiagramCompareLayout()
+
+  if (!state.isEnabled) {
+    return null
+  }
+
+  return (
+    <div>
+      <button onClick={() => actions.toggleCompare()}>
+        {state.isActive ? 'Stop comparing' : 'Compare with latest'}
+      </button>
+      <button
+        disabled={state.layout === 'auto' || !state.canApplyLatest}
+        onClick={actions.applyLatestToManual}
+      >
+        Apply latest
+      </button>
+      <button onClick={actions.resetManualLayout}>Reset manual layout</button>
+    </div>
+  )
+}
+
+function App() {
+  return (
+    <LikeC4Diagram
+      view={view}
+      onLayoutTypeChange={setLayoutType}
+    >
+      <LayoutControls />
+    </LikeC4Diagram>
+  )
+}
+```
+
+The hook reuses the same controller as LikeC4's built-in compare panel. It
+requires comparison to be enabled for the diagram and an editor provider for
+actions that modify a saved manual layout.
+
 ## Customization
 
 ### Custom node renderer

--- a/packages/diagram/src/hooks/useDiagramCompareLayout.public.spec.ts
+++ b/packages/diagram/src/hooks/useDiagramCompareLayout.public.spec.ts
@@ -1,6 +1,10 @@
 import type { LayoutedViewDriftReason } from '@likec4/core/types'
-import { describe, expect, it } from 'vitest'
-import { useDiagramCompareLayout as publicHook } from '../index'
+import { describe, expect, expectTypeOf, it } from 'vitest'
+import {
+  type DiagramCompareLayoutOps,
+  type DiagramCompareLayoutState,
+  useDiagramCompareLayout as publicHook,
+} from '../index'
 import type { DiagramActorSnapshot } from '../likec4diagram/state/types'
 import {
   selectCompareLayoutState,
@@ -36,6 +40,10 @@ const snapshot = ({
 describe('useDiagramCompareLayout public API', () => {
   it('exports the built-in manual-layout controller from the package root', () => {
     expect(publicHook).toBe(internalHook)
+    expectTypeOf<ReturnType<typeof publicHook>>().toEqualTypeOf<[
+      DiagramCompareLayoutState,
+      DiagramCompareLayoutOps,
+    ]>()
   })
 
   it('returns null drifts when comparison is unavailable', () => {

--- a/packages/diagram/src/hooks/useDiagramCompareLayout.public.spec.ts
+++ b/packages/diagram/src/hooks/useDiagramCompareLayout.public.spec.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest'
+import { useDiagramCompareLayout as publicHook } from '../index'
+import { useDiagramCompareLayout as internalHook } from './useDiagramCompareLayout'
+
+describe('useDiagramCompareLayout public API', () => {
+  it('exports the built-in manual-layout controller from the package root', () => {
+    expect(publicHook).toBe(internalHook)
+  })
+})

--- a/packages/diagram/src/hooks/useDiagramCompareLayout.public.spec.ts
+++ b/packages/diagram/src/hooks/useDiagramCompareLayout.public.spec.ts
@@ -1,9 +1,66 @@
+import type { LayoutedViewDriftReason } from '@likec4/core/types'
 import { describe, expect, it } from 'vitest'
 import { useDiagramCompareLayout as publicHook } from '../index'
-import { useDiagramCompareLayout as internalHook } from './useDiagramCompareLayout'
+import type { DiagramActorSnapshot } from '../likec4diagram/state/types'
+import {
+  selectCompareLayoutState,
+  useDiagramCompareLayout as internalHook,
+} from './useDiagramCompareLayout'
+
+const snapshot = ({
+  drifts,
+  compareEnabled,
+}: {
+  drifts: readonly [LayoutedViewDriftReason, ...LayoutedViewDriftReason[]] | null
+  compareEnabled: boolean
+}) =>
+  ({
+    context: {
+      activeWalkthrough: null,
+      features: {
+        enableCompareWithLatest: true,
+        enableEditor: true,
+        enableReadOnly: false,
+      },
+      toggledFeatures: {
+        enableCompareWithLatest: compareEnabled,
+        enableReadOnly: false,
+      },
+      view: {
+        _layout: 'manual',
+        drifts,
+      },
+    },
+  }) as DiagramActorSnapshot
 
 describe('useDiagramCompareLayout public API', () => {
   it('exports the built-in manual-layout controller from the package root', () => {
     expect(publicHook).toBe(internalHook)
+  })
+
+  it('returns null drifts when comparison is unavailable', () => {
+    const state = selectCompareLayoutState(snapshot({
+      drifts: null,
+      compareEnabled: false,
+    }))
+
+    expect(state.isEnabled).toBe(false)
+    if (!state.isEnabled) {
+      const drifts: null = state.drifts
+      expect(drifts).toBeNull()
+    }
+  })
+
+  it('returns non-empty drifts when comparison is available', () => {
+    const state = selectCompareLayoutState(snapshot({
+      drifts: ['nodes-added'],
+      compareEnabled: true,
+    }))
+
+    expect(state.isEnabled).toBe(true)
+    if (state.isEnabled) {
+      const drifts: readonly [LayoutedViewDriftReason, ...LayoutedViewDriftReason[]] = state.drifts
+      expect(drifts).toEqual(['nodes-added'])
+    }
   })
 })

--- a/packages/diagram/src/hooks/useDiagramCompareLayout.ts
+++ b/packages/diagram/src/hooks/useDiagramCompareLayout.ts
@@ -55,8 +55,14 @@ const selectCompareLayoutState = ({ context }: DiagramActorSnapshot): {
   })
 }
 
+/**
+ * Current manual-layout comparison state exposed by {@link useDiagramCompareLayout}.
+ */
 export type DiagramCompareLayoutState = ReturnType<typeof selectCompareLayoutState>
 
+/**
+ * Manual-layout actions exposed by {@link useDiagramCompareLayout}.
+ */
 export type DiagramCompareLayoutOps = {
   /**
    * Toggles the compare mode on or off.
@@ -78,6 +84,11 @@ export type DiagramCompareLayoutOps = {
   resetManualLayout: () => void
 }
 
+/**
+ * Controls LikeC4's manual-layout comparison from custom diagram children.
+ *
+ * The hook must be called by a component rendered inside {@link LikeC4Diagram}.
+ */
 export function useDiagramCompareLayout(): [
   DiagramCompareLayoutState,
   DiagramCompareLayoutOps,

--- a/packages/diagram/src/hooks/useDiagramCompareLayout.ts
+++ b/packages/diagram/src/hooks/useDiagramCompareLayout.ts
@@ -9,12 +9,12 @@ import type {
 import { useDiagramActorRef } from './safeContext'
 import { useCallbackRef } from './useCallbackRef'
 
-const selectCompareLayoutState = ({ context }: DiagramActorSnapshot): {
+export const selectCompareLayoutState = ({ context }: DiagramActorSnapshot): {
   isEnabled: false
   hasEditor: false
   isEditable: false
   isActive: false
-  drifts: never
+  drifts: null
   canApplyLatest: boolean
   layout: t.LayoutType
 } | {
@@ -33,7 +33,7 @@ const selectCompareLayoutState = ({ context }: DiagramActorSnapshot): {
       isEnabled: false as const,
       isEditable: false as const,
       isActive: false as const,
-      drifts: null as never,
+      drifts: null,
       canApplyLatest: false,
       layout: context.view._layout ?? 'auto',
     })

--- a/packages/diagram/src/index.ts
+++ b/packages/diagram/src/index.ts
@@ -62,6 +62,12 @@ export {
 } from './hooks/useDiagram'
 
 export {
+  type DiagramCompareLayoutOps,
+  type DiagramCompareLayoutState,
+  useDiagramCompareLayout,
+} from './hooks/useDiagramCompareLayout'
+
+export {
   useLikeC4Model,
   useLikeC4Specification,
   useLikeC4ViewModel,


### PR DESCRIPTION
Fixes #3186

## Summary

- export the existing `useDiagramCompareLayout` controller and its state/action types from `@likec4/diagram`
- let custom diagram children reuse the same compare, switch, Apply Latest, and reset behavior as the built-in viewer
- document custom controls and add a package-export contract test

This does not introduce a second controller or change the layout state machine; it makes the built-in controller public.

## Checklist

- [x] I have thoroughly read the latest [contribution guidelines](https://github.com/likec4/likec4/blob/main/CONTRIBUTING.md).
- [x] I have rebased my branch onto `main` **before** creating this PR.
- [x] I have added tests to cover my changes.
- [x] I have verified `pnpm typecheck` and `pnpm test`.
- [x] I have added a changeset.
- [x] My change requires documentation updates.
- [x] I have updated the documentation accordingly.