### PR TITLE
fix(generators): always emit LF line endings

### DIFF
--- a/.changeset/fix-generators-crlf-on-windows.md
+++ b/.changeset/fix-generators-crlf-on-windows.md
@@ -1,0 +1,5 @@
+---
+'@likec4/generators': patch
+---
+
+Fix generated output using CRLF line endings on Windows. Markdown, Mermaid, D2, PlantUML and LikeC4 DSL exports now always emit LF, so generated files are byte-identical across platforms.

--- a/packages/generators/src/d2/generate-d2.ts
+++ b/packages/generators/src/d2/generate-d2.ts
@@ -1,7 +1,8 @@
 import type { LikeC4ViewModel } from '@likec4/core/model'
 import type { aux, ComputedNode, NodeId, ProcessedView as AnyView } from '@likec4/core/types'
-import { CompositeGeneratorNode, joinToNode, NL, toString } from 'langium/generate'
+import { CompositeGeneratorNode, joinToNode, toString } from 'langium/generate'
 import { isNullish as isNil } from 'remeda'
+import { NL } from '../newline'
 
 const capitalizeFirstLetter = (value: string) => value.charAt(0).toLocaleUpperCase() + value.slice(1)
 

--- a/packages/generators/src/d2/generate-d2.ts
+++ b/packages/generators/src/d2/generate-d2.ts
@@ -1,8 +1,8 @@
 import type { LikeC4ViewModel } from '@likec4/core/model'
 import type { aux, ComputedNode, NodeId, ProcessedView as AnyView } from '@likec4/core/types'
-import { CompositeGeneratorNode, joinToNode, toString } from 'langium/generate'
+import { CompositeGeneratorNode, joinToNode } from 'langium/generate'
 import { isNullish as isNil } from 'remeda'
-import { NL } from '../newline'
+import { NL, toStringLF } from '../newline'
 
 const capitalizeFirstLetter = (value: string) => value.charAt(0).toLocaleUpperCase() + value.slice(1)
 
@@ -94,7 +94,7 @@ export function generateD2(viewmodel: LikeC4ViewModel<aux.Unknown>) {
       .append(out => edge.label && out.append(': ', JSON.stringify(edge.label)))
   }
 
-  return toString(
+  return toStringLF(
     new CompositeGeneratorNode()
       .append('direction: ', d2direction(view), NL, NL)
       .append(

--- a/packages/generators/src/likec4/operators/base.ts
+++ b/packages/generators/src/likec4/operators/base.ts
@@ -6,7 +6,6 @@ import {
   CompositeGeneratorNode,
   joinToNode,
   NewLineNode,
-  toString,
 } from 'langium/generate'
 import {
   filter,
@@ -27,7 +26,7 @@ import { dedent } from 'strip-indent'
 import type { IfAny, Or } from 'type-fest'
 import * as z from 'zod/v4'
 import type * as z4 from 'zod/v4/core'
-import { NL } from '../../newline'
+import { NL, toStringLF } from '../../newline'
 
 function hasContent(out: Generated): boolean {
   if (typeof out === 'string') {
@@ -109,7 +108,7 @@ export function fresh(ctx?: unknown) {
  */
 export function materialize(ctx: AnyCtx | Op<any>, defaultIndentation: string | number = 2): string {
   const out = isFunction(ctx) ? executeOnFresh(undefined, [ctx]).out : ctx.out
-  return toString(out, defaultIndentation).replaceAll(/\r\n/g, '\n')
+  return toStringLF(out, defaultIndentation)
 }
 
 /**

--- a/packages/generators/src/likec4/operators/base.ts
+++ b/packages/generators/src/likec4/operators/base.ts
@@ -6,7 +6,6 @@ import {
   CompositeGeneratorNode,
   joinToNode,
   NewLineNode,
-  NL,
   toString,
 } from 'langium/generate'
 import {
@@ -28,6 +27,7 @@ import { dedent } from 'strip-indent'
 import type { IfAny, Or } from 'type-fest'
 import * as z from 'zod/v4'
 import type * as z4 from 'zod/v4/core'
+import { NL } from '../../newline'
 
 function hasContent(out: Generated): boolean {
   if (typeof out === 'string') {

--- a/packages/generators/src/likec4/operators/views.ts
+++ b/packages/generators/src/likec4/operators/views.ts
@@ -3,8 +3,9 @@ import {
   invariant,
   nonexhaustive,
 } from '@likec4/core'
-import { CompositeGeneratorNode, NL } from 'langium/generate'
+import { CompositeGeneratorNode } from 'langium/generate'
 import { hasAtLeast, values } from 'remeda'
+import { NL } from '../../newline'
 import { schemas } from '../schemas'
 import {
   type Op,

--- a/packages/generators/src/markdown/generate-markdown.spec.ts
+++ b/packages/generators/src/markdown/generate-markdown.spec.ts
@@ -113,6 +113,10 @@ test('Output is reproducible', ({ expect }) => {
   expect(generateMarkdown(model)).toBe(generateMarkdown(model))
 })
 
+test('Line endings are LF on every platform', ({ expect }) => {
+  expect(generateMarkdown(model)).not.toContain('\r')
+})
+
 test('Full document snapshot', ({ expect }) => {
   expect(generateMarkdown(model)).toMatchSnapshot()
 })

--- a/packages/generators/src/markdown/generate-markdown.ts
+++ b/packages/generators/src/markdown/generate-markdown.ts
@@ -1,7 +1,8 @@
 import type { LikeC4Model, LikeC4ViewModel } from '@likec4/core/model'
 import type { aux } from '@likec4/core/types'
-import { CompositeGeneratorNode, NL, toString } from 'langium/generate'
+import { CompositeGeneratorNode, toString } from 'langium/generate'
 import { generateMermaid } from '../mmd/generate-mmd'
+import { NL } from '../newline'
 
 type ViewModel = LikeC4ViewModel<aux.Unknown>
 

--- a/packages/generators/src/markdown/generate-markdown.ts
+++ b/packages/generators/src/markdown/generate-markdown.ts
@@ -1,8 +1,8 @@
 import type { LikeC4Model, LikeC4ViewModel } from '@likec4/core/model'
 import type { aux } from '@likec4/core/types'
-import { CompositeGeneratorNode, toString } from 'langium/generate'
+import { CompositeGeneratorNode } from 'langium/generate'
 import { generateMermaid } from '../mmd/generate-mmd'
-import { NL } from '../newline'
+import { NL, toStringLF } from '../newline'
 
 type ViewModel = LikeC4ViewModel<aux.Unknown>
 
@@ -48,5 +48,5 @@ export function generateMarkdown(
     appendView(doc, view)
   }
 
-  return toString(doc)
+  return toStringLF(doc)
 }

--- a/packages/generators/src/mmd/generate-mmd.ts
+++ b/packages/generators/src/mmd/generate-mmd.ts
@@ -1,9 +1,9 @@
 import { nonexhaustive } from '@likec4/core'
 import type { LikeC4ViewModel } from '@likec4/core/model'
 import type { aux, NodeId, ProcessedView as AnyView } from '@likec4/core/types'
-import { CompositeGeneratorNode, joinToNode, toString } from 'langium/generate'
+import { CompositeGeneratorNode, joinToNode } from 'langium/generate'
 import { isNullish as isNil } from 'remeda'
-import { NL } from '../newline'
+import { NL, toStringLF } from '../newline'
 
 const capitalizeFirstLetter = (value: string) => value.charAt(0).toLocaleUpperCase() + value.slice(1)
 
@@ -98,7 +98,7 @@ export function generateMermaid(viewmodel: LikeC4ViewModel<aux.Unknown>) {
     )
   }
 
-  return toString(
+  return toStringLF(
     new CompositeGeneratorNode()
       .append(
         '---',

--- a/packages/generators/src/mmd/generate-mmd.ts
+++ b/packages/generators/src/mmd/generate-mmd.ts
@@ -1,8 +1,9 @@
 import { nonexhaustive } from '@likec4/core'
 import type { LikeC4ViewModel } from '@likec4/core/model'
 import type { aux, NodeId, ProcessedView as AnyView } from '@likec4/core/types'
-import { CompositeGeneratorNode, joinToNode, NL, toString } from 'langium/generate'
+import { CompositeGeneratorNode, joinToNode, toString } from 'langium/generate'
 import { isNullish as isNil } from 'remeda'
+import { NL } from '../newline'
 
 const capitalizeFirstLetter = (value: string) => value.charAt(0).toLocaleUpperCase() + value.slice(1)
 

--- a/packages/generators/src/newline.ts
+++ b/packages/generators/src/newline.ts
@@ -1,0 +1,10 @@
+import { NewLineNode } from 'langium/generate'
+
+/**
+ * Line separator for all generated output.
+ *
+ * Langium's own `NL` resolves to `os.EOL`, which emits CRLF on Windows and makes
+ * generated artifacts (Markdown, Mermaid, D2, PlantUML, LikeC4 DSL) differ per platform.
+ * Generators must be deterministic, so always emit LF.
+ */
+export const NL = new NewLineNode('\n')

--- a/packages/generators/src/newline.ts
+++ b/packages/generators/src/newline.ts
@@ -1,4 +1,5 @@
-import { NewLineNode } from 'langium/generate'
+import type { GeneratorNode } from 'langium/generate'
+import { NewLineNode, toString } from 'langium/generate'
 
 /**
  * Line separator for all generated output.
@@ -8,3 +9,13 @@ import { NewLineNode } from 'langium/generate'
  * Generators must be deterministic, so always emit LF.
  */
 export const NL = new NewLineNode('\n')
+
+/**
+ * Renders a generator node with LF line endings.
+ *
+ * Some Langium helpers insert `os.EOL` internally (for example `joinToNode`'s
+ * `appendNewLineIfNotEmpty`), so normalize the rendered output as well as using {@link NL}.
+ */
+export function toStringLF(node: GeneratorNode | undefined, defaultIndentation?: string | number): string {
+  return toString(node, defaultIndentation).replaceAll('\r\n', '\n')
+}

--- a/packages/generators/src/puml/generate-puml.ts
+++ b/packages/generators/src/puml/generate-puml.ts
@@ -13,9 +13,9 @@ import type {
   ThemeColor,
 } from '@likec4/core/types'
 import { RichText } from '@likec4/core/types'
-import { CompositeGeneratorNode, joinToNode, toString } from 'langium/generate'
+import { CompositeGeneratorNode, joinToNode } from 'langium/generate'
 import { isEmptyish, isNullish as isNil } from 'remeda'
-import { NL } from '../newline'
+import { NL, toStringLF } from '../newline'
 
 const capitalizeFirstLetter = (value: string) => value.charAt(0).toLocaleUpperCase() + value.slice(1)
 
@@ -234,7 +234,7 @@ export function generatePuml(viewmodel: LikeC4ViewModel<aux.Unknown>) {
     return out.append(NL)
   }
 
-  return toString(
+  return toStringLF(
     new CompositeGeneratorNode()
       .append('@startuml', NL)
       .append(printHeader(), NL)

--- a/packages/generators/src/puml/generate-puml.ts
+++ b/packages/generators/src/puml/generate-puml.ts
@@ -13,8 +13,9 @@ import type {
   ThemeColor,
 } from '@likec4/core/types'
 import { RichText } from '@likec4/core/types'
-import { CompositeGeneratorNode, joinToNode, NL, toString } from 'langium/generate'
+import { CompositeGeneratorNode, joinToNode, toString } from 'langium/generate'
 import { isEmptyish, isNullish as isNil } from 'remeda'
+import { NL } from '../newline'
 
 const capitalizeFirstLetter = (value: string) => value.charAt(0).toLocaleUpperCase() + value.slice(1)
 

--- a/packages/generators/src/views-data-ts/generate-views-data.ts
+++ b/packages/generators/src/views-data-ts/generate-views-data.ts
@@ -1,7 +1,7 @@
 import type { DiagramView } from '@likec4/core'
 import JSON5 from 'json5'
-import { CompositeGeneratorNode, expandToNode, joinToNode, toString } from 'langium/generate'
-import { NL } from '../newline'
+import { CompositeGeneratorNode, expandToNode, joinToNode } from 'langium/generate'
+import { NL, toStringLF } from '../newline'
 import { generateViewId } from './generateViewId'
 
 /**
@@ -22,7 +22,7 @@ export function generateViewsDataJs(diagrams: Iterable<DiagramView>) {
 
   if (views.length == 0) {
     out.append('export const LikeC4Views = {}', NL)
-    return toString(out)
+    return toStringLF(out)
   }
 
   out.appendTemplate`
@@ -55,7 +55,7 @@ export function generateViewsDataJs(diagrams: Iterable<DiagramView>) {
 
     /* prettier-ignore-end */
   `.append(NL)
-  return toString(out)
+  return toStringLF(out)
 }
 
 /**
@@ -79,7 +79,7 @@ export function generateViewsDataTs(diagrams: Iterable<DiagramView>) {
 
   if (views.length === 0) {
     out.append('export {}', NL)
-    return toString(out)
+    return toStringLF(out)
   }
 
   out.appendTemplate`
@@ -119,7 +119,7 @@ export function generateViewsDataTs(diagrams: Iterable<DiagramView>) {
 
     /* prettier-ignore-end */
   `.append(NL)
-  return toString(out)
+  return toStringLF(out)
 }
 
 /**
@@ -141,7 +141,7 @@ export function generateViewsDataDTs(diagrams: Iterable<DiagramView>) {
 
   if (views.length == 0) {
     out.append('export {}', NL)
-    return toString(out)
+    return toStringLF(out)
   }
 
   out.appendTemplate`
@@ -153,5 +153,5 @@ export function generateViewsDataDTs(diagrams: Iterable<DiagramView>) {
 
     /* prettier-ignore-end */
   `.append(NL)
-  return toString(out)
+  return toStringLF(out)
 }

--- a/packages/generators/src/views-data-ts/generate-views-data.ts
+++ b/packages/generators/src/views-data-ts/generate-views-data.ts
@@ -1,6 +1,7 @@
 import type { DiagramView } from '@likec4/core'
 import JSON5 from 'json5'
-import { CompositeGeneratorNode, expandToNode, joinToNode, NL, toString } from 'langium/generate'
+import { CompositeGeneratorNode, expandToNode, joinToNode, toString } from 'langium/generate'
+import { NL } from '../newline'
 import { generateViewId } from './generateViewId'
 
 /**


### PR DESCRIPTION
## Problem

Every generator imports `NL` from `langium/generate`, which resolves to `os.EOL` — CRLF on Windows. Generated Markdown, Mermaid, D2, PlantUML, LikeC4 DSL and views-data output was therefore platform-dependent.

This surfaced as a Windows CI failure in `packages/generators/src/markdown/generate-markdown.spec.ts` (2 tests), introduced with the Markdown generator in #3160. It goes unnoticed on `main` because the Windows job is skipped there, and the `.mmd`/`.puml` snapshot tests are masked by the `text eol=lf` rules in `.gitattributes`.

Repro: https://github.com/likec4/likec4/actions/runs/33490526448/job/99801853146

```
AssertionError: expected '# Acme Platform\r\n\r\n### Context\r\n…'
                to be     '# Acme Platform\n\n### Context\r\n…'
```

## Fix

Add a shared `NL` in `packages/generators/src/newline.ts` bound to LF and use it in place of Langium's `NL` across all generators. Adds a regression test asserting the Markdown output contains no `\r`.

Generator output is now byte-identical on every platform.

## Checklist

- [x] I've thoroughly read the latest [contribution guidelines](https://github.com/likec4/likec4/blob/main/CONTRIBUTING.md).
- [x] I've rebased my branch onto `main` **before** creating this PR.
- [x] I've added tests to cover my changes (if applicable).
- [x] I've verified `pnpm typecheck` and `pnpm test`.
- [x] I've added [changesets](https://changesets-docs.vercel.app/).
- [ ] My change requires documentation updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BXx8re1oq5uLRJtmiEhnTh