### PR TITLE
fix(spa): fix theme search param validation for exports (#3181)

### DIFF
--- a/.changeset/fix-theme-search-param.md
+++ b/.changeset/fix-theme-search-param.md
@@ -1,0 +1,5 @@
+---
+"likec4": patch
+---
+
+Fix `--theme light` and `--theme dark` export flag not applying the requested theme in PNG and JPEG diagram exports.

--- a/packages/likec4-spa/src/searchParams.spec.ts
+++ b/packages/likec4-spa/src/searchParams.spec.ts
@@ -1,5 +1,26 @@
 import { describe, expect, it } from 'vitest'
-import { resolveForceColorScheme } from './searchParams'
+import { resolveForceColorScheme, searchParamsSchema } from './searchParams'
+
+describe('searchParamsSchema', () => {
+  it('should parse valid theme options', () => {
+    expect(searchParamsSchema.parse({ theme: 'light' }).theme).toBe('light')
+    expect(searchParamsSchema.parse({ theme: 'dark' }).theme).toBe('dark')
+    expect(searchParamsSchema.parse({ theme: 'auto' }).theme).toBe('auto')
+  })
+
+  it('should fallback to undefined for invalid or missing theme', () => {
+    expect(searchParamsSchema.parse({ theme: 'invalid' }).theme).toBeUndefined()
+    expect(searchParamsSchema.parse({}).theme).toBeUndefined()
+  })
+
+  it('should parse default search params', () => {
+    const parsed = searchParamsSchema.parse({})
+    expect(parsed.dynamic).toBe('diagram')
+    expect(parsed.padding).toBe(20)
+    expect(parsed.relationships).toBeUndefined()
+    expect(parsed.focusOnElement).toBeUndefined()
+  })
+})
 
 describe('resolveForceColorScheme', () => {
   it('should force light/dark and pass through auto/undefined', () => {

--- a/packages/likec4-spa/src/searchParams.ts
+++ b/packages/likec4-spa/src/searchParams.ts
@@ -2,7 +2,7 @@ import type { Fqn } from '@likec4/core/types'
 import { z } from 'zod'
 
 export const searchParamsSchema = z.object({
-  theme: z.literal(['light', 'dark', 'auto'])
+  theme: z.enum(['light', 'dark', 'auto'])
     .optional()
     .catch(undefined),
   dynamic: z.enum(['diagram', 'sequence'])


### PR DESCRIPTION
Fixes #3181

## Summary
Fixes an issue where `likec4 export png --theme light` (and `--theme dark`) produced dark-themed diagrams despite the CLI passing the `theme` query parameter.

### Root Cause
In `packages/likec4-spa/src/searchParams.ts`, the `theme` schema was defined as `z.literal(['light', 'dark', 'auto'])` instead of `z.enum(['light', 'dark', 'auto'])`. 

In Zod, `z.literal([...])` validates that the input matches the array instance itself (by reference equality) rather than validating that a string is one of the enum values. When query strings like `?theme=light` were parsed, validation failed and fell back to `undefined` via `.catch(undefined)`. As a consequence, `resolveForceColorScheme(undefined)` returned `undefined` and Mantine's color scheme was not forced to `light`.

### Changes
- Changed `z.literal(['light', 'dark', 'auto'])` to `z.enum(['light', 'dark', 'auto'])` in `packages/likec4-spa/src/searchParams.ts`.
- Added unit tests in `packages/likec4-spa/src/searchParams.spec.ts` covering `searchParamsSchema` with valid themes (`'light'`, `'dark'`, `'auto'`), invalid fallback behavior, and default values.
- Added patch changeset targeting `likec4`.

### Verification
- **Unit Tests**: `pnpm --filter @likec4/spa test` (all 36 tests passed) and `pnpm --filter likec4 test` (all 57 tests passed).
- **Typecheck**: `pnpm typecheck` passed (26/26 tasks cleanly).
- **Linter**: `pnpm oxlint packages/likec4-spa` passed with 0 errors.
- **End-to-End Export**: Verified `likec4 export png --theme light ../../examples/cloud-system` and inspected computed styles / DOM attributes (`data-mantine-color-scheme="light"`).

## Checklist
- [x] I've thoroughly read the latest [contribution guidelines](https://github.com/likec4/likec4/blob/main/CONTRIBUTING.md).
- [x] I've rebased my branch onto `main` **before** creating this PR.
- [x] I've added tests to cover my changes (if applicable).
- [x] I've verified `pnpm typecheck` and `pnpm test`.
- [x] I've added [changesets](https://changesets-docs.vercel.app/).
- [ ] My change requires documentation updates.
- [ ] I've updated the documentation accordingly (or will do in follow-up PR).
