### PR TITLE
test(vscode): probe Bootstrap icon CSP on Windows

### DIFF
--- a/.changeset/vscode-bootstrap-icon-cors.md
+++ b/.changeset/vscode-bootstrap-icon-cors.md
@@ -1,0 +1,6 @@
+---
+"@likec4/vscode-preview": patch
+"likec4-vscode": patch
+---
+
+Render Bootstrap icons in the VS Code preview when webview CORS blocks the icon CDN.

--- a/.changeset/vscode-bootstrap-icon-csp.md
+++ b/.changeset/vscode-bootstrap-icon-csp.md
@@ -1,0 +1,5 @@
+---
+'likec4-vscode': patch
+---
+
+Restore Bootstrap icons and their configured colors in the VS Code preview.

--- a/.github/workflows/vscode-windows-csp-probe.yaml
+++ b/.github/workflows/vscode-windows-csp-probe.yaml
@@ -8,6 +8,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/vscode-windows-csp-probe.yaml'
+      - 'scripts/assert-vscode-bootstrap-cors-probe.ps1'
       - 'scripts/capture-vscode-preview.ps1'
       - 'scripts/start-bootstrap-icon-cors-server.ps1'
       - 'packages/vscode/**'

--- a/.github/workflows/vscode-windows-csp-probe.yaml
+++ b/.github/workflows/vscode-windows-csp-probe.yaml
@@ -73,6 +73,15 @@ jobs:
               }
             }
 
+            element sentinel {
+              style {
+                icon bootstrap:buildings-fill
+                iconColor #ff00ff
+                iconSize large
+                iconPosition top
+              }
+            }
+
             color pale-white #eff7ff
           }
 
@@ -81,11 +90,12 @@ jobs:
               #prod
               description 'System finansowo-księgowy.'
             }
+            sentinel corsSentinel 'CORS sentinel'
           }
 
           views {
             view index {
-              include *
+              include sap, corsSentinel
             }
           }
           '@ | Set-Content -Encoding utf8 (Join-Path $env:FIXTURE 'model.c4')
@@ -134,6 +144,14 @@ jobs:
             -ExtensionPath "$PWD\\packages\\vscode" `
             -FixturePath $env:FIXTURE `
             -OutputPath "$env:EVIDENCE\\pr.png"
+
+      - name: Assert CORS red and host-loader green
+        shell: pwsh
+        run: |
+          pwsh -NoProfile -ExecutionPolicy Bypass -File ./scripts/assert-vscode-bootstrap-cors-probe.ps1 `
+            -BaselineConsole "$env:EVIDENCE\baseline.png.console.json" -RepairConsole "$env:EVIDENCE\pr.png.console.json" `
+            -BaselinePng "$env:EVIDENCE\baseline.png" -RepairPng "$env:EVIDENCE\pr.png" `
+            -OutputPath "$env:EVIDENCE\probe-result.json"
 
       - name: Remove controlled Bootstrap CDN
         if: always()

--- a/.github/workflows/vscode-windows-csp-probe.yaml
+++ b/.github/workflows/vscode-windows-csp-probe.yaml
@@ -9,6 +9,7 @@ on:
     paths:
       - '.github/workflows/vscode-windows-csp-probe.yaml'
       - 'scripts/assert-vscode-bootstrap-cors-probe.ps1'
+      - 'scripts/capture-vscode-webview.mjs'
       - 'scripts/capture-vscode-preview.ps1'
       - 'scripts/start-bootstrap-icon-cors-server.ps1'
       - 'packages/vscode/**'

--- a/.github/workflows/vscode-windows-csp-probe.yaml
+++ b/.github/workflows/vscode-windows-csp-probe.yaml
@@ -102,6 +102,12 @@ jobs:
           }
           '@ | Set-Content -Encoding utf8 (Join-Path $env:FIXTURE 'model.c4')
 
+      - name: Parse CORS assertion script
+        shell: pwsh
+        run: |
+          $source = Get-Content -LiteralPath ./scripts/assert-vscode-bootstrap-cors-probe.ps1 -Raw
+          $null = [ScriptBlock]::Create($source)
+
       - name: Start controlled Bootstrap CDN
         shell: pwsh
         run: |

--- a/.github/workflows/vscode-windows-csp-probe.yaml
+++ b/.github/workflows/vscode-windows-csp-probe.yaml
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+name: VS Code Windows CSP probe
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/vscode-windows-csp-probe.yaml'
+      - 'scripts/capture-vscode-preview.ps1'
+      - 'packages/vscode/**'
+      - 'packages/vscode-preview/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  probe:
+    name: CSP baseline versus PR
+    runs-on: windows-2022
+    timeout-minutes: 30
+    env:
+      BASELINE_REF: 43f0b705d
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node and pnpm
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22.22.3
+
+      - name: Enable pnpm
+        shell: pwsh
+        run: |
+          corepack enable
+          corepack prepare pnpm@11.15.0 --activate
+          pnpm --version
+
+      - name: Set probe paths
+        shell: pwsh
+        run: |
+          "FIXTURE=$env:RUNNER_TEMP\\likec4-csp-fixture" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "EVIDENCE=$env:RUNNER_TEMP\\likec4-csp-evidence" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Install VS Code
+        shell: pwsh
+        run: |
+          if (-not (Get-Command code.cmd -ErrorAction SilentlyContinue) -and -not (Get-Command code -ErrorAction SilentlyContinue)) {
+            choco install vscode --yes --no-progress
+            $env:Path = "$env:ProgramFiles\\Microsoft VS Code\\bin;$env:Path"
+            "C:\\Program Files\\Microsoft VS Code\\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          }
+          code --version
+
+      - name: Create reporter fixture
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force $env:FIXTURE | Out-Null
+          @'
+          specification {
+            element system {
+              style {
+                opacity 10%
+                icon bootstrap:boxes
+                iconColor pale-white
+                iconSize small
+                iconPosition top
+              }
+            }
+
+            color pale-white #eff7ff
+          }
+
+          model {
+            system sap 'SAP' {
+              #prod
+              description 'System finansowo-księgowy.'
+            }
+          }
+
+          views {
+            view index {
+              include *
+            }
+          }
+          '@ | Set-Content -Encoding utf8 (Join-Path $env:FIXTURE 'model.c4')
+
+      - name: Build v1.59.3 baseline extension
+        shell: pwsh
+        env:
+          NODE_ENV: production
+        run: |
+          git worktree add "$env:RUNNER_TEMP\\likec4-baseline" $env:BASELINE_REF
+          Set-Location "$env:RUNNER_TEMP\\likec4-baseline"
+          pnpm install --frozen-lockfile
+          pnpm generate
+          pnpm --filter @likec4/vscode-preview build
+          pnpm --filter likec4-vscode build
+
+      - name: Build PR extension
+        shell: pwsh
+        env:
+          NODE_ENV: production
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm generate
+          pnpm --filter @likec4/vscode-preview build
+          pnpm --filter likec4-vscode build
+
+      - name: Capture baseline and PR previews
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force $env:EVIDENCE | Out-Null
+          pwsh -NoProfile -ExecutionPolicy Bypass -File ./scripts/capture-vscode-preview.ps1 `
+            -Label baseline `
+            -ExtensionPath "$env:RUNNER_TEMP\\likec4-baseline\\packages\\vscode" `
+            -FixturePath $env:FIXTURE `
+            -OutputPath "$env:EVIDENCE\\baseline.png"
+          pwsh -NoProfile -ExecutionPolicy Bypass -File ./scripts/capture-vscode-preview.ps1 `
+            -Label pr `
+            -ExtensionPath "$PWD\\packages\\vscode" `
+            -FixturePath $env:FIXTURE `
+            -OutputPath "$env:EVIDENCE\\pr.png"
+
+      - name: Upload probe evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: vscode-windows-csp-probe
+          path: ${{ env.EVIDENCE }}
+          if-no-files-found: warn

--- a/.github/workflows/vscode-windows-csp-probe.yaml
+++ b/.github/workflows/vscode-windows-csp-probe.yaml
@@ -89,6 +89,14 @@ jobs:
           }
           '@ | Set-Content -Encoding utf8 (Join-Path $env:FIXTURE 'model.c4')
 
+      - name: Start controlled Bootstrap CDN
+        shell: pwsh
+        run: |
+          pwsh -NoProfile -ExecutionPolicy Bypass -File ./scripts/start-bootstrap-icon-cors-server.ps1 -EvidencePath $env:EVIDENCE
+          $response = Invoke-WebRequest -UseBasicParsing https://icons.like-c4.dev/bootstrap/boxes.svg
+          if ($response.Content -notmatch '<svg') { throw 'Controlled SVG endpoint did not respond.' }
+          if ($response.Headers['Access-Control-Allow-Origin']) { throw 'Controlled SVG endpoint unexpectedly sent a CORS header.' }
+
       - name: Build v1.59.3 baseline extension
         shell: pwsh
         env:
@@ -125,6 +133,18 @@ jobs:
             -ExtensionPath "$PWD\\packages\\vscode" `
             -FixturePath $env:FIXTURE `
             -OutputPath "$env:EVIDENCE\\pr.png"
+
+      - name: Remove controlled Bootstrap CDN
+        if: always()
+        shell: pwsh
+        run: |
+          if ($env:ICON_CDN_PID) { Stop-Process -Id $env:ICON_CDN_PID -Force -ErrorAction SilentlyContinue }
+          if ($env:ICON_CDN_PORT) { netsh http delete sslcert ipport="0.0.0.0:$env:ICON_CDN_PORT" }
+          if ($env:ICON_CDN_HOSTS_BACKUP -and (Test-Path $env:ICON_CDN_HOSTS_BACKUP)) { Copy-Item -Force $env:ICON_CDN_HOSTS_BACKUP "$env:WINDIR\System32\drivers\etc\hosts" }
+          if ($env:ICON_CDN_CERT_THUMBPRINT) {
+            Remove-Item -Force "Cert:\LocalMachine\My\$env:ICON_CDN_CERT_THUMBPRINT" -ErrorAction SilentlyContinue
+            Remove-Item -Force "Cert:\LocalMachine\Root\$env:ICON_CDN_CERT_THUMBPRINT" -ErrorAction SilentlyContinue
+          }
 
       - name: Upload probe evidence
         if: always()

--- a/.github/workflows/vscode-windows-csp-probe.yaml
+++ b/.github/workflows/vscode-windows-csp-probe.yaml
@@ -9,6 +9,7 @@ on:
     paths:
       - '.github/workflows/vscode-windows-csp-probe.yaml'
       - 'scripts/capture-vscode-preview.ps1'
+      - 'scripts/start-bootstrap-icon-cors-server.ps1'
       - 'packages/vscode/**'
       - 'packages/vscode-preview/**'
   workflow_dispatch:
@@ -93,7 +94,7 @@ jobs:
         shell: pwsh
         run: |
           pwsh -NoProfile -ExecutionPolicy Bypass -File ./scripts/start-bootstrap-icon-cors-server.ps1 -EvidencePath $env:EVIDENCE
-          $response = Invoke-WebRequest -UseBasicParsing https://icons.like-c4.dev/bootstrap/boxes.svg
+          $response = Invoke-WebRequest -UseBasicParsing https://icons.like-c4.dev/bootstrap/boxes.svg -Headers @{ Origin = 'vscode-webview://probe' }
           if ($response.Content -notmatch '<svg') { throw 'Controlled SVG endpoint did not respond.' }
           if ($response.Headers['Access-Control-Allow-Origin']) { throw 'Controlled SVG endpoint unexpectedly sent a CORS header.' }
 
@@ -140,7 +141,10 @@ jobs:
         run: |
           if ($env:ICON_CDN_PID) { Stop-Process -Id $env:ICON_CDN_PID -Force -ErrorAction SilentlyContinue }
           if ($env:ICON_CDN_PORT) { netsh http delete sslcert ipport="0.0.0.0:$env:ICON_CDN_PORT" }
-          if ($env:ICON_CDN_HOSTS_BACKUP -and (Test-Path $env:ICON_CDN_HOSTS_BACKUP)) { Copy-Item -Force $env:ICON_CDN_HOSTS_BACKUP "$env:WINDIR\System32\drivers\etc\hosts" }
+          if ($env:ICON_CDN_HOSTS_BACKUP -and (Test-Path $env:ICON_CDN_HOSTS_BACKUP)) {
+            Copy-Item -Force $env:ICON_CDN_HOSTS_BACKUP "$env:WINDIR\System32\drivers\etc\hosts"
+            Clear-DnsClientCache -ErrorAction SilentlyContinue
+          }
           if ($env:ICON_CDN_CERT_THUMBPRINT) {
             Remove-Item -Force "Cert:\LocalMachine\My\$env:ICON_CDN_CERT_THUMBPRINT" -ErrorAction SilentlyContinue
             Remove-Item -Force "Cert:\LocalMachine\Root\$env:ICON_CDN_CERT_THUMBPRINT" -ErrorAction SilentlyContinue

--- a/packages/vscode-preview/protocol.ts
+++ b/packages/vscode-preview/protocol.ts
@@ -92,6 +92,10 @@ export const ReadLocalIcon: RequestType</* uri */ string, ReadLocalIconResult> =
   method: 'read-local-icon',
 }
 
+export const ReadBootstrapIcon: RequestType</* name */ string, ReadLocalIconResult> = {
+  method: 'read-bootstrap-icon',
+}
+
 export const ViewChangeReq = { method: 'webview:change' } as RequestType<
   { projectId: ProjectId; viewId: ViewId; change: ViewChange },
   { success: true } | { success: false; error: string }

--- a/packages/vscode-preview/src/IconRenderer.spec.tsx
+++ b/packages/vscode-preview/src/IconRenderer.spec.tsx
@@ -5,9 +5,10 @@
 //
 // Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
 
-import { renderToStaticMarkup } from 'react-dom/server'
-import { describe, expect, it, vi } from 'vitest'
+import { renderToReadableStream, renderToStaticMarkup } from 'react-dom/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { bootstrapIconRendererFromDataUrl, IconRenderer, localIconRendererFromDataUrl } from './IconRenderer'
+import { ExtensionApi } from './vscode'
 
 vi.mock('./vscode', () => ({
   ExtensionApi: {
@@ -17,9 +18,32 @@ vi.mock('./vscode', () => ({
 }))
 
 describe('IconRenderer', () => {
-  it('renders host-provided Bootstrap SVG data as a colorable mask', () => {
+  const bootstrapIconDataUrl = 'data:image/svg+xml;base64,PHN2ZyBmaWxsPSJjdXJyZW50Q29sb3IiLz4='
+  const readBootstrapIcon = vi.mocked(ExtensionApi.readBootstrapIcon)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders host-provided Bootstrap SVG data as a colorable mask', async () => {
+    readBootstrapIcon.mockResolvedValue({ base64data: bootstrapIconDataUrl })
+
+    const html = await renderToHtml(
+      <IconRenderer node={{ id: 'test', title: 'Test', icon: 'bootstrap:boxes' }} />,
+    )
+
+    expect(readBootstrapIcon).toHaveBeenCalledOnce()
+    expect(readBootstrapIcon).toHaveBeenCalledWith('boxes')
+    expect(html).toContain('background-color:currentColor')
+    expect(html).toContain('mask-image:url(')
+    expect(html).toContain('data:image/svg+xml;base64,')
+    expect(html).not.toContain('icons.like-c4.dev')
+    expect(html).not.toContain('<img')
+  })
+
+  it('keeps the synchronous Bootstrap mask helper for callers with host data', () => {
     const BootstrapIcon = bootstrapIconRendererFromDataUrl(
-      'data:image/svg+xml;base64,PHN2ZyBmaWxsPSJjdXJyZW50Q29sb3IiLz4=',
+      bootstrapIconDataUrl,
     )
     const html = renderToStaticMarkup(<BootstrapIcon node={{ id: 'test', title: 'Test', icon: 'bootstrap:boxes' }} />)
 
@@ -29,11 +53,42 @@ describe('IconRenderer', () => {
     expect(html).not.toContain('<img')
   })
 
-  it('renders nothing when the host does not return a Bootstrap SVG', () => {
-    const BootstrapIcon = bootstrapIconRendererFromDataUrl(null)
-    const html = renderToStaticMarkup(<BootstrapIcon node={{ id: 'test', title: 'Test', icon: 'bootstrap:boxes' }} />)
+  it('renders nothing when the host returns no Bootstrap SVG, then retries', async () => {
+    readBootstrapIcon
+      .mockResolvedValueOnce({ base64data: null })
+      .mockResolvedValueOnce({ base64data: bootstrapIconDataUrl })
 
-    expect(html).toBe('')
+    const firstHtml = await renderToHtml(
+      <IconRenderer node={{ id: 'test-empty', title: 'Test', icon: 'bootstrap:empty-retry' }} />,
+    )
+    const secondHtml = await renderToHtml(
+      <IconRenderer node={{ id: 'test-empty', title: 'Test', icon: 'bootstrap:empty-retry' }} />,
+    )
+
+    expect(firstHtml).not.toContain('mask-image:url(')
+    expect(firstHtml).not.toContain('<span')
+    expect(readBootstrapIcon).toHaveBeenNthCalledWith(1, 'empty-retry')
+    expect(readBootstrapIcon).toHaveBeenNthCalledWith(2, 'empty-retry')
+    expect(secondHtml).toContain('mask-image:url(')
+  })
+
+  it('renders nothing when the host rejects, then retries', async () => {
+    readBootstrapIcon
+      .mockRejectedValueOnce(new Error('temporary host failure'))
+      .mockResolvedValueOnce({ base64data: bootstrapIconDataUrl })
+
+    const firstHtml = await renderToHtml(
+      <IconRenderer node={{ id: 'test-error', title: 'Test', icon: 'bootstrap:error-retry' }} />,
+    )
+    const secondHtml = await renderToHtml(
+      <IconRenderer node={{ id: 'test-error', title: 'Test', icon: 'bootstrap:error-retry' }} />,
+    )
+
+    expect(firstHtml).not.toContain('mask-image:url(')
+    expect(firstHtml).not.toContain('<span')
+    expect(readBootstrapIcon).toHaveBeenNthCalledWith(1, 'error-retry')
+    expect(readBootstrapIcon).toHaveBeenNthCalledWith(2, 'error-retry')
+    expect(secondHtml).toContain('mask-image:url(')
   })
 
   it('keeps non-bootstrap bundled icons as CDN images', () => {
@@ -161,3 +216,18 @@ describe('IconRenderer', () => {
     expect(html).toBe('')
   })
 })
+
+async function renderToHtml(element: React.ReactNode): Promise<string> {
+  const stream = await renderToReadableStream(element)
+  const reader = stream.getReader()
+  const decoder = new TextDecoder()
+  let html = ''
+
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) {
+      return html + decoder.decode()
+    }
+    html += decoder.decode(value, { stream: true })
+  }
+}

--- a/packages/vscode-preview/src/IconRenderer.spec.tsx
+++ b/packages/vscode-preview/src/IconRenderer.spec.tsx
@@ -7,28 +7,33 @@
 
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it, vi } from 'vitest'
-import { IconRenderer, localIconRendererFromDataUrl } from './IconRenderer'
+import { bootstrapIconRendererFromDataUrl, IconRenderer, localIconRendererFromDataUrl } from './IconRenderer'
 
 vi.mock('./vscode', () => ({
   ExtensionApi: {
     readLocalIcon: vi.fn<(_: string) => Promise<{ base64data: string | null }>>(),
+    readBootstrapIcon: vi.fn<(_: string) => Promise<{ base64data: string | null }>>(),
   },
 }))
 
 describe('IconRenderer', () => {
-  it('renders bootstrap icons as a colorable mask instead of an image', () => {
-    const html = renderToStaticMarkup(
-      <IconRenderer
-        node={{
-          id: 'test',
-          title: 'Test',
-          icon: 'bootstrap:file-earmark-code',
-        }} />,
+  it('renders host-provided Bootstrap SVG data as a colorable mask', () => {
+    const BootstrapIcon = bootstrapIconRendererFromDataUrl(
+      'data:image/svg+xml;base64,PHN2ZyBmaWxsPSJjdXJyZW50Q29sb3IiLz4=',
     )
+    const html = renderToStaticMarkup(<BootstrapIcon node={{ id: 'test', title: 'Test', icon: 'bootstrap:boxes' }} />)
 
-    expect(html).not.toContain('<img')
-    expect(html).toContain('https://icons.like-c4.dev/bootstrap/file-earmark-code.svg')
     expect(html).toContain('background-color:currentColor')
+    expect(html).toContain('mask-image:url(')
+    expect(html).not.toContain('icons.like-c4.dev')
+    expect(html).not.toContain('<img')
+  })
+
+  it('renders nothing when the host does not return a Bootstrap SVG', () => {
+    const BootstrapIcon = bootstrapIconRendererFromDataUrl(null)
+    const html = renderToStaticMarkup(<BootstrapIcon node={{ id: 'test', title: 'Test', icon: 'bootstrap:boxes' }} />)
+
+    expect(html).toBe('')
   })
 
   it('keeps non-bootstrap bundled icons as CDN images', () => {

--- a/packages/vscode-preview/src/IconRenderer.tsx
+++ b/packages/vscode-preview/src/IconRenderer.tsx
@@ -7,7 +7,7 @@
 
 import { DefaultMap } from '@likec4/core/utils'
 import { type ElementIconRenderer, type ElementIconRendererProps, IconRendererProvider } from '@likec4/diagram'
-import { type CSSProperties, lazy, memo, Suspense } from 'react'
+import { lazy, memo, Suspense } from 'react'
 import { ExtensionApi as extensionApi } from './vscode'
 
 const iconUrl = (group: string, name: string) => `https://icons.like-c4.dev/${group}/${name}.svg`
@@ -36,23 +36,37 @@ function SvgMask({ src, ...props }: Omit<ElementIconRendererProps, 'node'> & { s
   )
 }
 
-function BootstrapIconMask({ name, ...props }: Omit<ElementIconRendererProps, 'node'> & { name: string }) {
-  const url = iconUrl('bootstrap', name)
-  const style = {
-    display: 'inline-block',
-    width: '100%',
-    height: '100%',
-    backgroundColor: 'currentColor',
-    maskImage: `url("${url}")`,
-    maskRepeat: 'no-repeat',
-    maskPosition: 'center',
-    maskSize: 'contain',
-    WebkitMaskImage: `url("${url}")`,
-    WebkitMaskRepeat: 'no-repeat',
-    WebkitMaskPosition: 'center',
-    WebkitMaskSize: 'contain',
-  } satisfies CSSProperties
-  return <span {...props} aria-hidden="true" style={style} />
+export function bootstrapIconRendererFromDataUrl(base64data: string | null): ElementIconRenderer {
+  if (!base64data) {
+    return () => null
+  }
+
+  return ({ node: _node, ...props }) => <SvgMask {...props} src={base64data} />
+}
+
+const bootstrapIcons = new DefaultMap<string, ElementIconRenderer>(name => {
+  return lazy(async () => {
+    try {
+      const { base64data } = await extensionApi.readBootstrapIcon(name)
+      return {
+        default: bootstrapIconRendererFromDataUrl(base64data),
+      }
+    } catch (error) {
+      console.error(error)
+      return {
+        default: () => null,
+      }
+    }
+  })
+})
+
+function BootstrapIcon({ name, ...props }: ElementIconRendererProps & { name: string }) {
+  const Icon = bootstrapIcons.get(name)
+  return (
+    <Suspense>
+      <Icon {...props} />
+    </Suspense>
+  )
 }
 
 const DefaultIconRenderer: ElementIconRenderer = ({ node, ...props }) => {
@@ -65,7 +79,7 @@ const DefaultIconRenderer: ElementIconRenderer = ({ node, ...props }) => {
   }
 
   if (group === 'bootstrap') {
-    return <BootstrapIconMask {...props} name={name} />
+    return <BootstrapIcon {...props} node={node} name={name} />
   }
 
   return <img {...props} src={iconUrl(group, name)} />

--- a/packages/vscode-preview/src/IconRenderer.tsx
+++ b/packages/vscode-preview/src/IconRenderer.tsx
@@ -48,11 +48,14 @@ const bootstrapIcons = new DefaultMap<string, ElementIconRenderer>(name => {
   return lazy(async () => {
     try {
       const { base64data } = await extensionApi.readBootstrapIcon(name)
+      if (!base64data) {
+        bootstrapIcons.delete(name)
+      }
       return {
         default: bootstrapIconRendererFromDataUrl(base64data),
       }
-    } catch (error) {
-      console.error(error)
+    } catch {
+      bootstrapIcons.delete(name)
       return {
         default: () => null,
       }

--- a/packages/vscode-preview/src/vscode.ts
+++ b/packages/vscode-preview/src/vscode.ts
@@ -21,6 +21,7 @@ import {
   FetchProjectsOverview,
   GetLastClickedNode,
   OnOpenView,
+  ReadBootstrapIcon,
   ReadLocalIcon,
   ViewChangeReq,
   WebviewMsgs,
@@ -124,6 +125,10 @@ export const ExtensionApi = {
   // Read local icon file and convert to base64 data URI
   readLocalIcon: async (uri: string) => {
     return await messenger.sendRequest(ReadLocalIcon, HOST_EXTENSION, uri)
+  },
+
+  readBootstrapIcon: async (name: string) => {
+    return await messenger.sendRequest(ReadBootstrapIcon, HOST_EXTENSION, name)
   },
 
   onOpenViewNotification: (handler: Handler<typeof OnOpenView>) => {

--- a/packages/vscode/src/panel/activateMessenger.ts
+++ b/packages/vscode/src/panel/activateMessenger.ts
@@ -9,6 +9,7 @@ import { useExtensionLogger } from '../useExtensionLogger'
 import { useMessenger } from '../useMessenger'
 import { useRpc } from '../useRpc'
 import { performanceMark, showEditorNextToPreview } from '../utils'
+import { createBootstrapIconLoader } from './bootstrapIcon'
 import { useDiagramPanel } from './useDiagramPanel'
 
 export function activateMessenger() {
@@ -17,6 +18,7 @@ export function activateMessenger() {
   const preview = useDiagramPanel()
 
   const { logger, output } = useExtensionLogger('messenger')
+  const loadBootstrapIcon = createBootstrapIconLoader()
 
   logger.debug('activating messenger <-> preview panel')
 
@@ -205,6 +207,14 @@ export function activateMessenger() {
       // Return null for any errors (file not found, permission denied, etc.)
       return { base64data: null }
     }
+  })
+
+  messenger.handleReadBootstrapIcon(async (name) => {
+    const result = await loadBootstrapIcon(name)
+    if (!result.base64data) {
+      logger.warn('readBootstrapIcon failed', { name })
+    }
+    return result
   })
 
   return messenger

--- a/packages/vscode/src/panel/bootstrapIcon.spec.ts
+++ b/packages/vscode/src/panel/bootstrapIcon.spec.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createBootstrapIconLoader, isBootstrapIconName } from './bootstrapIcon'
+
+const svg = '<svg xmlns="http://www.w3.org/2000/svg" fill="currentColor"/>'
+
+describe('bootstrap icon loader', () => {
+  it('accepts only bounded Bootstrap icon names', () => {
+    expect(isBootstrapIconName('boxes')).toBe(true)
+    expect(isBootstrapIconName('buildings-fill')).toBe(true)
+    expect(isBootstrapIconName('../secret')).toBe(false)
+    expect(isBootstrapIconName('boxes.svg')).toBe(false)
+    expect(isBootstrapIconName('A')).toBe(false)
+  })
+
+  it('returns a data URL from the fixed Bootstrap CDN endpoint', async () => {
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(svg, { headers: { 'content-type': 'image/svg+xml; charset=utf-8' } }),
+    )
+    const load = createBootstrapIconLoader(fetcher)
+
+    await expect(load('boxes')).resolves.toEqual({
+      base64data: `data:image/svg+xml;base64,${Buffer.from(svg).toString('base64')}`,
+    })
+    expect(fetcher).toHaveBeenCalledWith(
+      'https://icons.like-c4.dev/bootstrap/boxes.svg',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    )
+  })
+
+  it('returns null without fetching an invalid name', async () => {
+    const fetcher = vi.fn<typeof fetch>()
+    await expect(createBootstrapIconLoader(fetcher)('../boxes')).resolves.toEqual({ base64data: null })
+    expect(fetcher).not.toHaveBeenCalled()
+  })
+
+  it('rejects non-SVG and oversized responses', async () => {
+    const nonSvg = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response('x', { headers: { 'content-type': 'text/html' } }),
+    )
+    const oversized = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response('x'.repeat(256 * 1024 + 1), { headers: { 'content-type': 'image/svg+xml' } }),
+    )
+
+    await expect(createBootstrapIconLoader(nonSvg)('boxes')).resolves.toEqual({ base64data: null })
+    await expect(createBootstrapIconLoader(oversized)('boxes')).resolves.toEqual({ base64data: null })
+  })
+
+  it('returns null on fetch failure and caches only successful results', async () => {
+    const failing = vi.fn<typeof fetch>().mockRejectedValue(new Error('offline'))
+    await expect(createBootstrapIconLoader(failing)('boxes')).resolves.toEqual({ base64data: null })
+
+    const succeeding = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(svg, { headers: { 'content-type': 'image/svg+xml' } }),
+    )
+    const load = createBootstrapIconLoader(succeeding)
+    await load('boxes')
+    await load('boxes')
+    expect(succeeding).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/vscode/src/panel/bootstrapIcon.spec.ts
+++ b/packages/vscode/src/panel/bootstrapIcon.spec.ts
@@ -2,12 +2,17 @@
 //
 // Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
+import { ReadBootstrapIcon } from '@likec4/vscode-preview/protocol'
 import { describe, expect, it, vi } from 'vitest'
 import { createBootstrapIconLoader, isBootstrapIconName } from './bootstrapIcon'
 
 const svg = '<svg xmlns="http://www.w3.org/2000/svg" fill="currentColor"/>'
 
 describe('bootstrap icon loader', () => {
+  it('defines a dedicated Bootstrap-icon request', () => {
+    expect(ReadBootstrapIcon.method).toBe('read-bootstrap-icon')
+  })
+
   it('accepts only bounded Bootstrap icon names', () => {
     expect(isBootstrapIconName('boxes')).toBe(true)
     expect(isBootstrapIconName('buildings-fill')).toBe(true)

--- a/packages/vscode/src/panel/bootstrapIcon.spec.ts
+++ b/packages/vscode/src/panel/bootstrapIcon.spec.ts
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
 import { describe, expect, it, vi } from 'vitest'
 import { createBootstrapIconLoader, isBootstrapIconName } from './bootstrapIcon'
 
@@ -35,7 +39,7 @@ describe('bootstrap icon loader', () => {
 
   it('rejects non-SVG and oversized responses', async () => {
     const nonSvg = vi.fn<typeof fetch>().mockResolvedValue(
-      new Response('x', { headers: { 'content-type': 'text/html' } }),
+      new Response('x', { headers: { 'content-type': 'image/svg+xmlfoo' } }),
     )
     const oversized = vi.fn<typeof fetch>().mockResolvedValue(
       new Response('x'.repeat(256 * 1024 + 1), { headers: { 'content-type': 'image/svg+xml' } }),
@@ -47,7 +51,10 @@ describe('bootstrap icon loader', () => {
 
   it('returns null on fetch failure and caches only successful results', async () => {
     const failing = vi.fn<typeof fetch>().mockRejectedValue(new Error('offline'))
-    await expect(createBootstrapIconLoader(failing)('boxes')).resolves.toEqual({ base64data: null })
+    const loadFailing = createBootstrapIconLoader(failing)
+    await expect(loadFailing('boxes')).resolves.toEqual({ base64data: null })
+    await expect(loadFailing('boxes')).resolves.toEqual({ base64data: null })
+    expect(failing).toHaveBeenCalledTimes(2)
 
     const succeeding = vi.fn<typeof fetch>().mockResolvedValue(
       new Response(svg, { headers: { 'content-type': 'image/svg+xml' } }),

--- a/packages/vscode/src/panel/bootstrapIcon.ts
+++ b/packages/vscode/src/panel/bootstrapIcon.ts
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
 const bootstrapIconName = /^[a-z0-9][a-z0-9-]{0,127}$/
 const maxSvgBytes = 256 * 1024
 const bootstrapIconUrl = (name: string) => `https://icons.like-c4.dev/bootstrap/${name}.svg`
@@ -19,8 +23,8 @@ export function createBootstrapIconLoader(fetcher: typeof fetch = fetch) {
     }
     try {
       const response = await fetcher(bootstrapIconUrl(name), { signal: AbortSignal.timeout(10_000) })
-      const contentType = response.headers.get('content-type')?.toLowerCase() ?? ''
-      if (!response.ok || !contentType.startsWith('image/svg+xml')) {
+      const contentType = response.headers.get('content-type')?.split(';', 1)[0]?.trim().toLowerCase() ?? ''
+      if (!response.ok || contentType !== 'image/svg+xml') {
         return { base64data: null }
       }
       const bytes = new Uint8Array(await response.arrayBuffer())

--- a/packages/vscode/src/panel/bootstrapIcon.ts
+++ b/packages/vscode/src/panel/bootstrapIcon.ts
@@ -1,0 +1,37 @@
+const bootstrapIconName = /^[a-z0-9][a-z0-9-]{0,127}$/
+const maxSvgBytes = 256 * 1024
+const bootstrapIconUrl = (name: string) => `https://icons.like-c4.dev/bootstrap/${name}.svg`
+
+export type BootstrapIconResult = { base64data: string | null }
+
+export const isBootstrapIconName = (name: string) => bootstrapIconName.test(name)
+
+export function createBootstrapIconLoader(fetcher: typeof fetch = fetch) {
+  const cache = new Map<string, string>()
+
+  return async (name: string): Promise<BootstrapIconResult> => {
+    if (!isBootstrapIconName(name)) {
+      return { base64data: null }
+    }
+    const cached = cache.get(name)
+    if (cached) {
+      return { base64data: cached }
+    }
+    try {
+      const response = await fetcher(bootstrapIconUrl(name), { signal: AbortSignal.timeout(10_000) })
+      const contentType = response.headers.get('content-type')?.toLowerCase() ?? ''
+      if (!response.ok || !contentType.startsWith('image/svg+xml')) {
+        return { base64data: null }
+      }
+      const bytes = new Uint8Array(await response.arrayBuffer())
+      if (bytes.byteLength > maxSvgBytes) {
+        return { base64data: null }
+      }
+      const base64data = `data:image/svg+xml;base64,${Buffer.from(bytes).toString('base64')}`
+      cache.set(name, base64data)
+      return { base64data }
+    } catch {
+      return { base64data: null }
+    }
+  }
+}

--- a/packages/vscode/src/panel/writeHTMLToWebview.spec.ts
+++ b/packages/vscode/src/panel/writeHTMLToWebview.spec.ts
@@ -28,8 +28,10 @@ describe('writeHTMLToWebview', () => {
 
     writeHTMLToWebview({ webview } as never, { screen: 'view' })
 
-    expect(webview.html).toMatch(/style-src vscode-webview:\/\/likec4 'nonce-[^']+';/)
-    expect(webview.html).not.toContain('style-src vscode-webview://likec4 \'unsafe-inline\';')
+    const styleSrc = webview.html.match(/style-src ([^;]+);/)?.[1]
+
+    expect(styleSrc).toMatch(/^vscode-webview:\/\/likec4 'nonce-[A-Za-z0-9]{16}'$/)
+    expect(styleSrc).not.toContain('unsafe-inline')
     expect(webview.html).toContain('style-src-attr \'unsafe-inline\';')
     expect(webview.html).toContain('script-src \'nonce-')
   })

--- a/packages/vscode/src/panel/writeHTMLToWebview.spec.ts
+++ b/packages/vscode/src/panel/writeHTMLToWebview.spec.ts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('reactive-vscode', () => ({
+  computed: (value: () => boolean) => ({ value: value() }),
+  extensionContext: { value: { extensionUri: {} } },
+  useIsDarkTheme: () => ({ value: false }),
+  watch: (source: { value: boolean }, callback: (value: boolean) => void, options: { immediate?: boolean }) => {
+    if (options.immediate) callback(source.value)
+  },
+}))
+vi.mock('vscode', () => ({ Uri: { joinPath: (...parts: unknown[]) => parts.join('/') } }))
+vi.mock('../const.ts', () => ({ hasAI: false, isProd: true }))
+
+import { writeHTMLToWebview } from './writeHTMLToWebview'
+
+describe('writeHTMLToWebview', () => {
+  it('permits inline style attributes without relaxing production style or script sources', () => {
+    const webview = {
+      asWebviewUri: vi.fn(() => 'vscode-webview://likec4/resource'),
+      cspSource: 'vscode-webview://likec4',
+      html: '',
+      options: {},
+    }
+
+    writeHTMLToWebview({ webview } as never, { screen: 'view' })
+
+    expect(webview.html).toContain('style-src vscode-webview://likec4 \'nonce-')
+    expect(webview.html).toContain('style-src-attr \'unsafe-inline\';')
+    expect(webview.html).toContain('script-src \'nonce-')
+  })
+})

--- a/packages/vscode/src/panel/writeHTMLToWebview.spec.ts
+++ b/packages/vscode/src/panel/writeHTMLToWebview.spec.ts
@@ -4,6 +4,8 @@
 
 import { describe, expect, it, vi } from 'vitest'
 
+import { writeHTMLToWebview } from './writeHTMLToWebview'
+
 vi.mock('reactive-vscode', () => ({
   computed: (value: () => boolean) => ({ value: value() }),
   extensionContext: { value: { extensionUri: {} } },
@@ -15,12 +17,10 @@ vi.mock('reactive-vscode', () => ({
 vi.mock('vscode', () => ({ Uri: { joinPath: (...parts: unknown[]) => parts.join('/') } }))
 vi.mock('../const.ts', () => ({ hasAI: false, isProd: true }))
 
-import { writeHTMLToWebview } from './writeHTMLToWebview'
-
 describe('writeHTMLToWebview', () => {
   it('permits inline style attributes without relaxing production style or script sources', () => {
     const webview = {
-      asWebviewUri: vi.fn(() => 'vscode-webview://likec4/resource'),
+      asWebviewUri: vi.fn<() => string>(() => 'vscode-webview://likec4/resource'),
       cspSource: 'vscode-webview://likec4',
       html: '',
       options: {},
@@ -28,11 +28,20 @@ describe('writeHTMLToWebview', () => {
 
     writeHTMLToWebview({ webview } as never, { screen: 'view' })
 
-    const styleSrc = webview.html.match(/style-src ([^;]+);/)?.[1]
+    const cspContent = webview.html.match(/Content-Security-Policy" content="([^"]+)"/)?.[1] ?? ''
+    const directives = Object.fromEntries(
+      cspContent.split(';').filter(Boolean).map(directive => {
+        const [name, ...values] = directive.trim().split(/\s+/)
+        return [name, values]
+      }),
+    )
 
-    expect(styleSrc).toMatch(/^vscode-webview:\/\/likec4 'nonce-[A-Za-z0-9]{16}'$/)
-    expect(styleSrc).not.toContain('unsafe-inline')
-    expect(webview.html).toContain('style-src-attr \'unsafe-inline\';')
-    expect(webview.html).toContain('script-src \'nonce-')
+    expect(directives['style-src']).toEqual([
+      'vscode-webview://likec4',
+      expect.stringMatching(/^'nonce-[A-Za-z0-9]{16}'$/),
+    ])
+    expect(directives['style-src-attr']).toEqual(['\'unsafe-inline\''])
+    expect(directives['script-src']).toEqual([expect.stringMatching(/^'nonce-[A-Za-z0-9]{16}'$/)])
+    expect(cspContent.match(/'unsafe-inline'/g)).toHaveLength(1)
   })
 })

--- a/packages/vscode/src/panel/writeHTMLToWebview.spec.ts
+++ b/packages/vscode/src/panel/writeHTMLToWebview.spec.ts
@@ -28,7 +28,8 @@ describe('writeHTMLToWebview', () => {
 
     writeHTMLToWebview({ webview } as never, { screen: 'view' })
 
-    expect(webview.html).toContain('style-src vscode-webview://likec4 \'nonce-')
+    expect(webview.html).toMatch(/style-src vscode-webview:\/\/likec4 'nonce-[^']+';/)
+    expect(webview.html).not.toContain('style-src vscode-webview://likec4 \'unsafe-inline\';')
     expect(webview.html).toContain('style-src-attr \'unsafe-inline\';')
     expect(webview.html).toContain('script-src \'nonce-')
   })

--- a/packages/vscode/src/panel/writeHTMLToWebview.ts
+++ b/packages/vscode/src/panel/writeHTMLToWebview.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import type { ProjectId, ViewId } from '@likec4/core/types'
 import { computed, extensionContext, useIsDarkTheme, watch } from 'reactive-vscode'
 import { type Webview, type WebviewPanel, Uri } from 'vscode'
@@ -35,7 +42,9 @@ export function writeHTMLToWebview(
     const cspDirectives = [
       `default-src 'none';`,
       `font-src ${cspSource} data: https: 'nonce-${nonce}';`,
-      isProd ? `style-src ${cspSource} 'nonce-${nonce}';` : `style-src ${cspSource} 'unsafe-inline';`,
+      isProd
+        ? `style-src ${cspSource} 'nonce-${nonce}'; style-src-attr 'unsafe-inline';`
+        : `style-src ${cspSource} 'unsafe-inline';`,
       `img-src ${cspSource} data: https:;`,
       `script-src 'nonce-${nonce}';`,
     ]

--- a/packages/vscode/src/useMessenger.ts
+++ b/packages/vscode/src/useMessenger.ts
@@ -9,6 +9,7 @@ import {
   FetchProjectsOverview,
   GetLastClickedNode,
   OnOpenView,
+  ReadBootstrapIcon,
   ReadLocalIcon,
   ViewChangeReq,
   WebviewMsgs,
@@ -107,6 +108,7 @@ export const useMessenger = createSingletonComposable(() => {
     handleFetchComputedModel: requestHandler(FetchComputedModel),
     handleFetchLayoutedView: requestHandler(FetchLayoutedView),
     handleFetchProjectsOverview: requestHandler(FetchProjectsOverview),
+    handleReadBootstrapIcon: requestHandler(ReadBootstrapIcon),
     handleReadLocalIcon: requestHandler(ReadLocalIcon),
     handleViewChange: requestHandler(ViewChangeReq),
 

--- a/packages/vscode/vitest.config.ts
+++ b/packages/vscode/vitest.config.ts
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import { defineVitest } from '@likec4/devops/vitest'
+
+export default defineVitest('vscode')

--- a/scripts/assert-vscode-bootstrap-cors-probe.ps1
+++ b/scripts/assert-vscode-bootstrap-cors-probe.ps1
@@ -1,0 +1,141 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+param(
+  [Parameter(Mandatory)]
+  [string]$BaselineConsole,
+  [Parameter(Mandatory)]
+  [string]$RepairConsole,
+  [Parameter(Mandatory)]
+  [string]$BaselinePng,
+  [Parameter(Mandatory)]
+  [string]$RepairPng,
+  [Parameter(Mandatory)]
+  [string]$OutputPath
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Read-ConsoleEntries {
+  param([string]$Path)
+
+  if (-not (Test-Path -LiteralPath $Path)) {
+    throw "Console log does not exist: $Path"
+  }
+
+  try {
+    return @(Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json)
+  } catch {
+    throw "Cannot parse console log $Path: $($_.Exception.Message)"
+  }
+}
+
+function Test-CorsEntry {
+  param([object]$Entry)
+
+  $text = @($Entry.text, $Entry.description, $Entry.message) -join "`n"
+  return $text.Contains('blocked by CORS policy') -and $text.Contains('icons.like-c4.dev/bootstrap/')
+}
+
+function Write-ProbeResult {
+  param(
+    [bool]$BaselineCors,
+    [bool]$RepairCors,
+    [int]$ChangedPixels,
+    [int]$Threshold,
+    [object]$BaselineDimensions,
+    [object]$RepairDimensions
+  )
+
+  $directory = Split-Path -Parent $OutputPath
+  if ($directory) {
+    New-Item -ItemType Directory -Force $directory | Out-Null
+  }
+
+  @{
+    baselineCors      = $BaselineCors
+    repairCors        = $RepairCors
+    changedPixels     = $ChangedPixels
+    threshold         = $Threshold
+    baselineDimensions = $BaselineDimensions
+    repairDimensions   = $RepairDimensions
+  } | ConvertTo-Json | Set-Content -LiteralPath $OutputPath -Encoding utf8
+}
+
+$threshold = 100
+$changedPixels = 0
+$baselineDimensions = $null
+$repairDimensions = $null
+$baselineCors = $false
+$repairCors = $false
+$failure = $null
+
+try {
+  $baselineCors = @(Read-ConsoleEntries $BaselineConsole | Where-Object { Test-CorsEntry $_ }).Count -gt 0
+  $repairCors = @(Read-ConsoleEntries $RepairConsole | Where-Object { Test-CorsEntry $_ }).Count -gt 0
+
+  if (-not (Test-Path -LiteralPath $BaselinePng)) {
+    throw "Baseline screenshot does not exist: $BaselinePng"
+  }
+  if (-not (Test-Path -LiteralPath $RepairPng)) {
+    throw "Repair screenshot does not exist: $RepairPng"
+  }
+
+  Add-Type -AssemblyName System.Drawing
+  $baselineBitmap = [System.Drawing.Bitmap]::new($BaselinePng)
+  $repairBitmap = [System.Drawing.Bitmap]::new($RepairPng)
+  try {
+    $baselineDimensions = @{ width = $baselineBitmap.Width; height = $baselineBitmap.Height }
+    $repairDimensions = @{ width = $repairBitmap.Width; height = $repairBitmap.Height }
+
+    if ($baselineBitmap.Width -eq $repairBitmap.Width -and $baselineBitmap.Height -eq $repairBitmap.Height) {
+      $sampleIndex = 0
+      for ($y = 0; $y -lt $baselineBitmap.Height; $y++) {
+        for ($x = 0; $x -lt $baselineBitmap.Width; $x++) {
+          if ($sampleIndex % 4 -eq 0) {
+            $baselinePixel = $baselineBitmap.GetPixel($x, $y)
+            $repairPixel = $repairBitmap.GetPixel($x, $y)
+            $delta = [Math]::Abs($baselinePixel.A - $repairPixel.A) +
+              [Math]::Abs($baselinePixel.R - $repairPixel.R) +
+              [Math]::Abs($baselinePixel.G - $repairPixel.G) +
+              [Math]::Abs($baselinePixel.B - $repairPixel.B)
+            if ($delta -gt 80) {
+              $changedPixels++
+            }
+          }
+          $sampleIndex++
+        }
+      }
+    }
+  } finally {
+    if ($null -ne $baselineBitmap) { $baselineBitmap.Dispose() }
+    if ($null -ne $repairBitmap) { $repairBitmap.Dispose() }
+  }
+} catch {
+  $failure = $_.Exception.Message
+}
+
+Write-ProbeResult `
+  -BaselineCors $baselineCors `
+  -RepairCors $repairCors `
+  -ChangedPixels $changedPixels `
+  -Threshold $threshold `
+  -BaselineDimensions $baselineDimensions `
+  -RepairDimensions $repairDimensions
+
+if ($failure) {
+  throw $failure
+}
+if (-not $baselineCors) {
+  throw "Baseline console did not report a Bootstrap CORS denial. See $BaselineConsole"
+}
+if ($repairCors) {
+  throw "Repair console still reports a Bootstrap CORS denial. See $RepairConsole"
+}
+if ($baselineDimensions.width -ne $repairDimensions.width -or $baselineDimensions.height -ne $repairDimensions.height) {
+  throw "Screenshot dimensions differ: baseline $($baselineDimensions.width)x$($baselineDimensions.height), repair $($repairDimensions.width)x$($repairDimensions.height)."
+}
+if ($changedPixels -lt $threshold) {
+  throw "Screenshot visual delta is insufficient: $changedPixels changed samples; expected at least $threshold."
+}

--- a/scripts/assert-vscode-bootstrap-cors-probe.ps1
+++ b/scripts/assert-vscode-bootstrap-cors-probe.ps1
@@ -27,7 +27,7 @@ function Read-ConsoleEntries {
   try {
     return @(Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json)
   } catch {
-    throw "Cannot parse console log $Path: $($_.Exception.Message)"
+    throw "Cannot parse console log ${Path}: $($_.Exception.Message)"
   }
 }
 

--- a/scripts/capture-vscode-preview.ps1
+++ b/scripts/capture-vscode-preview.ps1
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+param(
+  [Parameter(Mandatory)]
+  [string]$ExtensionPath,
+  [Parameter(Mandatory)]
+  [string]$FixturePath,
+  [Parameter(Mandatory)]
+  [string]$OutputPath,
+  [Parameter(Mandatory)]
+  [string]$Label
+)
+
+$ErrorActionPreference = 'Stop'
+
+$userDataPath = Join-Path $env:RUNNER_TEMP "likec4-$Label-user-data"
+$extensionsPath = Join-Path $env:RUNNER_TEMP "likec4-$Label-extensions"
+$evidenceDirectory = Split-Path -Parent $OutputPath
+$stdoutPath = Join-Path $evidenceDirectory "$Label-vscode.stdout.log"
+$stderrPath = Join-Path $evidenceDirectory "$Label-vscode.stderr.log"
+
+Remove-Item -Recurse -Force -ErrorAction SilentlyContinue $userDataPath, $extensionsPath
+@($userDataPath, $extensionsPath, $evidenceDirectory) | ForEach-Object {
+  New-Item -ItemType Directory -Force $_ | Out-Null
+}
+
+$codeCommand = Get-Command code.cmd -ErrorAction SilentlyContinue
+if ($null -eq $codeCommand) {
+  $codeCommand = Get-Command code -ErrorAction Stop
+}
+
+$arguments = @(
+  '--new-window',
+  "--user-data-dir=$userDataPath",
+  "--extensions-dir=$extensionsPath",
+  "--extensionDevelopmentPath=$ExtensionPath",
+  '--disable-gpu',
+  '--disable-workspace-trust',
+  '--skip-welcome',
+  '--skip-release-notes',
+  $FixturePath
+)
+
+Start-Process -FilePath $codeCommand.Source -ArgumentList $arguments -RedirectStandardOutput $stdoutPath -RedirectStandardError $stderrPath
+Start-Sleep -Seconds 12
+
+$window = Get-Process Code | Where-Object { $_.MainWindowHandle -ne 0 } | Select-Object -Last 1
+if ($null -eq $window) {
+  throw "No VS Code window found. See $stdoutPath and $stderrPath"
+}
+
+$shell = New-Object -ComObject WScript.Shell
+if (-not $shell.AppActivate($window.Id)) {
+  throw "Could not activate VS Code window $($window.Id)."
+}
+
+Add-Type -AssemblyName System.Windows.Forms
+Add-Type -AssemblyName System.Drawing
+
+[System.Windows.Forms.SendKeys]::SendWait('^+p')
+Start-Sleep -Seconds 1
+[System.Windows.Forms.SendKeys]::SendWait('LikeC4: Open Preview')
+Start-Sleep -Seconds 1
+[System.Windows.Forms.SendKeys]::SendWait('{ENTER}')
+Start-Sleep -Seconds 3
+[System.Windows.Forms.SendKeys]::SendWait('{ENTER}')
+Start-Sleep -Seconds 20
+
+$bounds = [System.Windows.Forms.Screen]::PrimaryScreen.Bounds
+$bitmap = New-Object System.Drawing.Bitmap $bounds.Width, $bounds.Height
+$graphics = [System.Drawing.Graphics]::FromImage($bitmap)
+$graphics.CopyFromScreen($bounds.Location, [System.Drawing.Point]::Empty, $bounds.Size)
+$bitmap.Save($OutputPath, [System.Drawing.Imaging.ImageFormat]::Png)
+$graphics.Dispose()
+$bitmap.Dispose()
+
+Get-Process Code -ErrorAction SilentlyContinue | Stop-Process -Force

--- a/scripts/capture-vscode-preview.ps1
+++ b/scripts/capture-vscode-preview.ps1
@@ -20,6 +20,11 @@ $extensionsPath = Join-Path $env:RUNNER_TEMP "likec4-$Label-extensions"
 $evidenceDirectory = Split-Path -Parent $OutputPath
 $stdoutPath = Join-Path $evidenceDirectory "$Label-vscode.stdout.log"
 $stderrPath = Join-Path $evidenceDirectory "$Label-vscode.stderr.log"
+$debugPort = switch ($Label) {
+  'baseline' { 9222 }
+  'pr' { 9223 }
+  default { throw "Unsupported capture label: $Label" }
+}
 
 Remove-Item -Recurse -Force -ErrorAction SilentlyContinue $userDataPath, $extensionsPath
 @($userDataPath, $extensionsPath, $evidenceDirectory) | ForEach-Object {
@@ -40,40 +45,38 @@ $arguments = @(
   '--disable-workspace-trust',
   '--skip-welcome',
   '--skip-release-notes',
+  "--remote-debugging-port=$debugPort",
   $FixturePath
 )
 
-Start-Process -FilePath $codeCommand.Source -ArgumentList $arguments -RedirectStandardOutput $stdoutPath -RedirectStandardError $stderrPath
-Start-Sleep -Seconds 12
+try {
+  Start-Process -FilePath $codeCommand.Source -ArgumentList $arguments -RedirectStandardOutput $stdoutPath -RedirectStandardError $stderrPath
+  Start-Sleep -Seconds 12
 
-$window = Get-Process Code | Where-Object { $_.MainWindowHandle -ne 0 } | Select-Object -Last 1
-if ($null -eq $window) {
-  throw "No VS Code window found. See $stdoutPath and $stderrPath"
+  $window = Get-Process Code | Where-Object { $_.MainWindowHandle -ne 0 } | Select-Object -Last 1
+  if ($null -eq $window) {
+    throw "No VS Code window found. See $stdoutPath and $stderrPath"
+  }
+
+  $shell = New-Object -ComObject WScript.Shell
+  if (-not $shell.AppActivate($window.Id)) {
+    throw "Could not activate VS Code window $($window.Id)."
+  }
+
+  Add-Type -AssemblyName System.Windows.Forms
+  [System.Windows.Forms.SendKeys]::SendWait('^+p')
+  Start-Sleep -Seconds 1
+  [System.Windows.Forms.SendKeys]::SendWait('LikeC4: Open Preview')
+  Start-Sleep -Seconds 1
+  [System.Windows.Forms.SendKeys]::SendWait('{ENTER}')
+  Start-Sleep -Seconds 3
+  [System.Windows.Forms.SendKeys]::SendWait('{ENTER}')
+  Start-Sleep -Seconds 20
+
+  node ./scripts/capture-vscode-webview.mjs --port $debugPort --output $OutputPath --console "$OutputPath.console.json"
+  if ($LASTEXITCODE -ne 0) {
+    throw "CDP capture failed for $Label. See $stdoutPath and $stderrPath"
+  }
+} finally {
+  Get-Process Code -ErrorAction SilentlyContinue | Stop-Process -Force
 }
-
-$shell = New-Object -ComObject WScript.Shell
-if (-not $shell.AppActivate($window.Id)) {
-  throw "Could not activate VS Code window $($window.Id)."
-}
-
-Add-Type -AssemblyName System.Windows.Forms
-Add-Type -AssemblyName System.Drawing
-
-[System.Windows.Forms.SendKeys]::SendWait('^+p')
-Start-Sleep -Seconds 1
-[System.Windows.Forms.SendKeys]::SendWait('LikeC4: Open Preview')
-Start-Sleep -Seconds 1
-[System.Windows.Forms.SendKeys]::SendWait('{ENTER}')
-Start-Sleep -Seconds 3
-[System.Windows.Forms.SendKeys]::SendWait('{ENTER}')
-Start-Sleep -Seconds 20
-
-$bounds = [System.Windows.Forms.Screen]::PrimaryScreen.Bounds
-$bitmap = New-Object System.Drawing.Bitmap $bounds.Width, $bounds.Height
-$graphics = [System.Drawing.Graphics]::FromImage($bitmap)
-$graphics.CopyFromScreen($bounds.Location, [System.Drawing.Point]::Empty, $bounds.Size)
-$bitmap.Save($OutputPath, [System.Drawing.Imaging.ImageFormat]::Png)
-$graphics.Dispose()
-$bitmap.Dispose()
-
-Get-Process Code -ErrorAction SilentlyContinue | Stop-Process -Force

--- a/scripts/capture-vscode-preview.ps1
+++ b/scripts/capture-vscode-preview.ps1
@@ -73,6 +73,11 @@ try {
   [System.Windows.Forms.SendKeys]::SendWait('{ENTER}')
   Start-Sleep -Seconds 20
 
+  # The language server can return focus to the source editor after the preview opens.
+  # The preview is the preceding editor tab, so activate it before CDP captures the workbench.
+  [System.Windows.Forms.SendKeys]::SendWait('^{PGUP}')
+  Start-Sleep -Seconds 2
+
   node ./scripts/capture-vscode-webview.mjs --port $debugPort --output $OutputPath --console "$OutputPath.console.json"
   if ($LASTEXITCODE -ne 0) {
     throw "CDP capture failed for $Label. See $stdoutPath and $stderrPath"

--- a/scripts/capture-vscode-webview.mjs
+++ b/scripts/capture-vscode-webview.mjs
@@ -28,12 +28,17 @@ if (!outputPath || !consolePath) {
 
 const sleep = milliseconds => new Promise(resolve => setTimeout(resolve, milliseconds))
 
-const targetMatches = target => {
+const isLikeC4Iframe = target => {
   const url = target.url?.toLowerCase() ?? ''
   return target.type === 'iframe' && url.includes('extensionid=likec4.likec4-vscode')
 }
 
-const findTarget = async () => {
+const isWorkbenchPage = target => {
+  const url = target.url?.toLowerCase() ?? ''
+  return target.type === 'page' && url.includes('/workbench/workbench.html')
+}
+
+const findTargets = async () => {
   const deadline = Date.now() + 60_000
   const endpoint = `http://127.0.0.1:${port}/json/list`
   let lastError
@@ -45,7 +50,8 @@ const findTarget = async () => {
         throw new Error(`CDP endpoint returned ${response.status}.`)
       }
       const targets = await response.json()
-      const target = targets.find(targetMatches)
+      const iframeTarget = targets.find(isLikeC4Iframe)
+      const workbenchTarget = targets.find(isWorkbenchPage)
       await writeFile(
         targetsPath,
         `${
@@ -54,24 +60,41 @@ const findTarget = async () => {
               endpoint,
               observedAt: new Date().toISOString(),
               targets,
-              selectedTarget: target ?? null,
+              iframeTarget: iframeTarget ?? null,
+              workbenchTarget: workbenchTarget ?? null,
             },
             null,
             2,
           )
         }\n`,
       )
-      if (target?.webSocketDebuggerUrl) {
-        return target
+      if (iframeTarget?.webSocketDebuggerUrl && workbenchTarget?.webSocketDebuggerUrl) {
+        return { iframeTarget, workbenchTarget }
       }
-      lastError = new Error('No LikeC4 webview target is available.')
+      lastError = new Error('LikeC4 iframe or VS Code workbench target is unavailable.')
     } catch (error) {
       lastError = error
     }
     await sleep(500)
   }
 
-  throw new Error(`Could not find a LikeC4 webview target: ${lastError?.message ?? 'unknown error'}`)
+  throw new Error(`Could not find the required CDP targets: ${lastError?.message ?? 'unknown error'}`)
+}
+
+const openSocket = async target => {
+  const socket = new WebSocket(target.webSocketDebuggerUrl)
+  await new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error(`Timed out connecting to ${target.type} CDP target.`)), 20_000)
+    socket.addEventListener('open', () => {
+      clearTimeout(timeout)
+      resolve()
+    }, { once: true })
+    socket.addEventListener('error', () => {
+      clearTimeout(timeout)
+      reject(new Error(`Could not connect to ${target.type} CDP target.`))
+    }, { once: true })
+  })
+  return socket
 }
 
 const cdp = async (socket, id, method, params = {}) => {
@@ -106,37 +129,27 @@ const cdp = async (socket, id, method, params = {}) => {
 }
 
 const main = async () => {
-  const target = await findTarget()
-  const socket = new WebSocket(target.webSocketDebuggerUrl)
+  const { iframeTarget, workbenchTarget } = await findTargets()
+  const iframeSocket = await openSocket(iframeTarget)
+  const workbenchSocket = await openSocket(workbenchTarget)
   const entries = []
 
   try {
-    await new Promise((resolve, reject) => {
-      const timeout = setTimeout(() => reject(new Error('Timed out connecting to CDP.')), 20_000)
-      socket.addEventListener('open', () => {
-        clearTimeout(timeout)
-        resolve()
-      }, { once: true })
-      socket.addEventListener('error', () => {
-        clearTimeout(timeout)
-        reject(new Error('Could not connect to CDP.'))
-      }, { once: true })
-    })
-
-    socket.addEventListener('message', event => {
+    iframeSocket.addEventListener('message', event => {
       const message = JSON.parse(event.data)
       if (message.method === 'Log.entryAdded') {
         entries.push(message.params.entry)
       }
     })
 
-    await cdp(socket, 1, 'Log.enable')
-    await cdp(socket, 2, 'Page.enable')
-    await cdp(socket, 3, 'Runtime.evaluate', { expression: 'location.reload()' })
+    await cdp(iframeSocket, 1, 'Log.enable')
+    await cdp(iframeSocket, 2, 'Page.enable')
+    await cdp(workbenchSocket, 1, 'Page.enable')
+    await cdp(iframeSocket, 3, 'Runtime.evaluate', { expression: 'location.reload()' })
     await sleep(12_000)
-    const screenshot = await cdp(socket, 4, 'Page.captureScreenshot', { format: 'png' })
-
     await writeFile(consolePath, `${JSON.stringify(entries, null, 2)}\n`)
+    const screenshot = await cdp(workbenchSocket, 2, 'Page.captureScreenshot', { format: 'png' })
+
     if (entries.length === 0) {
       throw new Error('CDP did not capture any Log.entryAdded entries.')
     }
@@ -145,7 +158,8 @@ const main = async () => {
     }
     await writeFile(outputPath, Buffer.from(screenshot.data, 'base64'))
   } finally {
-    socket.close()
+    iframeSocket.close()
+    workbenchSocket.close()
   }
 }
 

--- a/scripts/capture-vscode-webview.mjs
+++ b/scripts/capture-vscode-webview.mjs
@@ -30,7 +30,7 @@ const sleep = milliseconds => new Promise(resolve => setTimeout(resolve, millise
 
 const targetMatches = target => {
   const url = target.url?.toLowerCase() ?? ''
-  return url.includes('extensionid=likec4.likec4-vscode') || url.includes('likec4') || url.includes('webview')
+  return target.type === 'iframe' && url.includes('extensionid=likec4.likec4-vscode')
 }
 
 const findTarget = async () => {
@@ -132,7 +132,7 @@ const main = async () => {
 
     await cdp(socket, 1, 'Log.enable')
     await cdp(socket, 2, 'Page.enable')
-    await cdp(socket, 3, 'Page.reload', { ignoreCache: true })
+    await cdp(socket, 3, 'Runtime.evaluate', { expression: 'location.reload()' })
     await sleep(12_000)
     const screenshot = await cdp(socket, 4, 'Page.captureScreenshot', { format: 'png' })
 

--- a/scripts/capture-vscode-webview.mjs
+++ b/scripts/capture-vscode-webview.mjs
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import { writeFile } from 'node:fs/promises'
+
+const argumentsByName = new Map()
+for (let index = 2; index < process.argv.length; index += 2) {
+  const name = process.argv[index]
+  const value = process.argv[index + 1]
+  if (!name?.startsWith('--') || value === undefined) {
+    throw new Error(`Expected a value after ${name ?? 'the final argument'}.`)
+  }
+  argumentsByName.set(name, value)
+}
+
+const port = Number(argumentsByName.get('--port'))
+const outputPath = argumentsByName.get('--output')
+const consolePath = argumentsByName.get('--console')
+
+if (!Number.isInteger(port) || port < 1 || port > 65535) {
+  throw new Error('Pass --port with a valid TCP port.')
+}
+if (!outputPath || !consolePath) {
+  throw new Error('Pass both --output and --console paths.')
+}
+
+const sleep = milliseconds => new Promise(resolve => setTimeout(resolve, milliseconds))
+
+const targetMatches = target => {
+  const url = target.url?.toLowerCase() ?? ''
+  return url.includes('extensionid=likec4.likec4-vscode') || url.includes('likec4') || url.includes('webview')
+}
+
+const findTarget = async () => {
+  const deadline = Date.now() + 60_000
+  const endpoint = `http://127.0.0.1:${port}/json/list`
+  let lastError
+
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(endpoint)
+      if (!response.ok) {
+        throw new Error(`CDP endpoint returned ${response.status}.`)
+      }
+      const targets = await response.json()
+      const target = targets.find(targetMatches)
+      if (target?.webSocketDebuggerUrl) {
+        return target
+      }
+      lastError = new Error('No LikeC4 webview target is available.')
+    } catch (error) {
+      lastError = error
+    }
+    await sleep(500)
+  }
+
+  throw new Error(`Could not find a LikeC4 webview target: ${lastError?.message ?? 'unknown error'}`)
+}
+
+const cdp = async (socket, id, method, params = {}) => {
+  return await new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      socket.removeEventListener('message', onMessage)
+      socket.removeEventListener('error', onError)
+      reject(new Error(`Timed out: ${method}`))
+    }, 20_000)
+    const onMessage = event => {
+      const message = JSON.parse(event.data)
+      if (message.id === id) {
+        socket.removeEventListener('message', onMessage)
+        socket.removeEventListener('error', onError)
+        clearTimeout(timeout)
+        if (message.error) {
+          reject(new Error(`${method}: ${message.error.message}`))
+          return
+        }
+        resolve(message.result)
+      }
+    }
+    const onError = () => {
+      socket.removeEventListener('message', onMessage)
+      clearTimeout(timeout)
+      reject(new Error(`CDP connection failed: ${method}`))
+    }
+    socket.addEventListener('message', onMessage)
+    socket.addEventListener('error', onError, { once: true })
+    socket.send(JSON.stringify({ id, method, params }))
+  })
+}
+
+const main = async () => {
+  const target = await findTarget()
+  const socket = new WebSocket(target.webSocketDebuggerUrl)
+  const entries = []
+
+  try {
+    await new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('Timed out connecting to CDP.')), 20_000)
+      socket.addEventListener('open', () => {
+        clearTimeout(timeout)
+        resolve()
+      }, { once: true })
+      socket.addEventListener('error', () => {
+        clearTimeout(timeout)
+        reject(new Error('Could not connect to CDP.'))
+      }, { once: true })
+    })
+
+    socket.addEventListener('message', event => {
+      const message = JSON.parse(event.data)
+      if (message.method === 'Log.entryAdded') {
+        entries.push(message.params.entry)
+      }
+    })
+
+    await cdp(socket, 1, 'Log.enable')
+    await cdp(socket, 2, 'Page.enable')
+    await cdp(socket, 3, 'Page.reload', { ignoreCache: true })
+    await sleep(12_000)
+    const screenshot = await cdp(socket, 4, 'Page.captureScreenshot', { format: 'png' })
+
+    await writeFile(consolePath, `${JSON.stringify(entries, null, 2)}\n`)
+    if (entries.length === 0) {
+      throw new Error('CDP did not capture any Log.entryAdded entries.')
+    }
+    if (!screenshot?.data) {
+      throw new Error('CDP did not capture a screenshot.')
+    }
+    await writeFile(outputPath, Buffer.from(screenshot.data, 'base64'))
+  } finally {
+    socket.close()
+  }
+}
+
+await main()
+process.exit(0)

--- a/scripts/capture-vscode-webview.mjs
+++ b/scripts/capture-vscode-webview.mjs
@@ -17,6 +17,7 @@ for (let index = 2; index < process.argv.length; index += 2) {
 const port = Number(argumentsByName.get('--port'))
 const outputPath = argumentsByName.get('--output')
 const consolePath = argumentsByName.get('--console')
+const targetsPath = `${outputPath}.targets.json`
 
 if (!Number.isInteger(port) || port < 1 || port > 65535) {
   throw new Error('Pass --port with a valid TCP port.')
@@ -45,6 +46,21 @@ const findTarget = async () => {
       }
       const targets = await response.json()
       const target = targets.find(targetMatches)
+      await writeFile(
+        targetsPath,
+        `${
+          JSON.stringify(
+            {
+              endpoint,
+              observedAt: new Date().toISOString(),
+              targets,
+              selectedTarget: target ?? null,
+            },
+            null,
+            2,
+          )
+        }\n`,
+      )
       if (target?.webSocketDebuggerUrl) {
         return target
       }

--- a/scripts/start-bootstrap-icon-cors-server.ps1
+++ b/scripts/start-bootstrap-icon-cors-server.ps1
@@ -64,7 +64,7 @@ try {
     if ([string]::IsNullOrEmpty($origin)) {
       $origin = '-'
     }
-    [System.IO.File]::AppendAllText($logPath, "{0} {1} {2}`n" -f $context.Request.HttpMethod, $context.Request.Url.AbsolutePath, $origin)
+    [System.IO.File]::AppendAllText($logPath, ("{0} {1} {2}`n" -f $context.Request.HttpMethod, $context.Request.Url.AbsolutePath, $origin))
 
     if ($allowedPaths -contains $context.Request.Url.AbsolutePath) {
       $payload = [System.Text.Encoding]::UTF8.GetBytes($svg)

--- a/scripts/start-bootstrap-icon-cors-server.ps1
+++ b/scripts/start-bootstrap-icon-cors-server.ps1
@@ -97,9 +97,28 @@ try {
     '-Prefix',
     $urlPrefix
   ) -PassThru
-  Start-Sleep -Milliseconds 500
-  if ($server.HasExited) {
-    throw "Controlled Bootstrap CDN server exited. See $serverLogPath"
+
+  $readinessUrl = "${urlPrefix}bootstrap/boxes.svg"
+  $readinessDeadline = [DateTime]::UtcNow.AddSeconds(15)
+  $readinessError = $null
+  $serverReady = $false
+  while ([DateTime]::UtcNow -lt $readinessDeadline) {
+    if ($server.HasExited) {
+      throw "Controlled Bootstrap CDN server exited. See $serverLogPath"
+    }
+    try {
+      $response = Invoke-WebRequest -UseBasicParsing -Uri $readinessUrl -TimeoutSec 2
+      if ($response.StatusCode -eq 200 -and $response.Content -match '<svg') {
+        $serverReady = $true
+        break
+      }
+    } catch {
+      $readinessError = $_.Exception.Message
+    }
+    Start-Sleep -Milliseconds 250
+  }
+  if (-not $serverReady) {
+    throw "Controlled Bootstrap CDN did not become ready at $readinessUrl. Last error: $readinessError"
   }
 
   @(
@@ -117,6 +136,7 @@ try {
   }
   if ($hostsBackupCreated -and (Test-Path $backupPath)) {
     Copy-Item -Force $backupPath $hostsPath
+    Clear-DnsClientCache -ErrorAction SilentlyContinue
   }
   if ($null -ne $cert) {
     Remove-Item -Force "Cert:\LocalMachine\My\$($cert.Thumbprint)" -ErrorAction SilentlyContinue

--- a/scripts/start-bootstrap-icon-cors-server.ps1
+++ b/scripts/start-bootstrap-icon-cors-server.ps1
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+param(
+  [Parameter(Mandatory)]
+  [string]$EvidencePath
+)
+
+$ErrorActionPreference = 'Stop'
+
+$hostName = 'icons.like-c4.dev'
+$port = 443
+$hostsPath = "$env:WINDIR\System32\drivers\etc\hosts"
+$backupPath = Join-Path $EvidencePath 'hosts.before'
+$certificatePath = Join-Path $EvidencePath 'icons-like-c4-dev.cer'
+$serverScriptPath = Join-Path $EvidencePath 'bootstrap-icon-cdn-server.ps1'
+$serverLogPath = Join-Path $EvidencePath 'icon-cdn.log'
+$urlPrefix = "https://${hostName}:${port}/"
+$cert = $null
+$server = $null
+$hostsBackupCreated = $false
+$sslBindingCreated = $false
+
+New-Item -ItemType Directory -Force $EvidencePath | Out-Null
+
+try {
+  $cert = New-SelfSignedCertificate -DnsName $hostName -CertStoreLocation 'Cert:\LocalMachine\My'
+  Export-Certificate -Cert $cert -FilePath $certificatePath | Out-Null
+  Import-Certificate -FilePath $certificatePath -CertStoreLocation 'Cert:\LocalMachine\Root' | Out-Null
+
+  Copy-Item -Force $hostsPath $backupPath
+  $hostsBackupCreated = $true
+  Add-Content -Path $hostsPath -Value "127.0.0.1 $hostName"
+  Clear-DnsClientCache
+
+  $appId = '{8c68e414-5245-4dcc-a55a-d4d28c2c4ec0}'
+  & netsh http add sslcert ipport="0.0.0.0:$port" certhash=$($cert.Thumbprint) appid=$appId | Out-Null
+  if ($LASTEXITCODE -ne 0) {
+    throw 'Could not bind the controlled Bootstrap CDN certificate to port 443.'
+  }
+  $sslBindingCreated = $true
+
+  $serverScript = @'
+param(
+  [Parameter(Mandatory)]
+  [string]$EvidencePath,
+  [Parameter(Mandatory)]
+  [string]$Prefix
+)
+
+$ErrorActionPreference = 'Stop'
+$logPath = Join-Path $EvidencePath 'icon-cdn.log'
+$svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor"><path d="M1 1h14v14H1z"/></svg>'
+$allowedPaths = @('/bootstrap/boxes.svg', '/bootstrap/buildings-fill.svg')
+$listener = [System.Net.HttpListener]::new()
+$listener.Prefixes.Add($Prefix)
+
+try {
+  $listener.Start()
+  while ($true) {
+    $context = $listener.GetContext()
+    $origin = $context.Request.Headers['Origin']
+    if ([string]::IsNullOrEmpty($origin)) {
+      $origin = '-'
+    }
+    [System.IO.File]::AppendAllText($logPath, "{0} {1} {2}`n" -f $context.Request.HttpMethod, $context.Request.Url.AbsolutePath, $origin)
+
+    if ($allowedPaths -contains $context.Request.Url.AbsolutePath) {
+      $payload = [System.Text.Encoding]::UTF8.GetBytes($svg)
+      $context.Response.StatusCode = 200
+      $context.Response.ContentType = 'image/svg+xml'
+      $context.Response.ContentLength64 = $payload.Length
+      $context.Response.OutputStream.Write($payload, 0, $payload.Length)
+    } else {
+      $context.Response.StatusCode = 404
+    }
+    $context.Response.Close()
+  }
+} catch {
+  [System.IO.File]::AppendAllText($logPath, "SERVER ERROR: $($_.Exception.Message)`n")
+  throw
+} finally {
+  $listener.Close()
+}
+'@
+  Set-Content -Path $serverScriptPath -Value $serverScript -Encoding utf8
+
+  $server = Start-Process -FilePath 'pwsh' -ArgumentList @(
+    '-NoProfile',
+    '-ExecutionPolicy',
+    'Bypass',
+    '-File',
+    $serverScriptPath,
+    '-EvidencePath',
+    $EvidencePath,
+    '-Prefix',
+    $urlPrefix
+  ) -PassThru
+  Start-Sleep -Milliseconds 500
+  if ($server.HasExited) {
+    throw "Controlled Bootstrap CDN server exited. See $serverLogPath"
+  }
+
+  @(
+    "ICON_CDN_PORT=$port",
+    "ICON_CDN_PID=$($server.Id)",
+    "ICON_CDN_CERT_THUMBPRINT=$($cert.Thumbprint)",
+    "ICON_CDN_HOSTS_BACKUP=$backupPath"
+  ) | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+} catch {
+  if ($null -ne $server) {
+    Stop-Process -Id $server.Id -Force -ErrorAction SilentlyContinue
+  }
+  if ($sslBindingCreated) {
+    & netsh http delete sslcert ipport="0.0.0.0:$port" | Out-Null
+  }
+  if ($hostsBackupCreated -and (Test-Path $backupPath)) {
+    Copy-Item -Force $backupPath $hostsPath
+  }
+  if ($null -ne $cert) {
+    Remove-Item -Force "Cert:\LocalMachine\My\$($cert.Thumbprint)" -ErrorAction SilentlyContinue
+    Remove-Item -Force "Cert:\LocalMachine\Root\$($cert.Thumbprint)" -ErrorAction SilentlyContinue
+  }
+  throw
+}


### PR DESCRIPTION
## Purpose

Disposable, stacked reproduction probe for #3142. It runs on Windows Server 2022 and captures the reporter fixture in VS Code for both the v1.59.3 baseline and the #3220 branch.

## Contract

- The workflow is non-gating and may be abandoned after investigation.
- It uploads screenshots and VS Code process logs only as Actions artifacts. No screenshots are committed.
- It makes no claim that #3220 fixes the visual defect. A valid result requires the baseline capture to show the missing Bootstrap icon. If it does not, the job records a non-reproducing Windows Server environment.

## Validation

- `pnpm exec dprint check .github/workflows/vscode-windows-csp-probe.yaml scripts/capture-vscode-preview.ps1`
- `pnpm typecheck` (pre-push hook)