### PR TITLE
feat: allow escaping `/` in view and element titles

### DIFF
--- a/.changeset/allow-escaping-slash-in-view-titles.md
+++ b/.changeset/allow-escaping-slash-in-view-titles.md
@@ -1,0 +1,6 @@
+---
+'@likec4/core': patch
+'@likec4/language-server': patch
+---
+
+Allow escaping a forward slash in a title with `\/` so it doesn't create a view folder. This also applies to element titles, so `implicitViews` no longer split an auto-generated view into an unwanted subfolder when the element's title contains a slash.

--- a/apps/docs/src/content/docs/dsl/Views/organize.mdx
+++ b/apps/docs/src/content/docs/dsl/Views/organize.mdx
@@ -27,6 +27,22 @@ On the UI, this view will be displayed as:
 
 ![organize views](../../../../assets/views/organize.png)
 
+:::note
+If a title needs to contain a `/` without creating a folder, escape it with a backslash:
+
+```likec4
+views {
+  view {
+    title 'Cost \/ Benefit'
+  }
+}
+```
+
+This view keeps the single title `Cost / Benefit` and is not nested under a `Cost` folder.
+The same escape works for element titles, which is useful when `implicitViews` is enabled and an
+auto-generated view would otherwise be split into an unwanted subfolder.
+:::
+
 ## Order views
 
 Views in the same folder can be ordered with `order` followed by a non-negative integer.

--- a/packages/core/src/model/LikeC4Model.ts
+++ b/packages/core/src/model/LikeC4Model.ts
@@ -1,4 +1,4 @@
-import { entries, hasAtLeast, isEmpty, map, pipe, prop, sort, sortBy, split, values } from 'remeda'
+import { entries, hasAtLeast, isEmpty, map, pipe, prop, sort, sortBy, values } from 'remeda'
 import type { IsAny } from 'type-fest'
 import { LikeC4Styles } from '../styles/LikeC4Styles'
 import type {
@@ -53,7 +53,7 @@ import type {
   OutgoingFilter,
   RelationOrId,
 } from './types'
-import { getId, getViewFolderPath, normalizeViewPath, VIEW_FOLDERS_SEPARATOR } from './utils'
+import { getId, getViewFolderPath, normalizeViewPath, splitViewFolderPath, VIEW_FOLDERS_SEPARATOR } from './utils'
 import { LikeC4ViewModel } from './view/LikeC4ViewModel'
 import { LikeC4ViewsFolder } from './view/LikeC4ViewsFolder'
 import type { NodeModel } from './view/NodeModel'
@@ -228,7 +228,7 @@ export class LikeC4Model<A extends Any = Any> {
       const getOrCreateFolder = (path: string) => {
         let folder = this._viewFolders.get(path)
         if (!folder) {
-          const segments = split(path, VIEW_FOLDERS_SEPARATOR)
+          const segments = splitViewFolderPath(path)
           invariant(hasAtLeast(segments, 1), `View group path "${path}" must have at least one element`)
           let defaultView
           // Root group has "index" as default view
@@ -252,7 +252,7 @@ export class LikeC4Model<A extends Any = Any> {
           continue
         }
         // Create groups for each segment of the path
-        split(folderPath, VIEW_FOLDERS_SEPARATOR).reduce((segments, segment) => {
+        splitViewFolderPath(folderPath).reduce((segments, segment) => {
           const parent = segments.join(VIEW_FOLDERS_SEPARATOR)
           const path = isEmpty(parent) ? segment : parent + VIEW_FOLDERS_SEPARATOR + segment
 

--- a/packages/core/src/model/utils/index.ts
+++ b/packages/core/src/model/utils/index.ts
@@ -3,5 +3,7 @@ export {
   extractViewTitleFromPath,
   getViewFolderPath,
   normalizeViewPath,
+  splitViewFolderPath,
+  unescapeViewPathSegment,
   VIEW_FOLDERS_SEPARATOR,
 } from './view-title-path'

--- a/packages/core/src/model/utils/view-title-path.spec.ts
+++ b/packages/core/src/model/utils/view-title-path.spec.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { extractViewTitleFromPath, getViewFolderPath, normalizeViewPath } from './view-title-path'
+import {
+  extractViewTitleFromPath,
+  getViewFolderPath,
+  normalizeViewPath,
+  splitViewFolderPath,
+  unescapeViewPathSegment,
+} from './view-title-path'
 
 describe('normalizeViewPath', () => {
   it('should remove spaces from path segments', () => {
@@ -88,5 +94,33 @@ describe('getViewTitleFromPath', () => {
 
   it('should handle input with only spaces', () => {
     expect(extractViewTitleFromPath('   ')).toBe('')
+  })
+})
+
+describe('escaped forward slash', () => {
+  it('normalizeViewPath keeps an escaped slash as one segment', () => {
+    expect(normalizeViewPath('Group \\/ Name')).toBe('Group \\/ Name')
+  })
+
+  it('getViewFolderPath does not split on an escaped slash', () => {
+    expect(getViewFolderPath('Group \\/ Name')).toBeNull()
+    expect(getViewFolderPath('Folder / Group \\/ Name')).toBe('Folder')
+  })
+
+  it('extractViewTitleFromPath unescapes the slash for display', () => {
+    expect(extractViewTitleFromPath('Group \\/ Name')).toBe('Group / Name')
+    expect(extractViewTitleFromPath('Folder / Group \\/ Name')).toBe('Group / Name')
+  })
+
+  it('unescapeViewPathSegment converts \\/ back to /', () => {
+    expect(unescapeViewPathSegment('Group \\/ Name')).toBe('Group / Name')
+    expect(unescapeViewPathSegment('No slash here')).toBe('No slash here')
+  })
+
+  it('splitViewFolderPath re-splits a normalized path without breaking escaped segments', () => {
+    expect(splitViewFolderPath(normalizeViewPath('Folder / Group \\/ Name'))).toEqual([
+      'Folder',
+      'Group \\/ Name',
+    ])
   })
 })

--- a/packages/core/src/model/utils/view-title-path.ts
+++ b/packages/core/src/model/utils/view-title-path.ts
@@ -4,11 +4,26 @@ import { invariant } from '../../utils'
 
 export const VIEW_FOLDERS_SEPARATOR = '/'
 
+// A '/' preceded by a backslash is an escaped, literal slash (see docs on organizing views)
+// and must not be treated as a folder separator.
+const UNESCAPED_SEPARATOR = /(?<!\\)\//
+const ESCAPED_SEPARATOR = /\\\//g
+
+/**
+ * Converts an escaped `\/` (produced by the parser to protect a literal slash from being
+ * treated as a folder separator) back into a plain `/` for display.
+ */
+export const unescapeViewPathSegment = (segment: string): string => segment.replace(ESCAPED_SEPARATOR, '/')
+
+/**
+ * Splits a title/path into segments, honoring `\/` as an escaped (non-splitting) slash.
+ * Segments keep any `\/` markers intact - callers that display a segment must unescape it.
+ */
 const splitViewTitle = (title: string): NonEmptyArray<string> => {
   invariant(!title.includes('\n'), 'View title cannot contain newlines')
-  if (title.includes(VIEW_FOLDERS_SEPARATOR)) {
+  if (UNESCAPED_SEPARATOR.test(title)) {
     const segments = title
-      .split(VIEW_FOLDERS_SEPARATOR)
+      .split(UNESCAPED_SEPARATOR)
       .map(s => s.trim())
       .filter(s => s.length > 0)
     if (hasAtLeast(segments, 1)) {
@@ -18,6 +33,13 @@ const splitViewTitle = (title: string): NonEmptyArray<string> => {
   }
   return [title.trim()]
 }
+
+/**
+ * Splits an already-normalized path string back into its segments, honoring escaped slashes.
+ * Use this instead of a plain `String.split` whenever re-splitting a path produced by
+ * {@link normalizeViewPath} or {@link getViewFolderPath}.
+ */
+export const splitViewFolderPath = (path: string): NonEmptyArray<string> => splitViewTitle(path)
 
 /**
  * Normalizes view path by removing spaces from segments, removing empty segments,
@@ -51,8 +73,8 @@ export const getViewFolderPath = (title: string): string | null => {
  * getViewTitleFromPath('One') === 'One'
  */
 export const extractViewTitleFromPath = (title: string): string => {
-  if (!title.includes(VIEW_FOLDERS_SEPARATOR)) {
-    return title.trim()
+  if (!UNESCAPED_SEPARATOR.test(title)) {
+    return unescapeViewPathSegment(title.trim())
   }
-  return splitViewTitle(title).at(-1) ?? title
+  return unescapeViewPathSegment(splitViewTitle(title).at(-1) ?? title)
 }

--- a/packages/core/src/model/view/LikeC4ViewsFolder.ts
+++ b/packages/core/src/model/view/LikeC4ViewsFolder.ts
@@ -2,6 +2,7 @@ import { isEmptyish, last } from 'remeda'
 import type { aux, NonEmptyArray } from '../../types'
 import { invariant, memoizeProp } from '../../utils'
 import type { LikeC4Model } from '../LikeC4Model'
+import { unescapeViewPathSegment } from '../utils'
 import { LikeC4ViewModel } from './LikeC4ViewModel'
 
 export class LikeC4ViewsFolder<A extends aux.Any = aux.Any> {
@@ -46,7 +47,7 @@ export class LikeC4ViewsFolder<A extends aux.Any = aux.Any> {
     this.$model = $model
     this.path = path.join('/')
     this.isRoot = this.path === ''
-    this.title = last(path)
+    this.title = unescapeViewPathSegment(last(path))
     if (this.isRoot) {
       this.parentPath = undefined
     } else {

--- a/packages/language-server/src/model/__tests__/model-builder-view-folders.spec.ts
+++ b/packages/language-server/src/model/__tests__/model-builder-view-folders.spec.ts
@@ -397,6 +397,79 @@ describe('LikeC4ModelBuilder -- view folders', () => {
     expect(implicitView!.title).toBe('Auto / Multi Line Title')
   })
 
+  it('escaped slash in an explicit view title does not create a folder', async ({ expect }) => {
+    const { validate, buildLikeC4Model } = createTestServices({ projectConfig: {} })
+    const { errors } = await validate(`
+      specification {
+        element component
+      }
+      model {
+        component sys1
+      }
+      views {
+        view v1 {
+          title 'Cost \\/ Benefit'
+          include *
+        }
+      }
+    `)
+    expect(errors).toEqual([])
+    const model = await buildLikeC4Model()
+    expect(model.hasViewFolders).toBe(false)
+    expect(model.view('v1').title).toBe('Cost / Benefit')
+  })
+
+  it('escaped slash in an inline element title does not split the implicit view into a subfolder', async ({ expect }) => {
+    const { validate, buildModel, buildLikeC4Model } = createTestServices({
+      projectConfig: { implicitViews: true },
+    })
+    const { errors } = await validate(`
+      specification {
+        element component
+      }
+      model {
+        component sys1 'Cache\\/Redis'
+      }
+    `)
+    expect(errors).toEqual([])
+
+    const computed = await buildModel()
+    // the element's own title is unaffected and shows a plain slash
+    expect(computed.elements['sys1']?.title).toBe('Cache/Redis')
+
+    const model = await buildLikeC4Model()
+    expect([...model.viewFolder('Auto').views]).toEqual([
+      model.view('__sys1'),
+    ])
+    expect(model.view('__sys1').title).toBe('Cache/Redis')
+  })
+
+  it('escaped slash in a body-style element title does not split the implicit view into a subfolder', async ({ expect }) => {
+    const { validate, buildModel, buildLikeC4Model } = createTestServices({
+      projectConfig: { implicitViews: true },
+    })
+    const { errors } = await validate(`
+      specification {
+        element component
+      }
+      model {
+        component sys1 {
+          title 'Cache\\/Redis'
+        }
+      }
+    `)
+    expect(errors).toEqual([])
+
+    const computed = await buildModel()
+    expect(computed.elements['sys1']?.title).toBe('Cache/Redis')
+
+    const model = await buildLikeC4Model()
+    expect([...model.viewFolder('Auto').views]).toEqual([
+      model.view('__sys1'),
+    ])
+    expect(model.view('__sys1').title).toBe('Cache/Redis')
+  })
+
   it('implicit views skip elements with explicit scoped views', async ({ expect }) => {
     const { validate, buildModel } = createTestServices({
       projectConfig: { implicitViews: true },

--- a/packages/language-server/src/model/builder/buildModel.ts
+++ b/packages/language-server/src/model/builder/buildModel.ts
@@ -369,6 +369,14 @@ export function buildModelData(
     }
   }
 
+  // Element titles may still carry an escaped `\/` (kept around so the implicit-view
+  // title built above isn't split into extra folders) - resolve it to a plain `/` now
+  // that every consumer of `elements[fqn].title` has run.
+  const elementsForOutput = mapValues(
+    elements,
+    el => el.title.includes('\\/') ? { ...el, title: el.title.replaceAll('\\/', '/') } : el,
+  )
+
   return {
     data: {
       [_stage]: 'parsed',
@@ -394,7 +402,7 @@ export function buildModelData(
         ...(metadataKeys.size > 0 && { metadataKeys: [...metadataKeys].sort(compareNatural) }),
         customColors,
       },
-      elements,
+      elements: elementsForOutput,
       relations,
       globals: c4Specification.globals,
       views,

--- a/packages/language-server/src/model/parser/Base.ts
+++ b/packages/language-server/src/model/parser/Base.ts
@@ -7,7 +7,7 @@ import {
   nonexhaustive,
   nonNullable,
 } from '@likec4/core'
-import { type AstNode, type Reference, isAstNode, UriUtils } from 'langium'
+import { type AstNode, type Reference, GrammarUtils, isAstNode, UriUtils } from 'langium'
 import {
   filter,
   flatMap,
@@ -47,6 +47,52 @@ const logger = serverLogger.getChild('parser')
 
 // the class which this mixin is applied to
 export type GConstructor<T = {}> = new(...args: any[]) => T
+
+const BASIC_ESCAPES: Record<string, string> = { b: '\b', f: '\f', n: '\n', r: '\r', t: '\t', v: '\v', '0': '\0' }
+
+/**
+ * Mirrors langium's default string conversion, except an escaped `\/` is kept as-is,
+ * so @likec4/core's view-folder splitting can tell it apart from a real separator later on.
+ */
+function unescapeKeepingSlash(quoted: string): string {
+  let result = ''
+  for (let i = 1; i < quoted.length - 1; i++) {
+    const c = quoted[i]
+    if (c === '\\') {
+      const next = quoted[++i] ?? ''
+      result += next === '/' ? '\\/' : (BASIC_ESCAPES[next] ?? next)
+    } else {
+      result += c
+    }
+  }
+  return result
+}
+
+/**
+ * Re-reads a title's raw token text (instead of the already-unescaped AST value) so an
+ * escaped `\/` survives for the view-folder splitting logic. Returns `undefined` for
+ * markdown (triple-quoted) titles, which don't support this escape.
+ */
+export function parseTitleKeepingEscapedSlash(node: ast.MarkdownOrString | undefined): string | undefined {
+  if (!node || !isString(node.text)) {
+    return undefined
+  }
+  const raw = node.$cstNode?.text
+  return raw ? unescapeKeepingSlash(raw) : node.text
+}
+
+/**
+ * Same as {@link parseTitleKeepingEscapedSlash}, for an inline `String` property (not
+ * wrapped in `MarkdownOrString`), such as an element's positional title.
+ */
+export function parseInlineTitleKeepingEscapedSlash(
+  containerNode: AstNode | undefined,
+  property: string,
+  index = 0,
+): string | undefined {
+  const raw = GrammarUtils.findNodeForProperty(containerNode?.$cstNode, property, index)?.text
+  return raw ? unescapeKeepingSlash(raw) : undefined
+}
 
 export function toSingleLine(str: undefined | null): undefined
 export function toSingleLine(str: string): string

--- a/packages/language-server/src/model/parser/DeploymentViewParser.ts
+++ b/packages/language-server/src/model/parser/DeploymentViewParser.ts
@@ -4,7 +4,7 @@ import { filter, isNonNullish, mapToObj, pipe } from 'remeda'
 import { type ParsedAstDeploymentView, ast, parseMarkdownAsString, toAutoLayout, ViewOps } from '../../ast'
 import { logWarnError } from '../../logger'
 import { stringHash } from '../../utils'
-import { parseViewOrder, removeIndent, toSingleLine } from './Base'
+import { parseTitleKeepingEscapedSlash, parseViewOrder, removeIndent, toSingleLine } from './Base'
 import type { WithDeploymentModel } from './DeploymentModelParser'
 import type { WithExpressionV2 } from './FqnRefParser'
 
@@ -29,16 +29,17 @@ export function DeploymentViewParser<TBase extends WithExpressionV2 & WithDeploy
         ) as c4.ViewId
       }
 
+      const deploymentViewBodyProps = pipe(
+        props,
+        filter(ast.isViewStringProperty),
+        mapToObj(p => [p.key, p.value as ast.MarkdownOrString | undefined]),
+      )
       const {
         title = null,
         description = null,
-      } = this.parseBaseProps(
-        pipe(
-          props,
-          filter(ast.isViewStringProperty),
-          mapToObj(p => [p.key, p.value as ast.MarkdownOrString | undefined]),
-        ),
-      )
+      } = this.parseBaseProps(deploymentViewBodyProps, {
+        title: parseTitleKeepingEscapedSlash(deploymentViewBodyProps.title),
+      })
 
       const tags = this.convertTags(body)
       const links = this.convertLinks(body)

--- a/packages/language-server/src/model/parser/ModelParser.ts
+++ b/packages/language-server/src/model/parser/ModelParser.ts
@@ -20,6 +20,7 @@ import {
 } from '../../ast'
 import { stringHash } from '../../utils/stringHash'
 import { relationFingerprint } from '../relationFingerprint'
+import { parseInlineTitleKeepingEscapedSlash, parseTitleKeepingEscapedSlash } from './Base'
 import type { WithExpressionV2 } from './FqnRefParser'
 
 export type WithModel = ReturnType<typeof ModelParser>
@@ -103,7 +104,9 @@ export function ModelParser<TBase extends WithExpressionV2>(B: TBase) {
       )
 
       const { title, ...descAndTech } = this.parseBaseProps(bodyProps, {
-        title: _title,
+        title: isDefined(_title)
+          ? (parseInlineTitleKeepingEscapedSlash(astNode, 'props', 0) ?? _title)
+          : parseTitleKeepingEscapedSlash(bodyProps.title),
         summary: _summary,
         technology: _technology,
       })

--- a/packages/language-server/src/model/parser/ViewsParser.ts
+++ b/packages/language-server/src/model/parser/ViewsParser.ts
@@ -19,7 +19,7 @@ import {
   ViewOps,
 } from '../../ast'
 import { safeCall, stringHash } from '../../utils'
-import { parseViewOrder, removeIndent, toSingleLine } from './Base'
+import { parseTitleKeepingEscapedSlash, parseViewOrder, removeIndent, toSingleLine } from './Base'
 import type { WithDeploymentView } from './DeploymentViewParser'
 import type { WithPredicates } from './PredicatesParser'
 
@@ -104,13 +104,14 @@ export function ViewsParser<TBase extends WithPredicates & WithDeploymentView>(B
         ) as c4.ViewId
       }
 
-      const { title = null, description = null } = this.parseBaseProps(
-        pipe(
-          props,
-          filter(ast.isViewStringProperty),
-          mapToObj(p => [p.key, p.value as ast.MarkdownOrString | undefined]),
-        ),
+      const viewBodyProps = pipe(
+        props,
+        filter(ast.isViewStringProperty),
+        mapToObj(p => [p.key, p.value as ast.MarkdownOrString | undefined]),
       )
+      const { title = null, description = null } = this.parseBaseProps(viewBodyProps, {
+        title: parseTitleKeepingEscapedSlash(viewBodyProps.title),
+      })
 
       const tags = this.convertTags(body)
       const links = this.convertLinks(body)
@@ -281,13 +282,14 @@ export function ViewsParser<TBase extends WithPredicates & WithDeploymentView>(B
         ) as c4.ViewId
       }
 
-      const { title = null, description = null } = this.parseBaseProps(
-        pipe(
-          props,
-          filter(ast.isViewStringProperty),
-          mapToObj(p => [p.key, p.value as ast.MarkdownOrString | undefined]),
-        ),
+      const dynamicViewBodyProps = pipe(
+        props,
+        filter(ast.isViewStringProperty),
+        mapToObj(p => [p.key, p.value as ast.MarkdownOrString | undefined]),
       )
+      const { title = null, description = null } = this.parseBaseProps(dynamicViewBodyProps, {
+        title: parseTitleKeepingEscapedSlash(dynamicViewBodyProps.title),
+      })
 
       const tags = this.convertTags(body)
       const links = this.convertLinks(body)

--- a/skills/likec4-dsl/SKILL.md
+++ b/skills/likec4-dsl/SKILL.md
@@ -12,7 +12,7 @@ Architecture-as-code tool. Describe systems in `.c4`/`.likec4` files and LikeC4 
 1. **Projects** - it is possible to have multiple likec4 projects in a workspace, project is determined by presence of a config file (`.likec4rc`, `likec4.config.{ts,js,json}`). LikeC4 files belong to the project of the nearest config file in the directory hierarchy.
 2. **Top-level statements** — only `import`, `specification`, `model`, `deployment`, `views`, `global` are allowed. Blocks can repeat, but at least one per file must be present.
 3. **Multi-file merge** — Top-level blocks across files are merged. For example, `model { ... }` blocks present in multiple files, parsed separately, and then merged into a single model.
-4. **Strings** — `'single'`, `"double"` — all support multi-line. Escape quotes with backslash: `\'` or `\"`.
+4. **Strings** — `'single'`, `"double"` — all support multi-line. Escape quotes with backslash: `\'` or `\"`. In a `title`, escape `\/` to include a literal `/` without it being read as a view-folder separator.
 5. **Markdown** — properties like `summary`/`description`/`notes` can contain Markdown. Use triple quotes `'''` or `"""`. Begin a new line after opening quotes and indent Markdown content for better formatting and syntax highlighting.
 6. **Comments** — `// single line` and `/* multi-line */` comments supported anywhere.
 7. **Identifier** — letters, digits, hyphens, underscores only. No dots (dots are FQN separators). Can't start with a digit. Examples: `customer`, `payment-service`, `frontendApp`, `queue-1`. **Critical:** `payment-api` is valid; `payment.api` is NOT an identifier (dots separate FQN hierarchy). See `references/identifier-validity.md`.


### PR DESCRIPTION
Support `\/` as an escape sequence for a literal forward slash in titles, so it is not treated as a view-folder separator.

- packages/core: folder-splitting in view-title-path.ts now ignores a `/` preceded by a backslash, and unescapes it back to `/` only at the final display point (LikeC4ViewModel.title, LikeC4ViewsFolder.title). Internal path/Map-key handling in LikeC4Model.ts keeps the escape marker intact to stay collision-safe when re-splitting paths.
- packages/language-server: Base.ts re-reads the raw CST token text for `title` properties (inline and body-style) since Langium's default value conversion already collapses `\/` to `/`. ViewsParser.ts and DeploymentViewParser.ts apply this to view titles; ModelParser.ts applies it to element titles. buildModel.ts uses the escaped element title when building the `implicitViews` auto-generated title, then strips the escape marker from the final elements output so the element's own displayed title stays clean.
- Added tests covering explicit view titles and both implicit-view title styles (inline and body-style element titles).
- Updated the "Organize views" docs and the likec4-dsl skill to document the new escape.
- Added a changeset for @likec4/core and @likec4/language-server.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask, and propose improvements. We're here to help. -->

- [x] I've thoroughly read the latest [contribution guidelines](https://github.com/likec4/likec4/blob/main/CONTRIBUTING.md).
- [x] I've rebased my branch onto `main` **before** creating this PR.
- [x] I've added tests to cover my changes (if applicable).
- [x] I've verified `pnpm typecheck` and `pnpm test`.
- [x] I've added [changesets](https://changesets-docs.vercel.app/) (you can use `/changeset-generator` SKILL).
- [x] My change requires documentation updates.
- [x] I've updated the documentation accordingly (or will do in follow-up PR).
