### PR TITLE
fix(cli): honour LIKEC4_WORKSPACE in `likec4 mcp`

### DIFF
--- a/.changeset/mcp-honour-likec4-workspace-env.md
+++ b/.changeset/mcp-honour-likec4-workspace-env.md
@@ -1,0 +1,5 @@
+---
+'likec4': patch
+---
+
+Fix `likec4 mcp` ignoring the `LIKEC4_WORKSPACE` environment variable. The command overrode the shared `path` default, so the workspace always fell back to the current directory and the server silently served an empty model. Behaviour now matches the documented help text and the other commands.

--- a/packages/likec4/src/cli/mcp/index.ts
+++ b/packages/likec4/src/cli/mcp/index.ts
@@ -15,7 +15,6 @@ const mcpCmd = <T>(yargs: Argv<T>) => {
         y
           .usage(`${k.bold('Usage:')} $0 mcp [path]`)
           .positional('path', path)
-          .default('path', '.', 'current directory')
           .option('stdio', {
             boolean: true,
             description: 'use stdio transport',


### PR DESCRIPTION
Fixes #3203.

`likec4 mcp` advertises `LIKEC4_WORKSPACE` in its own help text but never reads it, so the workspace always falls back to the current directory.

The shared `path` positional in `packages/likec4/src/cli/options.ts` already carries `env['LIKEC4_WORKSPACE'] || '.'` as its default, and `mcp` overrode it one line after applying it:

```ts
.positional('path', path)
.default('path', '.', 'current directory')   // discards the env-derived default
```

Removing the override restores the documented behaviour and makes `mcp` consistent with `build`, `codegen`, `format`, `serve`, `sync` and `validate`, which all honour the variable.

### Why this is worth a patch

The failure is silent. With no sources in the current directory the server still starts, `initialize` succeeds and every tool answers — against an empty model. The only signal is a `WARN likec4.server.workspace No likec4 documents found in workspace` on stderr, which MCP clients do not surface: from the client's side LikeC4 simply appears to know nothing about the architecture.

It hits `mcp` harder than the other commands because the server is spawned by a client rather than typed into a shell, so the working directory is not the user's choice and passing the workspace through the environment is the natural thing to do.

Setting the variable to `.` appears to work, but only because `.` coincides with the hardcoded fallback.

### Verification

Same build, same command, same environment, from a directory holding no `.c4` files:

| | sources resolved |
|---|---|
| before, `LIKEC4_WORKSPACE=<workspace>` | **0** |
| after, `LIKEC4_WORKSPACE=<workspace>` | **40** |
| after, positional `<workspace>` | **40** (unchanged) |
| after, neither set | falls back to cwd (unchanged) |

Measured by driving the stdio server directly — `initialize`, then a `list-projects` tool call — and counting the returned sources.

- `pnpm --filter likec4 typecheck` — clean
- `vitest run --no-isolate` on `packages/likec4` — 11 files, 57 passed, 4 skipped

### Note on `preview`

`packages/likec4/src/cli/preview/index.ts` does not use the shared `path` positional — it declares its own with `default: resolve('.')`, so it does not support `LIKEC4_WORKSPACE` either. Its help text does not advertise the variable, so I treated it as an inconsistency rather than the same bug and left it out to keep this PR minimal. Happy to align it here or in a follow-up if you prefer.

## Checklist

- [x] I've thoroughly read the latest contribution guidelines.
- [x] I've rebased my branch onto `main` **before** creating this PR.
- [ ] I've added tests to cover my changes (if applicable).
- [x] I've verified `pnpm typecheck` and `pnpm test`.
- [x] I've added changesets.
- [ ] My change requires documentation updates.
- [ ] I've updated the documentation accordingly (or will do in follow-up PR).

On tests: there is currently no harness covering CLI option parsing — `packages/likec4/src/cli/**` has `serve.spec.ts` and two codegen specs, none of which exercise yargs wiring. I did not want to introduce one unprompted for a one-line fix, but I'm glad to add it if you'd like this covered.
