### PR TITLE
feat(mcp): return links and sourceLocation from batch-read-elements

### DIFF
--- a/.changeset/mcp-batch-read-elements-links.md
+++ b/.changeset/mcp-batch-read-elements-links.md
@@ -1,0 +1,5 @@
+---
+'@likec4/mcp': patch
+---
+
+`batch-read-elements` now returns `links` and `sourceLocation` for each element, matching `read-element`. Reading those for many elements no longer needs one call per element.

--- a/apps/docs/src/content/docs/tooling/ai-tools.mdx
+++ b/apps/docs/src/content/docs/tooling/ai-tools.mdx
@@ -212,7 +212,7 @@ Disable watch mode with `--no-watch` to consume less resources, if you have stat
 | `query-by-tags` | Tag filtering with boolean logic (allOf, anyOf, noneOf) |
 | `query-by-tag-pattern` | Search elements by tag patterns using prefix, contains, or suffix matching |
 | `find-relationship-paths` | Discover all multi-hop relationship chains between two elements via BFS |
-| `batch-read-elements` | Read full details for multiple elements in a single request |
+| `batch-read-elements` | Read full details for multiple elements in a single request, including links and source location |
 | `subgraph-summary` | Summarize descendants of an element with depth, metadata, and relationship counts |
 | `element-diff` | Compare two elements and show differences in properties, tags, metadata, and relationships |
 | `open-view` | Opens the LikeC4 view panel (editor only) |

--- a/apps/docs/src/content/docs/tooling/ai-tools.mdx
+++ b/apps/docs/src/content/docs/tooling/ai-tools.mdx
@@ -212,7 +212,7 @@ Disable watch mode with `--no-watch` to consume less resources, if you have stat
 | `query-by-tags` | Tag filtering with boolean logic (allOf, anyOf, noneOf) |
 | `query-by-tag-pattern` | Search elements by tag patterns using prefix, contains, or suffix matching |
 | `find-relationship-paths` | Discover all multi-hop relationship chains between two elements via BFS |
-| `batch-read-elements` | Read full details for multiple elements in a single request, including links and source location |
+| `batch-read-elements` | Read summaries of multiple elements in a single request, including links and source location |
 | `subgraph-summary` | Summarize descendants of an element with depth, metadata, and relationship counts |
 | `element-diff` | Compare two elements and show differences in properties, tags, metadata, and relationships |
 | `open-view` | Opens the LikeC4 view panel (editor only) |

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -67,7 +67,7 @@ OPTIONS
 - `query-by-tags`: Search elements and deployment nodes by tags with boolean logic (allOf, anyOf, noneOf).
 - `query-by-tag-pattern`: Search elements by tag patterns using prefix, contains, or suffix matching.
 - `find-relationship-paths`: Discover all relationship chains between two elements with bounded BFS traversal. Supports `includeIndirect` to control implied relationships.
-- `batch-read-elements`: Read full details for multiple elements in a single request.
+- `batch-read-elements`: Read full details for multiple elements in a single request, including links and sourceLocation.
 - `subgraph-summary`: Summarize descendants of an element with depth, metadata, and relationship counts.
 - `element-diff`: Compare two elements and show differences in properties, tags, metadata, and relationships.
 - `open-view`: Opens the LikeC4 view (available if MCP is running in the editor)

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -67,7 +67,7 @@ OPTIONS
 - `query-by-tags`: Search elements and deployment nodes by tags with boolean logic (allOf, anyOf, noneOf).
 - `query-by-tag-pattern`: Search elements by tag patterns using prefix, contains, or suffix matching.
 - `find-relationship-paths`: Discover all relationship chains between two elements with bounded BFS traversal. Supports `includeIndirect` to control implied relationships.
-- `batch-read-elements`: Read full details for multiple elements in a single request, including links and sourceLocation.
+- `batch-read-elements`: Read summaries of multiple elements in a single request, including links and sourceLocation.
 - `subgraph-summary`: Summarize descendants of an element with depth, metadata, and relationship counts.
 - `element-diff`: Compare two elements and show differences in properties, tags, metadata, and relationships.
 - `open-view`: Opens the LikeC4 view (available if MCP is running in the editor)

--- a/packages/mcp/src/server/createMCPServer.ts
+++ b/packages/mcp/src/server/createMCPServer.ts
@@ -57,7 +57,7 @@ Available tools:
 - query-by-metadata — Search elements by metadata key-value pairs with exact/contains/exists matching. Input: { key, value?, matchMode?, project? }.
 - query-by-tags — Advanced tag filtering with boolean logic (allOf, anyOf, noneOf). Input: { allOf?, anyOf?, noneOf?, project? }.
 - find-relationship-paths — Discover all paths (chains of relationships) between two elements with BFS traversal. Input: { sourceId, targetId, maxDepth?, includeIndirect?, project? }.
-- batch-read-elements — Read details of multiple elements in a single call, reducing round-trips. Input: { ids, project? }.
+- batch-read-elements — Read details of multiple elements in a single call, reducing round-trips. Includes links and sourceLocation, same as read-element. Input: { ids, project? }.
 - query-by-tag-pattern — Search elements by tag prefix/contains/suffix patterns. Input: { pattern, matchMode?, project? }.
 - element-diff — Compare two elements side-by-side showing differences in properties, tags, metadata, and relationships. Input: { element1Id, element2Id, project? }.
 - subgraph-summary — Compact summary of all descendants of a parent element with metadata, tags, and relationship counts. Input: { elementId, maxDepth?, metadataKeys?, project? }.

--- a/packages/mcp/src/tools/_common.ts
+++ b/packages/mcp/src/tools/_common.ts
@@ -250,6 +250,25 @@ export const locationSchema = z.object({
   }).describe('Range in the file'),
 }).nullable()
 
+export const linksSchema = z.array(z.object({
+  title: z.string().nullable().describe('Optional link title'),
+  url: z.string().describe('Link URL'),
+  relative: z.string().nullable().describe('Relative path (if URL is relative to workspace root)'),
+})).describe('External links associated with this element')
+
+/**
+ * Serializes the links of an element or deployment entity for MCP responses.
+ */
+export function serializeLinks(
+  element: ElementModel<AnyAux> | DeploymentElementModel<AnyAux>,
+): z.infer<typeof linksSchema> {
+  return (element.links ?? []).map(link => ({
+    title: link.title ?? null,
+    url: link.url,
+    relative: link.relative ?? null,
+  }))
+}
+
 export const projectIdSchema = z.string()
   .refine((_v): _v is ProjectId => true)
   .default('default' as ProjectId)

--- a/packages/mcp/src/tools/batch-read-elements.spec.ts
+++ b/packages/mcp/src/tools/batch-read-elements.spec.ts
@@ -139,4 +139,91 @@ describe('batch-read-elements tool', () => {
     expect(c.incomingCount).toBe(2)
     expect(c.outgoingCount).toBe(0)
   })
+
+  describe('links and sourceLocation', () => {
+    const MIXED_LINKS_DSL = `
+      specification {
+        element system
+        element container
+      }
+      model {
+        cloud = system 'Cloud System' {
+          link https://likec4.dev/docs/dsl/model/
+          link https://github.com/likec4/likec4 'GitHub Repository'
+
+          ui = container 'Frontend' {
+            link ./README.md 'Local Docs'
+          }
+        }
+        backend = system 'Backend'
+      }
+    `
+    const IDS = ['cloud', 'cloud.ui', 'backend']
+
+    // Link shapes (titled/untitled/relative) are covered per-tool in mcp-tools-links.spec.ts.
+    // This asserts what only a batch call can get wrong: attributing links to the right element.
+    it('should attribute links to the right element in a mixed batch', async () => {
+      await using pair = await createMCPTestPair(MIXED_LINKS_DSL)
+
+      const result = await pair.client.callTool({
+        name: 'batch-read-elements',
+        arguments: { ids: IDS, project: 'default' },
+      })
+
+      expect(result.structuredContent).toBeDefined()
+      const elements = structured(result)['elements'] as Array<any>
+      expect(elements).toHaveLength(3)
+
+      const urlsById = Object.fromEntries(
+        elements.map((e: any) => [e.id, e.links.map((l: any) => l.url)]),
+      )
+
+      expect(urlsById).toEqual({
+        'cloud': ['https://likec4.dev/docs/dsl/model/', 'https://github.com/likec4/likec4'],
+        'cloud.ui': ['./README.md'],
+        'backend': [],
+      })
+    })
+
+    it('should return the same links and sourceLocation as read-element', async () => {
+      await using pair = await createMCPTestPair(MIXED_LINKS_DSL)
+
+      const batch = await pair.client.callTool({
+        name: 'batch-read-elements',
+        arguments: { ids: IDS, project: 'default' },
+      })
+      const elements = structured(batch)['elements'] as Array<any>
+      expect(elements).toHaveLength(IDS.length)
+
+      for (const id of IDS) {
+        const single = await pair.client.callTool({
+          name: 'read-element',
+          arguments: { id, project: 'default' },
+        })
+        const expected = structured(single)
+        const actual = elements.find((e: any) => e.id === id)
+
+        expect(actual.links).toEqual(expected['links'])
+        expect(actual.sourceLocation).toEqual(expected['sourceLocation'])
+      }
+    })
+
+    it('should return sourceLocation for every element', async () => {
+      await using pair = await createMCPTestPair(MIXED_LINKS_DSL)
+
+      const result = await pair.client.callTool({
+        name: 'batch-read-elements',
+        arguments: { ids: IDS, project: 'default' },
+      })
+      const elements = structured(result)['elements'] as Array<any>
+
+      for (const element of elements) {
+        const location = element.sourceLocation
+        expect(location).not.toBeNull()
+        expect(typeof location.path).toBe('string')
+        expect(typeof location.range.start.line).toBe('number')
+        expect(typeof location.range.start.character).toBe('number')
+      }
+    })
+  })
 })

--- a/packages/mcp/src/tools/batch-read-elements.ts
+++ b/packages/mcp/src/tools/batch-read-elements.ts
@@ -5,7 +5,15 @@
 import { invariant } from '@likec4/core'
 import * as z from 'zod/v4'
 import { likec4Tool } from '../utils'
-import { elementSummarySchema, projectIdSchema, serializeElement } from './_common'
+import {
+  elementSummarySchema,
+  linksSchema,
+  locationSchema,
+  mkLocate,
+  projectIdSchema,
+  serializeElement,
+  serializeLinks,
+} from './_common'
 
 const MAX_IDS = 50
 
@@ -17,13 +25,15 @@ const elementDetailSchema = elementSummarySchema.extend({
   children: z.array(z.string()).describe('Direct child element ids'),
   incomingCount: z.number().describe('Number of incoming relationships'),
   outgoingCount: z.number().describe('Number of outgoing relationships'),
+  links: linksSchema,
+  sourceLocation: locationSchema,
 })
 
 export const batchReadElements = likec4Tool({
   name: 'batch-read-elements',
   description: `
 Read details of multiple elements in a single call, reducing round-trips.
-Returns a compact summary for each element including metadata, description, technology, shape, children, and relationship counts.
+Returns a compact summary for each element including metadata, description, technology, shape, children, relationship counts, links and source location.
 
 Request:
 - ids: string[] — array of element ids (FQNs) to read (max 50)
@@ -45,6 +55,8 @@ Response (JSON object):
   - incomingCount: number — number of incoming relationships
   - outgoingCount: number — number of outgoing relationships
   - includedInViews: View[] — views that include this element
+  - links: Array<{ title: string|null, url: string, relative: string|null }> — external links associated with this element
+  - sourceLocation: { path: string, range: { start: { line: number, character: number }, end: { line: number, character: number } } } | null — source location if available
 - notFound: string[] — ids that were not found in the project
 
 View (object) fields:
@@ -58,6 +70,8 @@ Notes:
 - Maximum 50 element ids per call.
 - Elements not found are listed in notFound array (not an error).
 - More efficient than multiple read-element calls when you need summary data for many elements.
+- Returns the same "links" and "sourceLocation" as read-element, so it fully replaces read-element for that case.
+- Call read-element only when you also need relationships, deployedInstances, defaultView or project.
 
 Example response:
 {
@@ -78,7 +92,14 @@ Example response:
       "outgoingCount": 3,
       "includedInViews": [
         { "id": "system-overview", "title": "System Overview", "type": "element" }
-      ]
+      ],
+      "links": [
+        { "title": "Documentation", "url": "https://docs.example.com/frontend", "relative": null }
+      ],
+      "sourceLocation": {
+        "path": "/abs/path/project/model.c4",
+        "range": { "start": { "line": 10, "character": 0 }, "end": { "line": 25, "character": 0 } }
+      }
     }
   ],
   "notFound": []
@@ -102,6 +123,7 @@ Example response:
 
   const projectId = languageServices.projectsManager.ensureProjectId(args.project)
   const model = await languageServices.computedModel(projectId)
+  const locate = mkLocate(languageServices, projectId)
 
   const elements: z.infer<typeof elementDetailSchema>[] = []
   const notFound: string[] = []
@@ -122,6 +144,8 @@ Example response:
       children: [...element.children()].map(c => c.id),
       incomingCount: element.allIncoming.size,
       outgoingCount: element.allOutgoing.size,
+      links: serializeLinks(element),
+      sourceLocation: locate({ element: element.id }),
     })
   }
 

--- a/packages/mcp/src/tools/mcp-tools-links.spec.ts
+++ b/packages/mcp/src/tools/mcp-tools-links.spec.ts
@@ -277,4 +277,94 @@ describe('MCP Tools - Links', () => {
       expect(links[1]!.title).toBeNull()
     })
   })
+
+  describe('batch-read-elements tool', () => {
+    it('should include links in each element of the batch', async () => {
+      await using pair = await createMCPTestPair(`
+        specification {
+          element system
+        }
+        model {
+          cloud = system 'Cloud System' {
+            link https://likec4.dev/docs/dsl/model/
+            link https://github.com/likec4/likec4 'GitHub Repository'
+          }
+        }
+      `)
+
+      const result = await pair.client.callTool({
+        name: 'batch-read-elements',
+        arguments: { ids: ['cloud'], project: 'default' },
+      })
+
+      expect(result.structuredContent).toBeDefined()
+      const elements = structured(result)['elements'] as Array<any>
+      expect(elements).toHaveLength(1)
+
+      const links = elements[0].links as Array<{ url: string; title: string | null }>
+      expect(links).toBeDefined()
+      expect(links).toHaveLength(2)
+
+      expect(links[0]!.url).toBe('https://likec4.dev/docs/dsl/model/')
+      expect(links[0]!.title).toBeNull() // MCP transforms undefined to null
+
+      expect(links[1]!.url).toBe('https://github.com/likec4/likec4')
+      expect(links[1]!.title).toBe('GitHub Repository')
+    })
+
+    it('should have empty links array for elements without links', async () => {
+      await using pair = await createMCPTestPair(`
+        specification {
+          element system
+        }
+        model {
+          cloud = system 'Cloud System'
+        }
+      `)
+
+      const result = await pair.client.callTool({
+        name: 'batch-read-elements',
+        arguments: { ids: ['cloud'], project: 'default' },
+      })
+
+      expect(result.structuredContent).toBeDefined()
+      const elements = structured(result)['elements'] as Array<any>
+      expect(elements).toHaveLength(1)
+
+      const links = elements[0].links as Array<{ url: string; title: string | null }>
+      expect(links).toBeDefined()
+      expect(Array.isArray(links)).toBe(true)
+      expect(links).toHaveLength(0)
+    })
+
+    it('should handle relative links correctly', async () => {
+      await using pair = await createMCPTestPair(`
+        specification {
+          element container
+        }
+        model {
+          ui = container 'Frontend' {
+            link ./docs/README.md 'Relative Documentation'
+            link ../CONTRIBUTING.md
+          }
+        }
+      `)
+
+      const result = await pair.client.callTool({
+        name: 'batch-read-elements',
+        arguments: { ids: ['ui'], project: 'default' },
+      })
+
+      expect(result.structuredContent).toBeDefined()
+      const elements = structured(result)['elements'] as Array<any>
+      const links = elements[0].links as Array<{ url: string; title: string | null }>
+      expect(links).toHaveLength(2)
+
+      expect(links[0]!.url).toBe('./docs/README.md')
+      expect(links[0]!.title).toBe('Relative Documentation')
+
+      expect(links[1]!.url).toBe('../CONTRIBUTING.md')
+      expect(links[1]!.title).toBeNull()
+    })
+  })
 })

--- a/packages/mcp/src/tools/read-deployment.ts
+++ b/packages/mcp/src/tools/read-deployment.ts
@@ -8,7 +8,15 @@
 import { invariant } from '@likec4/core'
 import * as z from 'zod/v4'
 import { likec4Tool } from '../utils'
-import { includedInViews, includedInViewsSchema, locationSchema, mkLocate, projectIdSchema } from './_common'
+import {
+  includedInViews,
+  includedInViewsSchema,
+  linksSchema,
+  locationSchema,
+  mkLocate,
+  projectIdSchema,
+  serializeLinks,
+} from './_common'
 
 export const readDeployment = likec4Tool({
   name: 'read-deployment',
@@ -98,11 +106,7 @@ Example response (deployed instance):
     tags: z.array(z.string()),
     project: z.string(),
     metadata: z.record(z.string(), z.union([z.string(), z.array(z.string())])),
-    links: z.array(z.object({
-      title: z.string().nullable().describe('Optional link title'),
-      url: z.string().describe('Link URL'),
-      relative: z.string().nullable().describe('Relative path (if URL is relative to workspace root)'),
-    })).describe('External links associated with this deployment entity'),
+    links: linksSchema.describe('External links associated with this deployment entity'),
     shape: z.string(),
     color: z.string(),
     children: z.array(z.string()).describe('Children of this deployment node (Array of Deployment ids)'),
@@ -133,11 +137,7 @@ Example response (deployed instance):
     tags: [...element.tags],
     project: projectId,
     metadata: element.getMetadata(),
-    links: (element.links ?? []).map(link => ({
-      title: link.title ?? null,
-      url: link.url,
-      relative: link.relative ?? null,
-    })),
+    links: serializeLinks(element),
     shape: element.shape,
     color: element.color,
     children: element.isInstance() ? [] : [...element.children()].map(c => c.id),

--- a/packages/mcp/src/tools/read-element.ts
+++ b/packages/mcp/src/tools/read-element.ts
@@ -8,7 +8,15 @@
 import { invariant } from '@likec4/core'
 import * as z from 'zod/v4'
 import { likec4Tool } from '../utils'
-import { includedInViews, includedInViewsSchema, locationSchema, mkLocate, projectIdSchema } from './_common'
+import {
+  includedInViews,
+  includedInViewsSchema,
+  linksSchema,
+  locationSchema,
+  mkLocate,
+  projectIdSchema,
+  serializeLinks,
+} from './_common'
 
 export const readElement = likec4Tool({
   name: 'read-element',
@@ -119,11 +127,7 @@ Example response:
     tags: z.array(z.string()),
     project: z.string(),
     metadata: z.record(z.string(), z.union([z.string(), z.array(z.string())])),
-    links: z.array(z.object({
-      title: z.string().nullable().describe('Optional link title'),
-      url: z.string().describe('Link URL'),
-      relative: z.string().nullable().describe('Relative path (if URL is relative to workspace root)'),
-    })).describe('External links associated with this element'),
+    links: linksSchema,
     shape: z.string(),
     color: z.string(),
     children: z.array(z.string()).describe('Children of this element (Array of FQNs)'),
@@ -182,11 +186,7 @@ Example response:
     tags: [...element.tags],
     project: projectId,
     metadata: element.getMetadata(),
-    links: (element.links ?? []).map(link => ({
-      title: link.title ?? null,
-      url: link.url,
-      relative: link.relative ?? null,
-    })),
+    links: serializeLinks(element),
     shape: element.shape,
     color: element.color,
     children: [...element.children()].map(c => c.id),


### PR DESCRIPTION
## Problem

`batch-read-elements` exists to cut round-trips, but returns neither `links` nor `sourceLocation`. `read-element` returns both.

So "which repo does each of these N elements live in", or "where is each declared", costs N `read-element` calls for data the batch tool is already shaped to return in one.

## Fix

Both fields are added to each element, from the code path `read-element` already uses: the same `computedModel(projectId)` and the shared `mkLocate` helper in `_common.ts`. `find-relationships` already emits per-item `sourceLocation` from a loop, so no new pattern is introduced.

The link mapping moves out of `read-element` into a shared `serializeLinks` in `_common.ts`, now used by `read-element`, `read-deployment` and `batch-read-elements`. Output of the first two is unchanged.

Shapes match `read-element` exactly, so callers handle one shape for every tool:

- `sourceLocation.range.start.line` stays 0-based. Normalizing it here would break existing `read-element` consumers.
- An element with no links returns `[]`, never an omitted field.

Additive only, no new tool. Response size is not a concern: `includedInViews` already dominates the payload, and links plus a source location are a few bytes per element.

## Changes

- **`@likec4/mcp`**: the two fields on `batch-read-elements`, shared `serializeLinks` / `linksSchema` in `_common.ts`, tool description, server instructions and README updated to list them
- **`apps/docs`**: `batch-read-elements` row in the MCP tool table

## Tests

Batch output for a given element is asserted equal to `read-element` output for both fields, so the two cannot drift. Plus link cases: an element with two links, one with a relative link, one with none, and a mix in a single batch call.

## Checklist

- [x] I've thoroughly read the latest [contribution guidelines](https://github.com/likec4/likec4/blob/main/CONTRIBUTING.md).
- [x] I've rebased my branch onto `main` **before** creating this PR.
- [x] I've added tests to cover my changes (if applicable).
- [x] I've verified `pnpm typecheck` and `pnpm test`.
- [x] I've added [changesets](https://changesets-docs.vercel.app/).
- [x] My change requires documentation updates.
- [x] I've updated the documentation accordingly (or will do in follow-up PR).
