### PR TITLE
fix(diagram): walkthrough crash when clicking a step in diagram variant

### DIFF
--- a/.changeset/fix-walkthrough-edge-click-in-diagram-variant.md
+++ b/.changeset/fix-walkthrough-edge-click-in-diagram-variant.md
@@ -1,0 +1,5 @@
+---
+'@likec4/diagram': patch
+---
+
+Fix crash when clicking another step during a walkthrough in a `diagram`-variant dynamic view. The click handler asserted the ReactFlow edge type, which is `seq-step` only in the `sequence` variant, and now checks the step id instead. Fixes [#3201](https://github.com/likec4/likec4/issues/3201).

--- a/packages/diagram/src/likec4diagram/state/machine.state.ready.walkthrough.spec.ts
+++ b/packages/diagram/src/likec4diagram/state/machine.state.ready.walkthrough.spec.ts
@@ -1,0 +1,172 @@
+import type { LayoutedDynamicView, NonEmptyArray, Point } from '@likec4/core/types'
+import { scalar } from '@likec4/core/types'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createActor, fromCallback } from 'xstate'
+import { DefaultFeatures } from '../../context/DiagramFeatures'
+import type { XYFlowInstance, XYStoreApi } from '../../hooks/useXYFlow'
+import type { Types } from '../types'
+import { diagramMachine } from './machine'
+
+// One step of the view, as the layouter leaves it.
+const mockViewEdge = (stepnum: number) => ({
+  id: scalar.EdgeId(`step-0${stepnum}`),
+  parent: null,
+  source: scalar.NodeId('source-node'),
+  target: scalar.NodeId('target-node'),
+  label: `step ${stepnum}`,
+  relations: [],
+  color: 'primary' as const,
+  line: 'dashed' as const,
+  points: [[0, 0], [100, 100]] as NonEmptyArray<Point>,
+})
+
+// Minimal mock view — `satisfies` so TypeScript validates the shape.
+const mockDiagramDynamicView = {
+  _type: 'dynamic' as const,
+  _stage: 'layouted' as const,
+  id: scalar.ViewId('view:dynamic-diagram'),
+  title: 'Diagram Dynamic View',
+  description: null,
+  tags: null,
+  links: null,
+  hash: 'mock-hash-diagram',
+  autoLayout: { direction: 'TB' as const },
+  nodes: [],
+  edges: [mockViewEdge(1), mockViewEdge(2)],
+  bounds: { x: 0, y: 0, width: 800, height: 600 },
+  variant: 'diagram' as const,
+  sequenceLayout: {
+    actors: [],
+    compounds: [],
+    parallelAreas: [],
+    subflows: [],
+    steps: [],
+    bounds: { x: 0, y: 0, width: 800, height: 600 },
+  },
+} satisfies LayoutedDynamicView
+
+// The `diagram` variant renders steps as `relationship` edges,
+// only the `sequence` variant renders them as `seq-step`.
+// Intentional partial stub: only the fields the machine reads are set.
+const mockStepEdge = (stepnum: number) =>
+  ({
+    id: `step-0${stepnum}`,
+    type: 'relationship',
+    source: 'source-node',
+    target: 'target-node',
+    data: {
+      id: scalar.StepPath(`0${stepnum}`),
+      stepnum,
+      points: [[0, 0], [100, 100]],
+    },
+  }) as unknown as Types.Edge
+
+// Internal nodes as ReactFlow keeps them, needed to compute the bounds of the active step.
+const mockInternalNode = (id: string, x: number) => ({
+  id,
+  position: { x, y: 0 },
+  measured: { width: 200, height: 100 },
+  internals: { positionAbsolute: { x, y: 0 } },
+  data: {},
+})
+
+// XYStore and XYFlow are intentional partial stubs: only the methods the machine
+// actually calls are implemented, so satisfies cannot be used here.
+const mockXYStore = {
+  getState: () => ({
+    width: 800,
+    height: 600,
+    transform: [0, 0, 1] as [number, number, number],
+    panZoom: undefined,
+    panBy: async () => false,
+    resetSelectedElements: () => {},
+    nodeOrigin: [0, 0] as [number, number],
+    nodeLookup: new Map([
+      ['source-node', mockInternalNode('source-node', 0)],
+      ['target-node', mockInternalNode('target-node', 400)],
+    ]),
+  }),
+  setState: () => {},
+  subscribe: () => () => {},
+} as unknown as XYStoreApi
+
+const mockXYFlow = {
+  getViewport: () => ({ x: 0, y: 0, zoom: 1 }),
+  setViewport: () => Promise.resolve(true),
+  getInternalNode: (_id: string) => undefined,
+  flowToScreenPosition: (pt: { x: number; y: number }) => pt,
+  fitView: async () => true,
+} as unknown as XYFlowInstance
+
+/**
+ * Creates a test actor for the diagram machine, starts it and advances it to `ready`.
+ * The actors touching the DOM are replaced with no-ops, so this runs in Node.js.
+ */
+function createTestActor(xyedges: Types.Edge[]) {
+  const actor = createActor(
+    diagramMachine.provide({
+      actors: {
+        // mediaPrint actor uses window.addEventListener — replace with no-op for tests
+        mediaPrint: fromCallback(() => () => {}),
+        // hotkey actor (spawned on walkthrough entry) uses document — replace with no-op for tests
+        hotkey: fromCallback(() => () => {}),
+      },
+    }),
+    {
+      input: {
+        view: mockDiagramDynamicView,
+        xystore: mockXYStore,
+        zoomable: true,
+        pannable: true,
+        nodesDraggable: false,
+        nodesSelectable: false,
+        fitViewPadding: {},
+        where: null,
+        features: DefaultFeatures,
+      },
+    },
+  )
+  actor.start()
+  actor.send({ type: 'xyflow.init', instance: mockXYFlow })
+  actor.send({
+    type: 'update.view',
+    view: mockDiagramDynamicView,
+    source: 'external',
+    xynodes: [],
+    xyedges,
+  })
+  return actor
+}
+
+describe('walkthrough state - edge click', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('moves the walkthrough to the clicked step in a diagram-variant dynamic view', () => {
+    const actor = createTestActor([mockStepEdge(1), mockStepEdge(2)])
+
+    actor.send({ type: 'walkthrough.start', stepId: scalar.StepPath('01') })
+    expect(actor.getSnapshot().context.activeWalkthrough?.stepId).toBe('step-01')
+
+    actor.send({ type: 'xyflow.edgeClick', edge: mockStepEdge(2) })
+    expect(actor.getSnapshot().context.activeWalkthrough?.stepId).toBe('step-02')
+
+    actor.stop()
+  })
+
+  it('keeps the walkthrough on the active step when it is clicked again', () => {
+    const actor = createTestActor([mockStepEdge(1), mockStepEdge(2)])
+
+    actor.send({ type: 'walkthrough.start', stepId: scalar.StepPath('01') })
+    actor.send({ type: 'xyflow.edgeClick', edge: mockStepEdge(1) })
+
+    expect(actor.getSnapshot().context.activeWalkthrough?.stepId).toBe('step-01')
+
+    actor.stop()
+  })
+})

--- a/packages/diagram/src/likec4diagram/state/machine.state.ready.walkthrough.ts
+++ b/packages/diagram/src/likec4diagram/state/machine.state.ready.walkthrough.ts
@@ -272,9 +272,9 @@ export const walkthrough = machine.createStateConfig({
       {
         actions: [
           assign(({ event, context }) => {
-            invariant(event.edge.type === 'seq-step', `Expected seq-step edge, but got "${event.edge.type}"`)
             invariant(!!context.activeWalkthrough)
             const stepId = event.edge.data.id
+            invariant(isStepPath(stepId), `Expected step edge, but got "${stepId}"`)
             return {
               activeWalkthrough: {
                 ...context.activeWalkthrough,


### PR DESCRIPTION
Fixes #3201

## Problem

In a `diagram`-variant dynamic view, clicking another step while a walkthrough is active crashes the diagram:

```
Error: Expected seq-step edge, but got "relationship"
```

Steps to reproduce in the read-only viewer (`likec4 start`), on 1.59.2:

1. Open any dynamic view — the default `diagram` variant
2. Click a step arrow once, it gets selected
3. Click the same arrow again, the walkthrough starts
4. Click a different step arrow — the diagram crashes with the error above

Keyboard navigation (`←` / `→`) and `Esc` are unaffected, so the walkthrough itself works. Only switching steps by clicking fails.

## Cause

The walkthrough state handles `xyflow.edgeClick` in two branches. The second one, taken for any step other than the active one, asserts the ReactFlow edge type:

```ts
invariant(event.edge.type === 'seq-step', `Expected seq-step edge, but got "${event.edge.type}"`)
```

Steps are rendered as `seq-step` edges only in the `sequence` variant. In the `diagram` variant they are `relationship` edges, so the assertion never holds there.

The assertion arrived in 86282c12 and has been released since v1.59.0 (v1.58.0 does not contain it). Before that, the same branch checked the step id instead of the edge type and worked in both variants. The rest of the handler only reads `event.edge.data.id`, so it is variant-agnostic.

## Fix

Assert on the step id, the way `walkthrough.step` already does in the same file:

```ts
const stepId = event.edge.data.id
invariant(isStepPath(stepId), `Expected step edge, but got "${stepId}"`)
```

## Tests

`machine.state.ready.walkthrough.spec.ts` drives the machine into a walkthrough on a `diagram`-variant dynamic view and asserts that

- clicking another step moves the walkthrough to it (this threw before the fix)
- clicking the active step keeps the walkthrough where it is

## Checklist

- [x] I've thoroughly read the latest [contribution guidelines](https://github.com/likec4/likec4/blob/main/CONTRIBUTING.md).
- [x] I've rebased my branch onto `main` **before** creating this PR.
- [x] I've added tests to cover my changes (if applicable).
- [x] I've verified `pnpm typecheck` and `pnpm test`.
- [x] I've added [changesets](https://changesets-docs.vercel.app/).
- [ ] My change requires documentation updates.
- [ ] I've updated the documentation accordingly (or will do in follow-up PR).
