### PR TITLE
fix: specify tag color by name

### DIFF
--- a/apps/docs/src/content/docs/dsl/specification.mdx
+++ b/apps/docs/src/content/docs/dsl/specification.mdx
@@ -104,7 +104,11 @@ You can assign colors:
 ```likec4
 specification {
   tag deprecated {
-    color #FF0000 // or `rgb(255 0 0)` see below
+    color gray
+  }
+
+  tag team2 {
+    color #AABBCC // or using rgb/rgba (see below)
   }
 }
 ```

--- a/packages/core/src/styles/LikeC4Styles.ts
+++ b/packages/core/src/styles/LikeC4Styles.ts
@@ -18,6 +18,7 @@ import { styleDefaults } from './defaults'
 import { defaultTheme } from './theme'
 import type {
   ColorLiteral,
+  CustomColor,
   CustomColorDefinitions,
   ElementColorValues,
   IconSize,
@@ -249,7 +250,7 @@ export class LikeC4Styles {
   /**
    * Get color values for a tag (including default tag colors)
    */
-  tagColor(tag: typeof DefaultTagColors[number] | ThemeColor | ColorLiteral): ThemeColorValues['elements'] {
+  tagColor(tag: typeof DefaultTagColors[number] | ThemeColor | CustomColor | ColorLiteral): ThemeColorValues['elements'] {
     if (this.isThemeColor(tag)) {
       return this.theme.colors[tag].elements
     }

--- a/packages/core/src/types/model-spec.ts
+++ b/packages/core/src/types/model-spec.ts
@@ -3,6 +3,7 @@ import type {
   BorderStyle,
   Color,
   ColorLiteral,
+  CustomColor,
   CustomColorDefinitions,
   ElementShape,
   IconPosition,
@@ -53,7 +54,7 @@ export interface ElementSpecification {
 }
 
 export interface TagSpecification {
-  color: ThemeColor | ColorLiteral
+  color: ThemeColor | CustomColor | ColorLiteral
 }
 
 /**

--- a/packages/diagram/src/context/TagStylesContext.tsx
+++ b/packages/diagram/src/context/TagStylesContext.tsx
@@ -6,7 +6,7 @@ import { entries, flatMap, isEmpty, join, pipe } from 'remeda'
 import { useLikeC4Specification } from '../hooks/useLikeC4Model'
 import { useLikeC4Styles } from '../hooks/useLikeC4Styles'
 
-const radixColors = DefaultTagColors as unknown as string[]
+const radixColors: readonly string[] = DefaultTagColors
 
 export function generateColorVars(spec: TagSpecification, styles: LikeC4Styles = LikeC4Styles.DEFAULT): string {
   const color = spec.color

--- a/packages/diagram/src/context/TagStylesContext.tsx
+++ b/packages/diagram/src/context/TagStylesContext.tsx
@@ -1,14 +1,14 @@
 import { type TagSpecification, isTagColorSpecified } from '@likec4/core'
-import { DefaultTagColors } from '@likec4/core/styles'
-import { getContrastedColorsAPCA, isValidColor } from '@likec4/core/styles'
+import { DefaultTagColors, getContrastedColorsAPCA, isValidColor, LikeC4Styles } from '@likec4/core/styles'
 import { useMantineStyleNonce } from '@mantine/core'
 import { type PropsWithChildren, createContext, memo, useContext } from 'react'
 import { entries, flatMap, isEmpty, join, pipe } from 'remeda'
 import { useLikeC4Specification } from '../hooks/useLikeC4Model'
+import { useLikeC4Styles } from '../hooks/useLikeC4Styles'
 
 const radixColors = DefaultTagColors as unknown as string[]
 
-export function generateColorVars(spec: TagSpecification): string {
+export function generateColorVars(spec: TagSpecification, styles: LikeC4Styles = LikeC4Styles.DEFAULT): string {
   const color = spec.color
   // Tag has a color defined in the specification — derive a high-contrast text
   // color from it (APCA) so the chip text stays legible on any background.
@@ -22,24 +22,38 @@ export function generateColorVars(spec: TagSpecification): string {
       --colors-likec4-tag-text: ${text};
     `
   }
-  if (!radixColors.includes(color)) {
-    return ''
+  if (radixColors.includes(color)) {
+    let textcolor = `var(--colors-${color}-12)`
+    if (['mint', 'grass', 'lime', 'yellow', 'amber'].includes(color)) {
+      textcolor = 'rgba(0 0 0 / 0.85)'
+    }
+    return `
+    --colors-likec4-tag-border: var(--colors-${color}-8);
+    --colors-likec4-tag-bg: var(--colors-${color}-9);
+    --colors-likec4-tag-bg-hover: var(--colors-${color}-10);
+    --colors-likec4-tag-text: ${textcolor};
+    `
   }
-  let textcolor = `var(--colors-${color}-12)`
-  if (['mint', 'grass', 'lime', 'yellow', 'amber'].includes(color)) {
-    textcolor = 'rgba(0 0 0 / 0.85)'
+  // Theme color (e.g. `primary`, `secondary`) or a project-defined custom color —
+  // resolve to actual literal values via the project's LikeC4Styles.
+  if (styles.isThemeColor(color)) {
+    const { fill, hiContrast } = styles.tagColor(color)
+    return `
+    --colors-likec4-tag-bg: ${fill};
+    --colors-likec4-tag-bg-hover: color-mix(in oklab, ${fill}, var(--colors-likec4-mix-color) 20%);
+    --colors-likec4-tag-text: ${hiContrast};
+    `
   }
-  return `
-  --colors-likec4-tag-border: var(--colors-${color}-8);
-  --colors-likec4-tag-bg: var(--colors-${color}-9);
-  --colors-likec4-tag-bg-hover: var(--colors-${color}-10);
-  --colors-likec4-tag-text: ${textcolor};
-  `
+  return ''
 }
 
 const TagStylesContext = createContext<Record<string, TagSpecification>>({})
 
-function generateStylesheet(tags: Record<string, TagSpecification> | undefined, rootSelector: string) {
+function generateStylesheet(
+  tags: Record<string, TagSpecification> | undefined,
+  rootSelector: string,
+  styles: LikeC4Styles,
+) {
   if (!tags || isEmpty(tags)) {
     return ''
   }
@@ -47,7 +61,7 @@ function generateStylesheet(tags: Record<string, TagSpecification> | undefined, 
     entries(tags),
     flatMap(([tag, spec]) => [
       `:is(${rootSelector} [data-likec4-tag="${tag}"]) {`,
-      generateColorVars(spec),
+      generateColorVars(spec, styles),
       '}',
     ]),
     join('\n'),
@@ -56,8 +70,9 @@ function generateStylesheet(tags: Record<string, TagSpecification> | undefined, 
 
 export function TagStylesProvider({ children, id }: PropsWithChildren<{ id: string }>) {
   const tags = useLikeC4Specification().tags
+  const styles = useLikeC4Styles()
   const nonce = useMantineStyleNonce()?.()
-  const stylesheet = generateStylesheet(tags, `#${id}`)
+  const stylesheet = generateStylesheet(tags, `#${id}`, styles)
 
   return (
     <>

--- a/packages/generators/src/likec4/__snapshots__/likec4.generate.snap
+++ b/packages/generators/src/likec4/__snapshots__/likec4.generate.snap
@@ -30,8 +30,12 @@ specification {
     line dotted
   }
   
-  tag external
-  tag internal
+  tag external {
+    color tomato
+  }
+  tag internal {
+    color grass
+  }
 }
 
 model {

--- a/packages/generators/src/likec4/operators/__snapshots__/likec4.generate.snap
+++ b/packages/generators/src/likec4/operators/__snapshots__/likec4.generate.snap
@@ -30,8 +30,12 @@ specification {
     line dotted
   }
   
-  tag external
-  tag internal
+  tag external {
+    color tomato
+  }
+  tag internal {
+    color grass
+  }
 }
 
 model {

--- a/packages/generators/src/likec4/schemas/specification.ts
+++ b/packages/generators/src/likec4/schemas/specification.ts
@@ -38,11 +38,7 @@ export const relationship = z
 
 export const tagSpec = z
   .object({
-    color: z
-      .string()
-      .regex(/^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/)
-      .optional()
-      .catch(undefined),
+    color: common.color.nullable(),
   })
   .partial()
   .transform(pickBy(isNonNullish))

--- a/packages/language-server/src/ast.ts
+++ b/packages/language-server/src/ast.ts
@@ -70,7 +70,7 @@ export type ParsedElementStyle = {
 export interface ParsedAstSpecification {
   tags: Record<c4.Tag, {
     astPath: string
-    color?: c4.ColorLiteral
+    color?: c4.TagSpecification['color']
   }>
   elements: Record<c4.ElementKind, c4.ElementSpecification>
   relationships: Record<c4.RelationshipKind, c4.RelationshipSpecification>
@@ -381,7 +381,9 @@ export function toRelationshipStyle(props: ast.RelationshipStyleProperty[] | und
   return result
 }
 
-export function toColor(astNode: ast.ColorProperty | ast.IconColorProperty): c4.Color | undefined {
+export function toColor(
+  astNode: ast.ColorProperty | ast.IconColorProperty | ast.SpecificationTag,
+): c4.Color | undefined {
   return astNode?.themeColor ?? (astNode?.customColor?.$refText as (c4.CustomColor | undefined))
 }
 

--- a/packages/language-server/src/like-c4.langium
+++ b/packages/language-server/src/like-c4.langium
@@ -73,7 +73,7 @@ SpecificationDeploymentNodeKind:
 
 SpecificationTag:
   'tag' tag=Tag ('{'
-    ('color' color=ColorLiteral)?
+    ('color' (ColorRef | color=ColorLiteral))?
   '}')?;
 
 SpecificationColor:
@@ -981,8 +981,12 @@ type FqnReferenceable = Referenceable | Element | ExtendElement | ExtendDeployme
 
 LinkProperty:
   key='link' ':'? value=Uri title=String? ';'?;
+
+fragment ColorRef:
+  themeColor=ThemeColor | customColor=[CustomColor:CustomColorId];
+
 ColorProperty:
-  key='color' ':'? (themeColor=ThemeColor | customColor=[CustomColor:CustomColorId]) ';'?;
+  key='color' ':'? ColorRef ';'?;
 
 OpacityProperty:
   key='opacity' ':'? value=Percent ';'?;
@@ -995,7 +999,7 @@ IconProperty:
   key='icon' ':'? (libicon=[LibIcon:IconId] | value=('none'|Uri)) ';'?;
 
 IconColorProperty:
-  key='iconColor' ':'? (themeColor=ThemeColor | customColor=[CustomColor:CustomColorId]) ';'?;
+  key='iconColor' ':'? ColorRef ';'?;
 
 IconSizeProperty:
   key='iconSize' ':'? value=SizeValue ';'?;

--- a/packages/language-server/src/lsp/SemanticTokenProvider.ts
+++ b/packages/language-server/src/lsp/SemanticTokenProvider.ts
@@ -221,8 +221,14 @@ export class LikeC4SemanticTokenProvider extends AbstractSemanticTokenProvider {
       mark.property('name').readonly.declaration.type()
     })
     when(ast.isSpecificationTag, mark => {
-      if (isTruthy(mark.node.color)) {
+      if (isTruthy(mark.node.color) || isTruthy(mark.node.themeColor) || isTruthy(mark.node.customColor)) {
         mark.keyword('color').property()
+      }
+      if (isTruthy(mark.node.customColor)) {
+        mark.property('customColor').enum()
+      }
+      if (isTruthy(mark.node.themeColor)) {
+        mark.property('themeColor').enum()
       }
     })
     when(

--- a/packages/language-server/src/model/__tests__/model-builder-custom-colors.spec.ts
+++ b/packages/language-server/src/model/__tests__/model-builder-custom-colors.spec.ts
@@ -192,4 +192,37 @@ describe('LikeC4ModelBuilder - Custom Colors', () => {
     expect(indexView).toBeDefined()
     expect(indexView.nodes.find(n => n.id === 'sys1')?.color).toBe('custom-color1')
   })
+
+  it('allows theme and custom colors in tag specification', async ({ expect }) => {
+    const { validate, buildModel } = createTestServices()
+    const { errors, warnings } = await validate(`
+      specification {
+        color custom-color1 #FF00FF
+
+        tag themed {
+          color primary
+        }
+        tag customized {
+          color custom-color1
+        }
+        tag literal {
+          color #3094FEB9
+        }
+      }
+    `)
+    expect(errors).toEqual([])
+    expect(warnings).toEqual([])
+    const model = await buildModel()
+    expect(model.specification.tags).toEqual({
+      themed: {
+        color: 'primary',
+      },
+      customized: {
+        color: 'custom-color1',
+      },
+      literal: {
+        color: '#3094FEB9',
+      },
+    })
+  })
 })

--- a/packages/language-server/src/model/parser/SpecificationParser.ts
+++ b/packages/language-server/src/model/parser/SpecificationParser.ts
@@ -2,7 +2,7 @@ import * as c4 from '@likec4/core'
 import { exact } from '@likec4/core'
 import { nonNullable } from '@likec4/core/utils'
 import { filter, isTruthy, mapToObj, pipe } from 'remeda'
-import { ast, parseMarkdownAsString, toRelationshipStyle } from '../../ast'
+import { ast, parseMarkdownAsString, toColor, toRelationshipStyle } from '../../ast'
 import { type Base, removeIndent } from './Base'
 
 export function SpecificationParser<TBase extends Base>(B: TBase) {
@@ -83,7 +83,7 @@ export function SpecificationParser<TBase extends Base>(B: TBase) {
         try {
           const tag = tagSpec.tag.name as c4.Tag
           const astPath = this.getAstNodePath(tagSpec.tag)
-          const color = tagSpec.color && this.parseColorLiteral(tagSpec.color)
+          const color = toColor(tagSpec) ?? (tagSpec.color && this.parseColorLiteral(tagSpec.color))
           if (tag in c4Specification.tags) {
             this.logError(`Tag ${tag} is already defined, skipping duplicate`, tagSpec, 'specification')
             continue

--- a/packages/vscode/src/meta.ts
+++ b/packages/vscode/src/meta.ts
@@ -4,7 +4,7 @@
 // Meta info
 export const publisher = "likec4"
 export const name = "likec4-vscode"
-export const version = "1.59.0"
+export const version = "1.59.2"
 export const displayName = "LikeC4"
 export const description = "Support for the LikeC4 modeling language"
 export const extensionId = `${publisher}.${name}`

--- a/packages/vscode/src/meta.ts
+++ b/packages/vscode/src/meta.ts
@@ -4,7 +4,7 @@
 // Meta info
 export const publisher = "likec4"
 export const name = "likec4-vscode"
-export const version = "1.59.2"
+export const version = '1.59.2'
 export const displayName = "LikeC4"
 export const description = "Support for the LikeC4 modeling language"
 export const extensionId = `${publisher}.${name}`


### PR DESCRIPTION
This commit fixes bug #3191 by allowing tag colors by name in addition to hexadecimal/rgb/rgba in the specification.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask, and propose improvements. We're here to help. -->

- [x] I've thoroughly read the latest [contribution guidelines](https://github.com/likec4/likec4/blob/main/CONTRIBUTING.md).
- [x] I've rebased my branch onto `main` **before** creating this PR.
- [x] I've added tests to cover my changes (if applicable).
- [x] I've verified `pnpm typecheck` and `pnpm test`.
- [ ] I've added [changesets](https://changesets-docs.vercel.app/) (you can use `/changeset-generator` SKILL).
- [x] My change requires documentation updates.
- [x] I've updated the documentation accordingly (or will do in follow-up PR).
