### PR TITLE
fix(vscode): restore bootstrap icons in preview

### DIFF
--- a/.changeset/vscode-bootstrap-icon-cors.md
+++ b/.changeset/vscode-bootstrap-icon-cors.md
@@ -1,0 +1,6 @@
+---
+"@likec4/vscode-preview": patch
+"likec4-vscode": patch
+---
+
+Render Bootstrap icons in the VS Code preview when webview CORS blocks the icon CDN.

--- a/.changeset/vscode-bootstrap-icon-cors.md
+++ b/.changeset/vscode-bootstrap-icon-cors.md
@@ -1,6 +1,5 @@
 ---
-"@likec4/vscode-preview": patch
 "likec4-vscode": patch
 ---
 
-Render Bootstrap icons in the VS Code preview when webview CORS blocks the icon CDN.
+Load Bootstrap icons in the VS Code preview through the extension host. The webview does not fetch Bootstrap SVG files from the CDN.

--- a/.changeset/vscode-bootstrap-icon-csp.md
+++ b/.changeset/vscode-bootstrap-icon-csp.md
@@ -1,0 +1,5 @@
+---
+'likec4-vscode': patch
+---
+
+Restore Bootstrap icons and their configured colors in the VS Code preview.

--- a/.changeset/vscode-bootstrap-icon-csp.md
+++ b/.changeset/vscode-bootstrap-icon-csp.md
@@ -2,4 +2,4 @@
 'likec4-vscode': patch
 ---
 
-Restore Bootstrap icons and their configured colors in the VS Code preview.
+Allow inline style attributes in the VS Code webview CSP so configured Bootstrap icon colors can apply.

--- a/packages/vscode-preview/protocol.ts
+++ b/packages/vscode-preview/protocol.ts
@@ -92,6 +92,10 @@ export const ReadLocalIcon: RequestType</* uri */ string, ReadLocalIconResult> =
   method: 'read-local-icon',
 }
 
+export const ReadBootstrapIcon: RequestType</* name */ string, ReadLocalIconResult> = {
+  method: 'read-bootstrap-icon',
+}
+
 export const ViewChangeReq = { method: 'webview:change' } as RequestType<
   { projectId: ProjectId; viewId: ViewId; change: ViewChange },
   { success: true } | { success: false; error: string }

--- a/packages/vscode-preview/src/IconRenderer.spec.tsx
+++ b/packages/vscode-preview/src/IconRenderer.spec.tsx
@@ -5,9 +5,10 @@
 //
 // Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
 
-import { renderToStaticMarkup } from 'react-dom/server'
-import { describe, expect, it, vi } from 'vitest'
+import { renderToReadableStream, renderToStaticMarkup } from 'react-dom/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { bootstrapIconRendererFromDataUrl, IconRenderer, localIconRendererFromDataUrl } from './IconRenderer'
+import { ExtensionApi } from './vscode'
 
 vi.mock('./vscode', () => ({
   ExtensionApi: {
@@ -17,9 +18,32 @@ vi.mock('./vscode', () => ({
 }))
 
 describe('IconRenderer', () => {
-  it('renders host-provided Bootstrap SVG data as a colorable mask', () => {
+  const bootstrapIconDataUrl = 'data:image/svg+xml;base64,PHN2ZyBmaWxsPSJjdXJyZW50Q29sb3IiLz4='
+  const readBootstrapIcon = vi.mocked(ExtensionApi.readBootstrapIcon)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders host-provided Bootstrap SVG data as a colorable mask', async () => {
+    readBootstrapIcon.mockResolvedValue({ base64data: bootstrapIconDataUrl })
+
+    const html = await renderToHtml(
+      <IconRenderer node={{ id: 'test', title: 'Test', icon: 'bootstrap:boxes' }} />,
+    )
+
+    expect(readBootstrapIcon).toHaveBeenCalledOnce()
+    expect(readBootstrapIcon).toHaveBeenCalledWith('boxes')
+    expect(html).toContain('background-color:currentColor')
+    expect(html).toContain('mask-image:url(')
+    expect(html).toContain('data:image/svg+xml;base64,')
+    expect(html).not.toContain('icons.like-c4.dev')
+    expect(html).not.toContain('<img')
+  })
+
+  it('keeps the synchronous Bootstrap mask helper for callers with host data', () => {
     const BootstrapIcon = bootstrapIconRendererFromDataUrl(
-      'data:image/svg+xml;base64,PHN2ZyBmaWxsPSJjdXJyZW50Q29sb3IiLz4=',
+      bootstrapIconDataUrl,
     )
     const html = renderToStaticMarkup(<BootstrapIcon node={{ id: 'test', title: 'Test', icon: 'bootstrap:boxes' }} />)
 
@@ -29,11 +53,42 @@ describe('IconRenderer', () => {
     expect(html).not.toContain('<img')
   })
 
-  it('renders nothing when the host does not return a Bootstrap SVG', () => {
-    const BootstrapIcon = bootstrapIconRendererFromDataUrl(null)
-    const html = renderToStaticMarkup(<BootstrapIcon node={{ id: 'test', title: 'Test', icon: 'bootstrap:boxes' }} />)
+  it('renders nothing when the host returns no Bootstrap SVG, then retries', async () => {
+    readBootstrapIcon
+      .mockResolvedValueOnce({ base64data: null })
+      .mockResolvedValueOnce({ base64data: bootstrapIconDataUrl })
 
-    expect(html).toBe('')
+    const firstHtml = await renderToHtml(
+      <IconRenderer node={{ id: 'test-empty', title: 'Test', icon: 'bootstrap:empty-retry' }} />,
+    )
+    const secondHtml = await renderToHtml(
+      <IconRenderer node={{ id: 'test-empty', title: 'Test', icon: 'bootstrap:empty-retry' }} />,
+    )
+
+    expect(firstHtml).not.toContain('mask-image:url(')
+    expect(firstHtml).not.toContain('<span')
+    expect(readBootstrapIcon).toHaveBeenNthCalledWith(1, 'empty-retry')
+    expect(readBootstrapIcon).toHaveBeenNthCalledWith(2, 'empty-retry')
+    expect(secondHtml).toContain('mask-image:url(')
+  })
+
+  it('renders nothing when the host rejects, then retries', async () => {
+    readBootstrapIcon
+      .mockRejectedValueOnce(new Error('temporary host failure'))
+      .mockResolvedValueOnce({ base64data: bootstrapIconDataUrl })
+
+    const firstHtml = await renderToHtml(
+      <IconRenderer node={{ id: 'test-error', title: 'Test', icon: 'bootstrap:error-retry' }} />,
+    )
+    const secondHtml = await renderToHtml(
+      <IconRenderer node={{ id: 'test-error', title: 'Test', icon: 'bootstrap:error-retry' }} />,
+    )
+
+    expect(firstHtml).not.toContain('mask-image:url(')
+    expect(firstHtml).not.toContain('<span')
+    expect(readBootstrapIcon).toHaveBeenNthCalledWith(1, 'error-retry')
+    expect(readBootstrapIcon).toHaveBeenNthCalledWith(2, 'error-retry')
+    expect(secondHtml).toContain('mask-image:url(')
   })
 
   it('keeps non-bootstrap bundled icons as CDN images', () => {
@@ -161,3 +216,18 @@ describe('IconRenderer', () => {
     expect(html).toBe('')
   })
 })
+
+async function renderToHtml(element: React.ReactNode): Promise<string> {
+  const stream = await renderToReadableStream(element)
+  const reader = stream.getReader()
+  const decoder = new TextDecoder()
+  let html = ''
+
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) {
+      return html + decoder.decode()
+    }
+    html += decoder.decode(value, { stream: true })
+  }
+}

--- a/packages/vscode-preview/src/IconRenderer.spec.tsx
+++ b/packages/vscode-preview/src/IconRenderer.spec.tsx
@@ -7,28 +7,33 @@
 
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it, vi } from 'vitest'
-import { IconRenderer, localIconRendererFromDataUrl } from './IconRenderer'
+import { bootstrapIconRendererFromDataUrl, IconRenderer, localIconRendererFromDataUrl } from './IconRenderer'
 
 vi.mock('./vscode', () => ({
   ExtensionApi: {
     readLocalIcon: vi.fn<(_: string) => Promise<{ base64data: string | null }>>(),
+    readBootstrapIcon: vi.fn<(_: string) => Promise<{ base64data: string | null }>>(),
   },
 }))
 
 describe('IconRenderer', () => {
-  it('renders bootstrap icons as a colorable mask instead of an image', () => {
-    const html = renderToStaticMarkup(
-      <IconRenderer
-        node={{
-          id: 'test',
-          title: 'Test',
-          icon: 'bootstrap:file-earmark-code',
-        }} />,
+  it('renders host-provided Bootstrap SVG data as a colorable mask', () => {
+    const BootstrapIcon = bootstrapIconRendererFromDataUrl(
+      'data:image/svg+xml;base64,PHN2ZyBmaWxsPSJjdXJyZW50Q29sb3IiLz4=',
     )
+    const html = renderToStaticMarkup(<BootstrapIcon node={{ id: 'test', title: 'Test', icon: 'bootstrap:boxes' }} />)
 
-    expect(html).not.toContain('<img')
-    expect(html).toContain('https://icons.like-c4.dev/bootstrap/file-earmark-code.svg')
     expect(html).toContain('background-color:currentColor')
+    expect(html).toContain('mask-image:url(')
+    expect(html).not.toContain('icons.like-c4.dev')
+    expect(html).not.toContain('<img')
+  })
+
+  it('renders nothing when the host does not return a Bootstrap SVG', () => {
+    const BootstrapIcon = bootstrapIconRendererFromDataUrl(null)
+    const html = renderToStaticMarkup(<BootstrapIcon node={{ id: 'test', title: 'Test', icon: 'bootstrap:boxes' }} />)
+
+    expect(html).toBe('')
   })
 
   it('keeps non-bootstrap bundled icons as CDN images', () => {

--- a/packages/vscode-preview/src/IconRenderer.tsx
+++ b/packages/vscode-preview/src/IconRenderer.tsx
@@ -48,11 +48,14 @@ const bootstrapIcons = new DefaultMap<string, ElementIconRenderer>(name => {
   return lazy(async () => {
     try {
       const { base64data } = await extensionApi.readBootstrapIcon(name)
+      if (!base64data) {
+        bootstrapIcons.delete(name)
+      }
       return {
         default: bootstrapIconRendererFromDataUrl(base64data),
       }
-    } catch (error) {
-      console.error(error)
+    } catch {
+      bootstrapIcons.delete(name)
       return {
         default: () => null,
       }

--- a/packages/vscode-preview/src/IconRenderer.tsx
+++ b/packages/vscode-preview/src/IconRenderer.tsx
@@ -6,14 +6,11 @@
 // Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
 
 import { DefaultMap } from '@likec4/core/utils'
-import {
-  type ElementIconRenderer,
-  type ElementIconRendererProps,
-  DefaultIconRenderer,
-  IconRendererProvider,
-} from '@likec4/diagram'
+import { type ElementIconRenderer, type ElementIconRendererProps, IconRendererProvider } from '@likec4/diagram'
 import { lazy, memo, Suspense } from 'react'
 import { ExtensionApi as extensionApi } from './vscode'
+
+const iconUrl = (group: string, name: string) => `https://icons.like-c4.dev/${group}/${name}.svg`
 
 function SvgMask({ src, ...props }: Omit<ElementIconRendererProps, 'node'> & { src: string }) {
   const maskUrl = `url(${JSON.stringify(src)})`
@@ -37,6 +34,55 @@ function SvgMask({ src, ...props }: Omit<ElementIconRendererProps, 'node'> & { s
       }}
     />
   )
+}
+
+export function bootstrapIconRendererFromDataUrl(base64data: string | null): ElementIconRenderer {
+  if (!base64data) {
+    return () => null
+  }
+
+  return ({ node: _node, ...props }) => <SvgMask {...props} src={base64data} />
+}
+
+const bootstrapIcons = new DefaultMap<string, ElementIconRenderer>(name => {
+  return lazy(async () => {
+    try {
+      const { base64data } = await extensionApi.readBootstrapIcon(name)
+      return {
+        default: bootstrapIconRendererFromDataUrl(base64data),
+      }
+    } catch (error) {
+      console.error(error)
+      return {
+        default: () => null,
+      }
+    }
+  })
+})
+
+function BootstrapIcon({ name, ...props }: ElementIconRendererProps & { name: string }) {
+  const Icon = bootstrapIcons.get(name)
+  return (
+    <Suspense>
+      <Icon {...props} />
+    </Suspense>
+  )
+}
+
+const DefaultIconRenderer: ElementIconRenderer = ({ node, ...props }) => {
+  if (!node.icon || node.icon === 'none') {
+    return null
+  }
+  const [group, name] = node.icon.split(':') as [string, string]
+  if (!group || !name) {
+    return null
+  }
+
+  if (group === 'bootstrap') {
+    return <BootstrapIcon {...props} node={node} name={name} />
+  }
+
+  return <img {...props} src={iconUrl(group, name)} />
 }
 
 export function localIconRendererFromDataUrl(base64data: string | null): ElementIconRenderer {

--- a/packages/vscode-preview/src/vscode.ts
+++ b/packages/vscode-preview/src/vscode.ts
@@ -21,6 +21,7 @@ import {
   FetchProjectsOverview,
   GetLastClickedNode,
   OnOpenView,
+  ReadBootstrapIcon,
   ReadLocalIcon,
   ViewChangeReq,
   WebviewMsgs,
@@ -124,6 +125,10 @@ export const ExtensionApi = {
   // Read local icon file and convert to base64 data URI
   readLocalIcon: async (uri: string) => {
     return await messenger.sendRequest(ReadLocalIcon, HOST_EXTENSION, uri)
+  },
+
+  readBootstrapIcon: async (name: string) => {
+    return await messenger.sendRequest(ReadBootstrapIcon, HOST_EXTENSION, name)
   },
 
   onOpenViewNotification: (handler: Handler<typeof OnOpenView>) => {

--- a/packages/vscode/src/panel/activateMessenger.ts
+++ b/packages/vscode/src/panel/activateMessenger.ts
@@ -1,6 +1,7 @@
 import { loggable, wrapError } from '@likec4/log'
 import {
   executeCommand,
+  extensionContext,
   toValue,
 } from 'reactive-vscode'
 import * as vscode from 'vscode'
@@ -9,7 +10,7 @@ import { useExtensionLogger } from '../useExtensionLogger'
 import { useMessenger } from '../useMessenger'
 import { useRpc } from '../useRpc'
 import { performanceMark, showEditorNextToPreview } from '../utils'
-import { createBootstrapIconLoader } from './bootstrapIcon'
+import { type BootstrapIconResult, createBootstrapIconLoader } from './bootstrapIcon'
 import { useDiagramPanel } from './useDiagramPanel'
 
 export function activateMessenger() {
@@ -18,7 +19,10 @@ export function activateMessenger() {
   const preview = useDiagramPanel()
 
   const { logger, output } = useExtensionLogger('messenger')
-  const loadBootstrapIcon = createBootstrapIconLoader()
+  const storageUri = extensionContext.value?.globalStorageUri
+  const loadBootstrapIcon = storageUri
+    ? createBootstrapIconLoader(storageUri)
+    : async (): Promise<BootstrapIconResult> => ({ base64data: null })
 
   logger.debug('activating messenger <-> preview panel')
 

--- a/packages/vscode/src/panel/activateMessenger.ts
+++ b/packages/vscode/src/panel/activateMessenger.ts
@@ -9,6 +9,7 @@ import { useExtensionLogger } from '../useExtensionLogger'
 import { useMessenger } from '../useMessenger'
 import { useRpc } from '../useRpc'
 import { performanceMark, showEditorNextToPreview } from '../utils'
+import { createBootstrapIconLoader } from './bootstrapIcon'
 import { useDiagramPanel } from './useDiagramPanel'
 
 export function activateMessenger() {
@@ -17,6 +18,7 @@ export function activateMessenger() {
   const preview = useDiagramPanel()
 
   const { logger, output } = useExtensionLogger('messenger')
+  const loadBootstrapIcon = createBootstrapIconLoader()
 
   logger.debug('activating messenger <-> preview panel')
 
@@ -205,6 +207,14 @@ export function activateMessenger() {
       // Return null for any errors (file not found, permission denied, etc.)
       return { base64data: null }
     }
+  })
+
+  messenger.handleReadBootstrapIcon(async (name) => {
+    const result = await loadBootstrapIcon(name)
+    if (!result.base64data) {
+      logger.warn('readBootstrapIcon failed', { name })
+    }
+    return result
   })
 
   return messenger

--- a/packages/vscode/src/panel/bootstrapIcon.spec.ts
+++ b/packages/vscode/src/panel/bootstrapIcon.spec.ts
@@ -6,11 +6,38 @@ import { ReadBootstrapIcon } from '@likec4/vscode-preview/protocol'
 import { describe, expect, it, vi } from 'vitest'
 import { createBootstrapIconLoader, isBootstrapIconName } from './bootstrapIcon'
 
+vi.mock('vscode', () => {
+  const parse = (value: string) => {
+    const parsed = new URL(value)
+    const fsPath = decodeURIComponent(parsed.pathname)
+    return {
+      scheme: parsed.protocol.slice(0, -1),
+      authority: parsed.host,
+      path: parsed.pathname,
+      fsPath,
+      toString: () => value,
+    }
+  }
+
+  const joinPath = (base: { toString: () => string }, ...segments: string[]) => {
+    const uri = new URL(base.toString())
+    const nextPath = [uri.pathname.replace(/\/+$/, ''), ...segments.map(segment => segment.replace(/^\/+/, ''))]
+      .filter(Boolean)
+      .join('/')
+    uri.pathname = nextPath.startsWith('/') ? nextPath : `/${nextPath}`
+    return parse(uri.toString())
+  }
+
+  return { Uri: { parse, joinPath } }
+})
+
+import * as vscode from 'vscode'
+
 const svg = '<svg xmlns="http://www.w3.org/2000/svg" fill="currentColor"/>'
 const svgBytes = new TextEncoder().encode(svg)
-const storageUri = { fsPath: '/global-storage' }
-const storageDirPath = '/global-storage/bootstrap-icons'
-const storageFilePath = '/global-storage/bootstrap-icons/boxes.svg'
+const storageUri = vscode.Uri.parse('file:///global-storage')
+const storageDirUri = vscode.Uri.joinPath(storageUri, 'bootstrap-icons')
+const storageFileUri = vscode.Uri.joinPath(storageDirUri, 'boxes.svg')
 
 describe('bootstrap icon loader', () => {
   it('defines a dedicated Bootstrap-icon request', () => {
@@ -47,12 +74,16 @@ describe('bootstrap icon loader', () => {
       createDirectory: vi.fn(),
     }
     const fetcher = vi.fn<typeof fetch>()
-    const load = createBootstrapIconLoader(storageUri as never, fileSystem, fetcher)
+    const load = createBootstrapIconLoader(storageUri, fileSystem, fetcher)
 
     await expect(load('boxes')).resolves.toEqual({
       base64data: `data:image/svg+xml;base64,${Buffer.from(svg).toString('base64')}`,
     })
-    expect(fileSystem.readFile).toHaveBeenCalledWith(expect.objectContaining({ fsPath: storageFilePath }))
+    expect(storageUri.toString()).toBe('file:///global-storage')
+    expect(storageUri.fsPath).toBe('/global-storage')
+    expect(storageDirUri.toString()).toBe('file:///global-storage/bootstrap-icons')
+    expect(storageFileUri.toString()).toBe('file:///global-storage/bootstrap-icons/boxes.svg')
+    expect(fileSystem.readFile).toHaveBeenCalledWith(storageFileUri)
     expect(fileSystem.createDirectory).not.toHaveBeenCalled()
     expect(fileSystem.writeFile).not.toHaveBeenCalled()
     expect(fetcher).not.toHaveBeenCalled()
@@ -67,17 +98,14 @@ describe('bootstrap icon loader', () => {
     const fetcher = vi.fn<typeof fetch>().mockResolvedValue(
       new Response(svg, { headers: { 'content-type': 'image/svg+xml' } }),
     )
-    const load = createBootstrapIconLoader(storageUri as never, fileSystem, fetcher)
+    const load = createBootstrapIconLoader(storageUri, fileSystem, fetcher)
 
     await expect(load('boxes')).resolves.toEqual({
       base64data: `data:image/svg+xml;base64,${Buffer.from(svg).toString('base64')}`,
     })
-    expect(fileSystem.readFile).toHaveBeenCalledWith(expect.objectContaining({ fsPath: storageFilePath }))
-    expect(fileSystem.createDirectory).toHaveBeenCalledWith(expect.objectContaining({ fsPath: storageDirPath }))
-    expect(fileSystem.writeFile).toHaveBeenCalledWith(
-      expect.objectContaining({ fsPath: storageFilePath }),
-      svgBytes,
-    )
+    expect(fileSystem.readFile).toHaveBeenCalledWith(storageFileUri)
+    expect(fileSystem.createDirectory).toHaveBeenCalledWith(storageDirUri)
+    expect(fileSystem.writeFile).toHaveBeenCalledWith(storageFileUri, svgBytes)
     expect(fetcher).toHaveBeenCalledWith(
       'https://icons.like-c4.dev/bootstrap/boxes.svg',
       expect.objectContaining({ signal: expect.any(AbortSignal) }),
@@ -93,17 +121,37 @@ describe('bootstrap icon loader', () => {
     const fetcher = vi.fn<typeof fetch>().mockResolvedValue(
       new Response(svg, { headers: { 'content-type': 'image/svg+xml' } }),
     )
-    const load = createBootstrapIconLoader(storageUri as never, fileSystem, fetcher)
+    const load = createBootstrapIconLoader(storageUri, fileSystem, fetcher)
 
     await expect(load('boxes')).resolves.toEqual({
       base64data: `data:image/svg+xml;base64,${Buffer.from(svg).toString('base64')}`,
     })
-    expect(fileSystem.readFile).toHaveBeenCalledWith(expect.objectContaining({ fsPath: storageFilePath }))
-    expect(fileSystem.createDirectory).toHaveBeenCalledWith(expect.objectContaining({ fsPath: storageDirPath }))
-    expect(fileSystem.writeFile).toHaveBeenCalledWith(
-      expect.objectContaining({ fsPath: storageFilePath }),
-      svgBytes,
+    expect(fileSystem.readFile).toHaveBeenCalledWith(storageFileUri)
+    expect(fileSystem.createDirectory).toHaveBeenCalledWith(storageDirUri)
+    expect(fileSystem.writeFile).toHaveBeenCalledWith(storageFileUri, svgBytes)
+    expect(fetcher).toHaveBeenCalledWith(
+      'https://icons.like-c4.dev/bootstrap/boxes.svg',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
     )
+  })
+
+  it('skips stale oversized storage data and refreshes from the CDN', async () => {
+    const fileSystem = {
+      readFile: vi.fn().mockResolvedValue(new Uint8Array(256 * 1024 + 1)),
+      createDirectory: vi.fn().mockResolvedValue(undefined),
+      writeFile: vi.fn().mockResolvedValue(undefined),
+    }
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(svg, { headers: { 'content-type': 'image/svg+xml' } }),
+    )
+    const load = createBootstrapIconLoader(storageUri, fileSystem, fetcher)
+
+    await expect(load('boxes')).resolves.toEqual({
+      base64data: `data:image/svg+xml;base64,${Buffer.from(svg).toString('base64')}`,
+    })
+    expect(fileSystem.readFile).toHaveBeenCalledWith(storageFileUri)
+    expect(fileSystem.createDirectory).toHaveBeenCalledWith(storageDirUri)
+    expect(fileSystem.writeFile).toHaveBeenCalledWith(storageFileUri, svgBytes)
     expect(fetcher).toHaveBeenCalledWith(
       'https://icons.like-c4.dev/bootstrap/boxes.svg',
       expect.objectContaining({ signal: expect.any(AbortSignal) }),

--- a/packages/vscode/src/panel/bootstrapIcon.spec.ts
+++ b/packages/vscode/src/panel/bootstrapIcon.spec.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createBootstrapIconLoader, isBootstrapIconName } from './bootstrapIcon'
+
+const svg = '<svg xmlns="http://www.w3.org/2000/svg" fill="currentColor"/>'
+
+describe('bootstrap icon loader', () => {
+  it('accepts only bounded Bootstrap icon names', () => {
+    expect(isBootstrapIconName('boxes')).toBe(true)
+    expect(isBootstrapIconName('buildings-fill')).toBe(true)
+    expect(isBootstrapIconName('../secret')).toBe(false)
+    expect(isBootstrapIconName('boxes.svg')).toBe(false)
+    expect(isBootstrapIconName('A')).toBe(false)
+  })
+
+  it('returns a data URL from the fixed Bootstrap CDN endpoint', async () => {
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(svg, { headers: { 'content-type': 'image/svg+xml; charset=utf-8' } }),
+    )
+    const load = createBootstrapIconLoader(fetcher)
+
+    await expect(load('boxes')).resolves.toEqual({
+      base64data: `data:image/svg+xml;base64,${Buffer.from(svg).toString('base64')}`,
+    })
+    expect(fetcher).toHaveBeenCalledWith(
+      'https://icons.like-c4.dev/bootstrap/boxes.svg',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    )
+  })
+
+  it('returns null without fetching an invalid name', async () => {
+    const fetcher = vi.fn<typeof fetch>()
+    await expect(createBootstrapIconLoader(fetcher)('../boxes')).resolves.toEqual({ base64data: null })
+    expect(fetcher).not.toHaveBeenCalled()
+  })
+
+  it('rejects non-SVG and oversized responses', async () => {
+    const nonSvg = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response('x', { headers: { 'content-type': 'text/html' } }),
+    )
+    const oversized = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response('x'.repeat(256 * 1024 + 1), { headers: { 'content-type': 'image/svg+xml' } }),
+    )
+
+    await expect(createBootstrapIconLoader(nonSvg)('boxes')).resolves.toEqual({ base64data: null })
+    await expect(createBootstrapIconLoader(oversized)('boxes')).resolves.toEqual({ base64data: null })
+  })
+
+  it('returns null on fetch failure and caches only successful results', async () => {
+    const failing = vi.fn<typeof fetch>().mockRejectedValue(new Error('offline'))
+    await expect(createBootstrapIconLoader(failing)('boxes')).resolves.toEqual({ base64data: null })
+
+    const succeeding = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(svg, { headers: { 'content-type': 'image/svg+xml' } }),
+    )
+    const load = createBootstrapIconLoader(succeeding)
+    await load('boxes')
+    await load('boxes')
+    expect(succeeding).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/vscode/src/panel/bootstrapIcon.spec.ts
+++ b/packages/vscode/src/panel/bootstrapIcon.spec.ts
@@ -7,6 +7,10 @@ import { describe, expect, it, vi } from 'vitest'
 import { createBootstrapIconLoader, isBootstrapIconName } from './bootstrapIcon'
 
 const svg = '<svg xmlns="http://www.w3.org/2000/svg" fill="currentColor"/>'
+const svgBytes = new TextEncoder().encode(svg)
+const storageUri = { fsPath: '/global-storage' }
+const storageDirPath = '/global-storage/bootstrap-icons'
+const storageFilePath = '/global-storage/bootstrap-icons/boxes.svg'
 
 describe('bootstrap icon loader', () => {
   it('defines a dedicated Bootstrap-icon request', () => {
@@ -30,6 +34,76 @@ describe('bootstrap icon loader', () => {
     await expect(load('boxes')).resolves.toEqual({
       base64data: `data:image/svg+xml;base64,${Buffer.from(svg).toString('base64')}`,
     })
+    expect(fetcher).toHaveBeenCalledWith(
+      'https://icons.like-c4.dev/bootstrap/boxes.svg',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    )
+  })
+
+  it('reads a valid icon from global storage before it fetches', async () => {
+    const fileSystem = {
+      readFile: vi.fn().mockResolvedValue(svgBytes),
+      writeFile: vi.fn(),
+      createDirectory: vi.fn(),
+    }
+    const fetcher = vi.fn<typeof fetch>()
+    const load = createBootstrapIconLoader(storageUri as never, fileSystem, fetcher)
+
+    await expect(load('boxes')).resolves.toEqual({
+      base64data: `data:image/svg+xml;base64,${Buffer.from(svg).toString('base64')}`,
+    })
+    expect(fileSystem.readFile).toHaveBeenCalledWith(expect.objectContaining({ fsPath: storageFilePath }))
+    expect(fileSystem.createDirectory).not.toHaveBeenCalled()
+    expect(fileSystem.writeFile).not.toHaveBeenCalled()
+    expect(fetcher).not.toHaveBeenCalled()
+  })
+
+  it('fetches and caches a missing icon in global storage', async () => {
+    const fileSystem = {
+      readFile: vi.fn().mockRejectedValue(new Error('FileNotFound')),
+      createDirectory: vi.fn().mockResolvedValue(undefined),
+      writeFile: vi.fn().mockResolvedValue(undefined),
+    }
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(svg, { headers: { 'content-type': 'image/svg+xml' } }),
+    )
+    const load = createBootstrapIconLoader(storageUri as never, fileSystem, fetcher)
+
+    await expect(load('boxes')).resolves.toEqual({
+      base64data: `data:image/svg+xml;base64,${Buffer.from(svg).toString('base64')}`,
+    })
+    expect(fileSystem.readFile).toHaveBeenCalledWith(expect.objectContaining({ fsPath: storageFilePath }))
+    expect(fileSystem.createDirectory).toHaveBeenCalledWith(expect.objectContaining({ fsPath: storageDirPath }))
+    expect(fileSystem.writeFile).toHaveBeenCalledWith(
+      expect.objectContaining({ fsPath: storageFilePath }),
+      svgBytes,
+    )
+    expect(fetcher).toHaveBeenCalledWith(
+      'https://icons.like-c4.dev/bootstrap/boxes.svg',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    )
+  })
+
+  it('still returns fetched data if caching to global storage fails', async () => {
+    const fileSystem = {
+      readFile: vi.fn().mockRejectedValue(new Error('FileNotFound')),
+      createDirectory: vi.fn().mockResolvedValue(undefined),
+      writeFile: vi.fn().mockRejectedValue(new Error('disk full')),
+    }
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(svg, { headers: { 'content-type': 'image/svg+xml' } }),
+    )
+    const load = createBootstrapIconLoader(storageUri as never, fileSystem, fetcher)
+
+    await expect(load('boxes')).resolves.toEqual({
+      base64data: `data:image/svg+xml;base64,${Buffer.from(svg).toString('base64')}`,
+    })
+    expect(fileSystem.readFile).toHaveBeenCalledWith(expect.objectContaining({ fsPath: storageFilePath }))
+    expect(fileSystem.createDirectory).toHaveBeenCalledWith(expect.objectContaining({ fsPath: storageDirPath }))
+    expect(fileSystem.writeFile).toHaveBeenCalledWith(
+      expect.objectContaining({ fsPath: storageFilePath }),
+      svgBytes,
+    )
     expect(fetcher).toHaveBeenCalledWith(
       'https://icons.like-c4.dev/bootstrap/boxes.svg',
       expect.objectContaining({ signal: expect.any(AbortSignal) }),

--- a/packages/vscode/src/panel/bootstrapIcon.spec.ts
+++ b/packages/vscode/src/panel/bootstrapIcon.spec.ts
@@ -2,12 +2,17 @@
 //
 // Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
+import { ReadBootstrapIcon } from '@likec4/vscode-preview/protocol'
 import { describe, expect, it, vi } from 'vitest'
 import { createBootstrapIconLoader, isBootstrapIconName } from './bootstrapIcon'
 
 const svg = '<svg xmlns="http://www.w3.org/2000/svg" fill="currentColor"/>'
 
 describe('bootstrap icon loader', () => {
+  it('defines a dedicated Bootstrap-icon request', () => {
+    expect(ReadBootstrapIcon.method).toBe('read-bootstrap-icon')
+  })
+
   it('accepts only bounded Bootstrap icon names', () => {
     expect(isBootstrapIconName('boxes')).toBe(true)
     expect(isBootstrapIconName('buildings-fill')).toBe(true)

--- a/packages/vscode/src/panel/bootstrapIcon.spec.ts
+++ b/packages/vscode/src/panel/bootstrapIcon.spec.ts
@@ -203,6 +203,31 @@ describe('bootstrap icon loader', () => {
     })
   })
 
+  it('stops reading an oversized streamed response before it buffers the body', async () => {
+    const reader = {
+      read: vi.fn()
+        .mockResolvedValueOnce({ done: false, value: new Uint8Array(256 * 1024) })
+        .mockResolvedValueOnce({ done: false, value: new Uint8Array(1) }),
+      cancel: vi.fn().mockResolvedValue(undefined),
+    }
+    const response = {
+      ok: true,
+      headers: new Headers({ 'content-type': 'image/svg+xml' }),
+      body: { getReader: () => reader },
+      arrayBuffer: vi.fn(),
+    } as unknown as Response
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(response)
+    const fileSystem = missingFileSystem()
+
+    await expect(createBootstrapIconLoader(storageUri, fileSystem, fetcher)('boxes')).resolves.toEqual({
+      base64data: null,
+    })
+
+    expect(reader.cancel).toHaveBeenCalledOnce()
+    expect(response.arrayBuffer).not.toHaveBeenCalled()
+    expect(fileSystem.writeFile).not.toHaveBeenCalled()
+  })
+
   it('returns null on fetch failure and does not cache successful results in process', async () => {
     const failing = vi.fn<typeof fetch>().mockRejectedValue(new Error('offline'))
     const loadFailing = createBootstrapIconLoader(storageUri, missingFileSystem(), failing)

--- a/packages/vscode/src/panel/bootstrapIcon.spec.ts
+++ b/packages/vscode/src/panel/bootstrapIcon.spec.ts
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
 import { describe, expect, it, vi } from 'vitest'
 import { createBootstrapIconLoader, isBootstrapIconName } from './bootstrapIcon'
 
@@ -35,7 +39,7 @@ describe('bootstrap icon loader', () => {
 
   it('rejects non-SVG and oversized responses', async () => {
     const nonSvg = vi.fn<typeof fetch>().mockResolvedValue(
-      new Response('x', { headers: { 'content-type': 'text/html' } }),
+      new Response('x', { headers: { 'content-type': 'image/svg+xmlfoo' } }),
     )
     const oversized = vi.fn<typeof fetch>().mockResolvedValue(
       new Response('x'.repeat(256 * 1024 + 1), { headers: { 'content-type': 'image/svg+xml' } }),
@@ -47,7 +51,10 @@ describe('bootstrap icon loader', () => {
 
   it('returns null on fetch failure and caches only successful results', async () => {
     const failing = vi.fn<typeof fetch>().mockRejectedValue(new Error('offline'))
-    await expect(createBootstrapIconLoader(failing)('boxes')).resolves.toEqual({ base64data: null })
+    const loadFailing = createBootstrapIconLoader(failing)
+    await expect(loadFailing('boxes')).resolves.toEqual({ base64data: null })
+    await expect(loadFailing('boxes')).resolves.toEqual({ base64data: null })
+    expect(failing).toHaveBeenCalledTimes(2)
 
     const succeeding = vi.fn<typeof fetch>().mockResolvedValue(
       new Response(svg, { headers: { 'content-type': 'image/svg+xml' } }),

--- a/packages/vscode/src/panel/bootstrapIcon.spec.ts
+++ b/packages/vscode/src/panel/bootstrapIcon.spec.ts
@@ -38,6 +38,14 @@ const svgBytes = new TextEncoder().encode(svg)
 const storageUri = vscode.Uri.parse('file:///global-storage')
 const storageDirUri = vscode.Uri.joinPath(storageUri, 'bootstrap-icons')
 const storageFileUri = vscode.Uri.joinPath(storageDirUri, 'boxes.svg')
+const missingFileSystem = () => ({
+  readFile: vi.fn().mockRejectedValue(new Error('FileNotFound')),
+  writeFile: vi.fn().mockResolvedValue(undefined),
+  createDirectory: vi.fn().mockResolvedValue(undefined),
+})
+const expectUri = (actual: { toString(): string } | undefined, expected: { toString(): string }) => {
+  expect(actual?.toString()).toBe(expected.toString())
+}
 
 describe('bootstrap icon loader', () => {
   it('defines a dedicated Bootstrap-icon request', () => {
@@ -56,7 +64,7 @@ describe('bootstrap icon loader', () => {
     const fetcher = vi.fn<typeof fetch>().mockResolvedValue(
       new Response(svg, { headers: { 'content-type': 'image/svg+xml; charset=utf-8' } }),
     )
-    const load = createBootstrapIconLoader(fetcher)
+    const load = createBootstrapIconLoader(storageUri, missingFileSystem(), fetcher)
 
     await expect(load('boxes')).resolves.toEqual({
       base64data: `data:image/svg+xml;base64,${Buffer.from(svg).toString('base64')}`,
@@ -83,7 +91,8 @@ describe('bootstrap icon loader', () => {
     expect(storageUri.fsPath).toBe('/global-storage')
     expect(storageDirUri.toString()).toBe('file:///global-storage/bootstrap-icons')
     expect(storageFileUri.toString()).toBe('file:///global-storage/bootstrap-icons/boxes.svg')
-    expect(fileSystem.readFile).toHaveBeenCalledWith(storageFileUri)
+    expect(fileSystem.readFile).toHaveBeenCalledOnce()
+    expectUri(fileSystem.readFile.mock.calls[0]?.[0], storageFileUri)
     expect(fileSystem.createDirectory).not.toHaveBeenCalled()
     expect(fileSystem.writeFile).not.toHaveBeenCalled()
     expect(fetcher).not.toHaveBeenCalled()
@@ -103,9 +112,13 @@ describe('bootstrap icon loader', () => {
     await expect(load('boxes')).resolves.toEqual({
       base64data: `data:image/svg+xml;base64,${Buffer.from(svg).toString('base64')}`,
     })
-    expect(fileSystem.readFile).toHaveBeenCalledWith(storageFileUri)
-    expect(fileSystem.createDirectory).toHaveBeenCalledWith(storageDirUri)
-    expect(fileSystem.writeFile).toHaveBeenCalledWith(storageFileUri, svgBytes)
+    expect(fileSystem.readFile).toHaveBeenCalledOnce()
+    expectUri(fileSystem.readFile.mock.calls[0]?.[0], storageFileUri)
+    expect(fileSystem.createDirectory).toHaveBeenCalledOnce()
+    expectUri(fileSystem.createDirectory.mock.calls[0]?.[0], storageDirUri)
+    expect(fileSystem.writeFile).toHaveBeenCalledOnce()
+    expectUri(fileSystem.writeFile.mock.calls[0]?.[0], storageFileUri)
+    expect(fileSystem.writeFile.mock.calls[0]?.[1]).toEqual(svgBytes)
     expect(fetcher).toHaveBeenCalledWith(
       'https://icons.like-c4.dev/bootstrap/boxes.svg',
       expect.objectContaining({ signal: expect.any(AbortSignal) }),
@@ -126,9 +139,13 @@ describe('bootstrap icon loader', () => {
     await expect(load('boxes')).resolves.toEqual({
       base64data: `data:image/svg+xml;base64,${Buffer.from(svg).toString('base64')}`,
     })
-    expect(fileSystem.readFile).toHaveBeenCalledWith(storageFileUri)
-    expect(fileSystem.createDirectory).toHaveBeenCalledWith(storageDirUri)
-    expect(fileSystem.writeFile).toHaveBeenCalledWith(storageFileUri, svgBytes)
+    expect(fileSystem.readFile).toHaveBeenCalledOnce()
+    expectUri(fileSystem.readFile.mock.calls[0]?.[0], storageFileUri)
+    expect(fileSystem.createDirectory).toHaveBeenCalledOnce()
+    expectUri(fileSystem.createDirectory.mock.calls[0]?.[0], storageDirUri)
+    expect(fileSystem.writeFile).toHaveBeenCalledOnce()
+    expectUri(fileSystem.writeFile.mock.calls[0]?.[0], storageFileUri)
+    expect(fileSystem.writeFile.mock.calls[0]?.[1]).toEqual(svgBytes)
     expect(fetcher).toHaveBeenCalledWith(
       'https://icons.like-c4.dev/bootstrap/boxes.svg',
       expect.objectContaining({ signal: expect.any(AbortSignal) }),
@@ -149,9 +166,13 @@ describe('bootstrap icon loader', () => {
     await expect(load('boxes')).resolves.toEqual({
       base64data: `data:image/svg+xml;base64,${Buffer.from(svg).toString('base64')}`,
     })
-    expect(fileSystem.readFile).toHaveBeenCalledWith(storageFileUri)
-    expect(fileSystem.createDirectory).toHaveBeenCalledWith(storageDirUri)
-    expect(fileSystem.writeFile).toHaveBeenCalledWith(storageFileUri, svgBytes)
+    expect(fileSystem.readFile).toHaveBeenCalledOnce()
+    expectUri(fileSystem.readFile.mock.calls[0]?.[0], storageFileUri)
+    expect(fileSystem.createDirectory).toHaveBeenCalledOnce()
+    expectUri(fileSystem.createDirectory.mock.calls[0]?.[0], storageDirUri)
+    expect(fileSystem.writeFile).toHaveBeenCalledOnce()
+    expectUri(fileSystem.writeFile.mock.calls[0]?.[0], storageFileUri)
+    expect(fileSystem.writeFile.mock.calls[0]?.[1]).toEqual(svgBytes)
     expect(fetcher).toHaveBeenCalledWith(
       'https://icons.like-c4.dev/bootstrap/boxes.svg',
       expect.objectContaining({ signal: expect.any(AbortSignal) }),
@@ -160,7 +181,9 @@ describe('bootstrap icon loader', () => {
 
   it('returns null without fetching an invalid name', async () => {
     const fetcher = vi.fn<typeof fetch>()
-    await expect(createBootstrapIconLoader(fetcher)('../boxes')).resolves.toEqual({ base64data: null })
+    await expect(createBootstrapIconLoader(storageUri, missingFileSystem(), fetcher)('../boxes')).resolves.toEqual({
+      base64data: null,
+    })
     expect(fetcher).not.toHaveBeenCalled()
   })
 
@@ -172,13 +195,17 @@ describe('bootstrap icon loader', () => {
       new Response('x'.repeat(256 * 1024 + 1), { headers: { 'content-type': 'image/svg+xml' } }),
     )
 
-    await expect(createBootstrapIconLoader(nonSvg)('boxes')).resolves.toEqual({ base64data: null })
-    await expect(createBootstrapIconLoader(oversized)('boxes')).resolves.toEqual({ base64data: null })
+    await expect(createBootstrapIconLoader(storageUri, missingFileSystem(), nonSvg)('boxes')).resolves.toEqual({
+      base64data: null,
+    })
+    await expect(createBootstrapIconLoader(storageUri, missingFileSystem(), oversized)('boxes')).resolves.toEqual({
+      base64data: null,
+    })
   })
 
-  it('returns null on fetch failure and caches only successful results', async () => {
+  it('returns null on fetch failure and does not cache successful results in process', async () => {
     const failing = vi.fn<typeof fetch>().mockRejectedValue(new Error('offline'))
-    const loadFailing = createBootstrapIconLoader(failing)
+    const loadFailing = createBootstrapIconLoader(storageUri, missingFileSystem(), failing)
     await expect(loadFailing('boxes')).resolves.toEqual({ base64data: null })
     await expect(loadFailing('boxes')).resolves.toEqual({ base64data: null })
     expect(failing).toHaveBeenCalledTimes(2)
@@ -186,9 +213,9 @@ describe('bootstrap icon loader', () => {
     const succeeding = vi.fn<typeof fetch>().mockResolvedValue(
       new Response(svg, { headers: { 'content-type': 'image/svg+xml' } }),
     )
-    const load = createBootstrapIconLoader(succeeding)
+    const load = createBootstrapIconLoader(storageUri, missingFileSystem(), succeeding)
     await load('boxes')
     await load('boxes')
-    expect(succeeding).toHaveBeenCalledTimes(1)
+    expect(succeeding).toHaveBeenCalledTimes(2)
   })
 })

--- a/packages/vscode/src/panel/bootstrapIcon.ts
+++ b/packages/vscode/src/panel/bootstrapIcon.ts
@@ -2,25 +2,41 @@
 //
 // Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
+import * as vscode from 'vscode'
+
 const bootstrapIconName = /^[a-z0-9][a-z0-9-]{0,127}$/
 const maxSvgBytes = 256 * 1024
 const bootstrapIconUrl = (name: string) => `https://icons.like-c4.dev/bootstrap/${name}.svg`
 
 export type BootstrapIconResult = { base64data: string | null }
 
+type IconFileSystem = Pick<typeof vscode.workspace.fs, 'readFile' | 'writeFile' | 'createDirectory'>
+
 export const isBootstrapIconName = (name: string) => bootstrapIconName.test(name)
 
-export function createBootstrapIconLoader(fetcher: typeof fetch = fetch) {
-  const cache = new Map<string, string>()
+const bootstrapIconCacheUri = (storageUri: vscode.Uri, name: string) =>
+  vscode.Uri.joinPath(storageUri, 'bootstrap-icons', `${name}.svg`)
 
+export function createBootstrapIconLoader(
+  storageUri: vscode.Uri,
+  fileSystem: IconFileSystem = vscode.workspace.fs,
+  fetcher: typeof fetch = fetch,
+) {
   return async (name: string): Promise<BootstrapIconResult> => {
     if (!isBootstrapIconName(name)) {
       return { base64data: null }
     }
-    const cached = cache.get(name)
-    if (cached) {
-      return { base64data: cached }
+
+    const iconUri = bootstrapIconCacheUri(storageUri, name)
+    try {
+      const bytes = await fileSystem.readFile(iconUri)
+      if (bytes.byteLength <= maxSvgBytes) {
+        return { base64data: `data:image/svg+xml;base64,${Buffer.from(bytes).toString('base64')}` }
+      }
+    } catch {
+      // Cache misses and storage errors fall through to the CDN.
     }
+
     try {
       const response = await fetcher(bootstrapIconUrl(name), { signal: AbortSignal.timeout(10_000) })
       const contentType = response.headers.get('content-type')?.split(';', 1)[0]?.trim().toLowerCase() ?? ''
@@ -32,7 +48,12 @@ export function createBootstrapIconLoader(fetcher: typeof fetch = fetch) {
         return { base64data: null }
       }
       const base64data = `data:image/svg+xml;base64,${Buffer.from(bytes).toString('base64')}`
-      cache.set(name, base64data)
+      try {
+        await fileSystem.createDirectory(vscode.Uri.joinPath(storageUri, 'bootstrap-icons'))
+        await fileSystem.writeFile(iconUri, bytes)
+      } catch {
+        // The icon remains usable when storage is unavailable.
+      }
       return { base64data }
     } catch {
       return { base64data: null }

--- a/packages/vscode/src/panel/bootstrapIcon.ts
+++ b/packages/vscode/src/panel/bootstrapIcon.ts
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
 const bootstrapIconName = /^[a-z0-9][a-z0-9-]{0,127}$/
 const maxSvgBytes = 256 * 1024
 const bootstrapIconUrl = (name: string) => `https://icons.like-c4.dev/bootstrap/${name}.svg`
@@ -19,8 +23,8 @@ export function createBootstrapIconLoader(fetcher: typeof fetch = fetch) {
     }
     try {
       const response = await fetcher(bootstrapIconUrl(name), { signal: AbortSignal.timeout(10_000) })
-      const contentType = response.headers.get('content-type')?.toLowerCase() ?? ''
-      if (!response.ok || !contentType.startsWith('image/svg+xml')) {
+      const contentType = response.headers.get('content-type')?.split(';', 1)[0]?.trim().toLowerCase() ?? ''
+      if (!response.ok || contentType !== 'image/svg+xml') {
         return { base64data: null }
       }
       const bytes = new Uint8Array(await response.arrayBuffer())

--- a/packages/vscode/src/panel/bootstrapIcon.ts
+++ b/packages/vscode/src/panel/bootstrapIcon.ts
@@ -1,0 +1,37 @@
+const bootstrapIconName = /^[a-z0-9][a-z0-9-]{0,127}$/
+const maxSvgBytes = 256 * 1024
+const bootstrapIconUrl = (name: string) => `https://icons.like-c4.dev/bootstrap/${name}.svg`
+
+export type BootstrapIconResult = { base64data: string | null }
+
+export const isBootstrapIconName = (name: string) => bootstrapIconName.test(name)
+
+export function createBootstrapIconLoader(fetcher: typeof fetch = fetch) {
+  const cache = new Map<string, string>()
+
+  return async (name: string): Promise<BootstrapIconResult> => {
+    if (!isBootstrapIconName(name)) {
+      return { base64data: null }
+    }
+    const cached = cache.get(name)
+    if (cached) {
+      return { base64data: cached }
+    }
+    try {
+      const response = await fetcher(bootstrapIconUrl(name), { signal: AbortSignal.timeout(10_000) })
+      const contentType = response.headers.get('content-type')?.toLowerCase() ?? ''
+      if (!response.ok || !contentType.startsWith('image/svg+xml')) {
+        return { base64data: null }
+      }
+      const bytes = new Uint8Array(await response.arrayBuffer())
+      if (bytes.byteLength > maxSvgBytes) {
+        return { base64data: null }
+      }
+      const base64data = `data:image/svg+xml;base64,${Buffer.from(bytes).toString('base64')}`
+      cache.set(name, base64data)
+      return { base64data }
+    } catch {
+      return { base64data: null }
+    }
+  }
+}

--- a/packages/vscode/src/panel/bootstrapIcon.ts
+++ b/packages/vscode/src/panel/bootstrapIcon.ts
@@ -17,6 +17,36 @@ export const isBootstrapIconName = (name: string) => bootstrapIconName.test(name
 const bootstrapIconCacheUri = (storageUri: vscode.Uri, name: string) =>
   vscode.Uri.joinPath(storageUri, 'bootstrap-icons', `${name}.svg`)
 
+async function readBoundedResponseBody(response: Response): Promise<Uint8Array | null> {
+  const reader = response.body?.getReader()
+  if (!reader) {
+    return null
+  }
+
+  const chunks: Uint8Array[] = []
+  let totalBytes = 0
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) {
+      break
+    }
+    totalBytes += value.byteLength
+    if (totalBytes > maxSvgBytes) {
+      await reader.cancel()
+      return null
+    }
+    chunks.push(value)
+  }
+
+  const bytes = new Uint8Array(totalBytes)
+  let offset = 0
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+  return bytes
+}
+
 export function createBootstrapIconLoader(
   storageUri: vscode.Uri,
   fileSystem: IconFileSystem = vscode.workspace.fs,
@@ -43,8 +73,8 @@ export function createBootstrapIconLoader(
       if (!response.ok || contentType !== 'image/svg+xml') {
         return { base64data: null }
       }
-      const bytes = new Uint8Array(await response.arrayBuffer())
-      if (bytes.byteLength > maxSvgBytes) {
+      const bytes = await readBoundedResponseBody(response)
+      if (!bytes) {
         return { base64data: null }
       }
       const base64data = `data:image/svg+xml;base64,${Buffer.from(bytes).toString('base64')}`

--- a/packages/vscode/src/panel/writeHTMLToWebview.spec.ts
+++ b/packages/vscode/src/panel/writeHTMLToWebview.spec.ts
@@ -28,8 +28,10 @@ describe('writeHTMLToWebview', () => {
 
     writeHTMLToWebview({ webview } as never, { screen: 'view' })
 
-    expect(webview.html).toMatch(/style-src vscode-webview:\/\/likec4 'nonce-[^']+';/)
-    expect(webview.html).not.toContain('style-src vscode-webview://likec4 \'unsafe-inline\';')
+    const styleSrc = webview.html.match(/style-src ([^;]+);/)?.[1]
+
+    expect(styleSrc).toMatch(/^vscode-webview:\/\/likec4 'nonce-[A-Za-z0-9]{16}'$/)
+    expect(styleSrc).not.toContain('unsafe-inline')
     expect(webview.html).toContain('style-src-attr \'unsafe-inline\';')
     expect(webview.html).toContain('script-src \'nonce-')
   })

--- a/packages/vscode/src/panel/writeHTMLToWebview.spec.ts
+++ b/packages/vscode/src/panel/writeHTMLToWebview.spec.ts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('reactive-vscode', () => ({
+  computed: (value: () => boolean) => ({ value: value() }),
+  extensionContext: { value: { extensionUri: {} } },
+  useIsDarkTheme: () => ({ value: false }),
+  watch: (source: { value: boolean }, callback: (value: boolean) => void, options: { immediate?: boolean }) => {
+    if (options.immediate) callback(source.value)
+  },
+}))
+vi.mock('vscode', () => ({ Uri: { joinPath: (...parts: unknown[]) => parts.join('/') } }))
+vi.mock('../const.ts', () => ({ hasAI: false, isProd: true }))
+
+import { writeHTMLToWebview } from './writeHTMLToWebview'
+
+describe('writeHTMLToWebview', () => {
+  it('permits inline style attributes without relaxing production style or script sources', () => {
+    const webview = {
+      asWebviewUri: vi.fn(() => 'vscode-webview://likec4/resource'),
+      cspSource: 'vscode-webview://likec4',
+      html: '',
+      options: {},
+    }
+
+    writeHTMLToWebview({ webview } as never, { screen: 'view' })
+
+    expect(webview.html).toContain('style-src vscode-webview://likec4 \'nonce-')
+    expect(webview.html).toContain('style-src-attr \'unsafe-inline\';')
+    expect(webview.html).toContain('script-src \'nonce-')
+  })
+})

--- a/packages/vscode/src/panel/writeHTMLToWebview.spec.ts
+++ b/packages/vscode/src/panel/writeHTMLToWebview.spec.ts
@@ -4,6 +4,8 @@
 
 import { describe, expect, it, vi } from 'vitest'
 
+import { writeHTMLToWebview } from './writeHTMLToWebview'
+
 vi.mock('reactive-vscode', () => ({
   computed: (value: () => boolean) => ({ value: value() }),
   extensionContext: { value: { extensionUri: {} } },
@@ -15,12 +17,10 @@ vi.mock('reactive-vscode', () => ({
 vi.mock('vscode', () => ({ Uri: { joinPath: (...parts: unknown[]) => parts.join('/') } }))
 vi.mock('../const.ts', () => ({ hasAI: false, isProd: true }))
 
-import { writeHTMLToWebview } from './writeHTMLToWebview'
-
 describe('writeHTMLToWebview', () => {
   it('permits inline style attributes without relaxing production style or script sources', () => {
     const webview = {
-      asWebviewUri: vi.fn(() => 'vscode-webview://likec4/resource'),
+      asWebviewUri: vi.fn<() => string>(() => 'vscode-webview://likec4/resource'),
       cspSource: 'vscode-webview://likec4',
       html: '',
       options: {},
@@ -28,11 +28,20 @@ describe('writeHTMLToWebview', () => {
 
     writeHTMLToWebview({ webview } as never, { screen: 'view' })
 
-    const styleSrc = webview.html.match(/style-src ([^;]+);/)?.[1]
+    const cspContent = webview.html.match(/Content-Security-Policy" content="([^"]+)"/)?.[1] ?? ''
+    const directives = Object.fromEntries(
+      cspContent.split(';').filter(Boolean).map(directive => {
+        const [name, ...values] = directive.trim().split(/\s+/)
+        return [name, values]
+      }),
+    )
 
-    expect(styleSrc).toMatch(/^vscode-webview:\/\/likec4 'nonce-[A-Za-z0-9]{16}'$/)
-    expect(styleSrc).not.toContain('unsafe-inline')
-    expect(webview.html).toContain('style-src-attr \'unsafe-inline\';')
-    expect(webview.html).toContain('script-src \'nonce-')
+    expect(directives['style-src']).toEqual([
+      'vscode-webview://likec4',
+      expect.stringMatching(/^'nonce-[A-Za-z0-9]{16}'$/),
+    ])
+    expect(directives['style-src-attr']).toEqual(['\'unsafe-inline\''])
+    expect(directives['script-src']).toEqual([expect.stringMatching(/^'nonce-[A-Za-z0-9]{16}'$/)])
+    expect(cspContent.match(/'unsafe-inline'/g)).toHaveLength(1)
   })
 })

--- a/packages/vscode/src/panel/writeHTMLToWebview.spec.ts
+++ b/packages/vscode/src/panel/writeHTMLToWebview.spec.ts
@@ -28,7 +28,8 @@ describe('writeHTMLToWebview', () => {
 
     writeHTMLToWebview({ webview } as never, { screen: 'view' })
 
-    expect(webview.html).toContain('style-src vscode-webview://likec4 \'nonce-')
+    expect(webview.html).toMatch(/style-src vscode-webview:\/\/likec4 'nonce-[^']+';/)
+    expect(webview.html).not.toContain('style-src vscode-webview://likec4 \'unsafe-inline\';')
     expect(webview.html).toContain('style-src-attr \'unsafe-inline\';')
     expect(webview.html).toContain('script-src \'nonce-')
   })

--- a/packages/vscode/src/panel/writeHTMLToWebview.ts
+++ b/packages/vscode/src/panel/writeHTMLToWebview.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import type { ProjectId, ViewId } from '@likec4/core/types'
 import { computed, extensionContext, useIsDarkTheme, watch } from 'reactive-vscode'
 import { type Webview, type WebviewPanel, Uri } from 'vscode'
@@ -35,7 +42,9 @@ export function writeHTMLToWebview(
     const cspDirectives = [
       `default-src 'none';`,
       `font-src ${cspSource} data: https: 'nonce-${nonce}';`,
-      isProd ? `style-src ${cspSource} 'nonce-${nonce}';` : `style-src ${cspSource} 'unsafe-inline';`,
+      isProd
+        ? `style-src ${cspSource} 'nonce-${nonce}'; style-src-attr 'unsafe-inline';`
+        : `style-src ${cspSource} 'unsafe-inline';`,
       `img-src ${cspSource} data: https:;`,
       `script-src 'nonce-${nonce}';`,
     ]

--- a/packages/vscode/src/useMessenger.ts
+++ b/packages/vscode/src/useMessenger.ts
@@ -9,6 +9,7 @@ import {
   FetchProjectsOverview,
   GetLastClickedNode,
   OnOpenView,
+  ReadBootstrapIcon,
   ReadLocalIcon,
   ViewChangeReq,
   WebviewMsgs,
@@ -107,6 +108,7 @@ export const useMessenger = createSingletonComposable(() => {
     handleFetchComputedModel: requestHandler(FetchComputedModel),
     handleFetchLayoutedView: requestHandler(FetchLayoutedView),
     handleFetchProjectsOverview: requestHandler(FetchProjectsOverview),
+    handleReadBootstrapIcon: requestHandler(ReadBootstrapIcon),
     handleReadLocalIcon: requestHandler(ReadLocalIcon),
     handleViewChange: requestHandler(ViewChangeReq),
 

--- a/packages/vscode/vitest.config.ts
+++ b/packages/vscode/vitest.config.ts
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import { defineVitest } from '@likec4/devops/vitest'
+
+export default defineVitest('vscode')


### PR DESCRIPTION
## Summary

Fixes #3142.

- Load Bootstrap SVG icons in the extension host. The webview requests SVG data from the extension host and paints it as CSS masks. It does not fetch Bootstrap SVG files from the CDN.
- Cache validated Bootstrap SVG files in VS Code global extension storage. Read the cache first. Fetch and save only when the cache is missing, too large, or unavailable.
- Keep the icon name validation, 256 KiB limit, fixed CDN URL, timeout, and SVG response checks.
- Stop reading an oversized CDN response before the loader buffers the complete body.
- Allow inline style attributes in the production VS Code webview CSP. Keep stylesheet and script restrictions.

## Validation

- Bootstrap loader tests: 11 passed.
- VS Code preview tests: 11 passed.
- VS Code package typecheck passed.
- Full `pnpm typecheck` passed before the bounded-reader correction.

## Limitation

Windows visual E2E did not run. The current live CDN does not reproduce the reported historical CORS response.