### PR TITLE
fix: support bidirectional relationships in deployment model

### DIFF
--- a/.changeset/deployment-bidirectional-relations.md
+++ b/.changeset/deployment-bidirectional-relations.md
@@ -1,0 +1,7 @@
+---
+'@likec4/core': patch
+'@likec4/language-server': patch
+'@likec4/generators': patch
+---
+
+Deployment relationships now support the `<->` and `-[kind]<->` bidirectional syntax introduced in v1.59.3.

--- a/apps/docs/src/content/docs/dsl/Deployment/model.mdx
+++ b/apps/docs/src/content/docs/dsl/Deployment/model.mdx
@@ -197,6 +197,25 @@ deployment {
 }
 ```
 
+Use **`<->`** (or **`-[kind]<->`**) when both nodes actively communicate with each other:
+
+```likec4
+deployment {
+  environment prod {
+    vm vm1 {
+      db = instanceOf database 'Primary DB'
+    }
+    vm vm2 {
+      db = instanceOf database 'Standby DB'
+    }
+    vm1.db <-> vm2.db 'replicates'
+  }
+}
+```
+
+Like in the logical model, bidirectional relationships render with arrows at both ends by default,
+and can be included or excluded from either endpoint in view predicates.
+
 :::tip
 Relationships can be defined for nested elements of deployed instances:
 

--- a/packages/core/src/builder/_types.ts
+++ b/packages/core/src/builder/_types.ts
@@ -151,11 +151,6 @@ export type NewRelationProps<Kind, Tag, Metadata> = {
   links?: NonEmptyArray<string | { title?: string; url: string }>
 }
 
-export type NewDeploymentRelationProps<Kind, Tag, Metadata> = Omit<
-  NewRelationProps<Kind, Tag, Metadata>,
-  'isBidirectional'
->
-
 export type Invalid<Message extends string> = Tagged<Message, 'Error'>
 export type Warn<Id, Existing> = IsLiteral<Existing> extends true ? Id extends Existing ? Invalid<'Already exists'> : Id
   : Id
@@ -193,7 +188,7 @@ export interface Types<
 
   NewElementProps: NewElementProps<Tag, Metadata<MetadataKey>>
   NewRelationshipProps: NewRelationProps<RelationshipKind, Tag, Metadata<MetadataKey>>
-  NewDeploymentRelationshipProps: NewDeploymentRelationProps<RelationshipKind, Tag, Metadata<MetadataKey>>
+  NewDeploymentRelationshipProps: NewRelationProps<RelationshipKind, Tag, Metadata<MetadataKey>>
   NewViewProps: NewViewProps<Tag>
 
   NewDeploymentNodeProps: NewDeploymentNodeProps<Tag, Metadata<MetadataKey>>

--- a/packages/core/src/compute-view/deployment-view/__test__/relation.bidirectional.spec.ts
+++ b/packages/core/src/compute-view/deployment-view/__test__/relation.bidirectional.spec.ts
@@ -1,0 +1,73 @@
+import { describe, test } from 'vitest'
+import { Builder } from '../../../builder'
+import { TestHelper } from './TestHelper'
+
+const builder = Builder
+  .specification({
+    elements: {
+      el: {},
+    },
+    deployments: {
+      env: {},
+      node: {},
+    },
+  })
+  .model(({ el }, _) =>
+    _(
+      el('sys1'),
+      el('sys2'),
+    )
+  )
+  .deployment(({ env, node, instanceOf, rel }, _) =>
+    _(
+      env('prod').with(
+        node('n1').with(
+          instanceOf('i1', 'sys1'),
+        ),
+        node('n2').with(
+          instanceOf('i2', 'sys2'),
+        ),
+        node('n3'),
+      ),
+      rel('prod.n1', 'prod.n2', { title: 'syncs', isBidirectional: true }),
+      rel('prod.n1', 'prod.n3', 'notifies'),
+    )
+  )
+
+describe('bidirectional deployment relations', () => {
+  test('are included from the declared target', () => {
+    const t = TestHelper.from(builder)
+    const view = t.computeView(
+      t.$include('prod.n1'),
+      t.$include('-> prod.n2'),
+    )
+    t.expect(view).toHaveEdges('prod.n1 -> prod.n2')
+  })
+
+  test('are included from the declared source', () => {
+    const t = TestHelper.from(builder)
+    const view = t.computeView(
+      t.$include('prod.n2'),
+      t.$include('-> prod.n1'),
+    )
+    t.expect(view).toHaveEdges('prod.n1 -> prod.n2')
+  })
+
+  test('unidirectional relations stay incoming-only', () => {
+    const t = TestHelper.from(builder)
+    const view = t.computeView(
+      t.$include('prod.n3'),
+      t.$include('-> prod.n1'),
+    )
+    t.expect(view).toHaveEdges()
+  })
+
+  test('are excluded from the declared source', () => {
+    const t = TestHelper.from(builder)
+    const view = t.computeView(
+      t.$include('prod.**'),
+      t.$exclude('-> prod.n1'),
+    )
+    t.expect(view).toHaveEdges('prod.n1 -> prod.n3')
+  })
+})

--- a/packages/core/src/compute-view/deployment-view/predicates/relation-incoming.ts
+++ b/packages/core/src/compute-view/deployment-view/predicates/relation-incoming.ts
@@ -1,10 +1,12 @@
-import { anyPass, filter, pipe } from 'remeda'
+import { anyPass, flatMap, pipe } from 'remeda'
 import type { LikeC4DeploymentModel, RelationshipModel } from '../../../model'
 import type { AnyAux, RelationExpr } from '../../../types'
 import { FqnExpr } from '../../../types'
 import { invariant, isAncestor } from '../../../utils'
+import { isBidirectionalRelation } from '../../utils/is-bidirectional-relation'
 import type { Connection, Elem, PredicateExecutor } from '../_types'
-import { findConnectionsBetween, resolveElements, resolveModelElements } from '../utils'
+import { findConnectionsFrom, narrowToBidirectional, resolveElements, resolveModelElements } from '../utils'
+import { filterOutgoingConnections } from './relation-outgoing'
 import { applyPredicate, excludeModelRelations, resolveAscendingSiblings } from './utils'
 
 // from visible element incoming to this
@@ -14,11 +16,11 @@ export const IncomingRelationPredicate: PredicateExecutor<RelationExpr.Incoming>
 
     if (FqnExpr.isWildcard(expr.incoming)) {
       for (const source of sources) {
-        if (source.allOutgoing.isEmpty) {
+        if (source.allOutgoing.isEmpty && source.allIncoming.isEmpty) {
           continue
         }
         const targets = [...resolveAscendingSiblings(source)]
-        const toInclude = applyPredicate(findConnectionsBetween(source, targets, 'directed'), where)
+        const toInclude = applyPredicate(findConnectionsFrom(source, targets), where)
         stage.addConnections(toInclude)
       }
       return stage
@@ -27,7 +29,7 @@ export const IncomingRelationPredicate: PredicateExecutor<RelationExpr.Incoming>
 
     const targets = resolveElements(model, expr.incoming)
     for (const source of sources) {
-      const toInclude = applyPredicate(findConnectionsBetween(source, targets, 'directed'), where)
+      const toInclude = applyPredicate(findConnectionsFrom(source, targets), where)
       stage.addConnections(toInclude)
     }
 
@@ -47,10 +49,18 @@ export const IncomingRelationPredicate: PredicateExecutor<RelationExpr.Incoming>
       return stage
     }
 
-    const isIncoming = filterIncomingConnections(resolveElements(model, expr.incoming))
+    const targets = resolveElements(model, expr.incoming)
+    const isIncoming = filterIncomingConnections(targets)
+    const isOutgoing = filterOutgoingConnections(targets)
     const toExclude = pipe(
       memory.connections,
-      filter(isIncoming),
+      flatMap(connection => {
+        if (isIncoming(connection)) {
+          return [connection]
+        }
+        // `a <-> b` also flows into `a`, so `exclude -> a` must drop it
+        return isOutgoing(connection) ? narrowToBidirectional(connection) : []
+      }),
       applyPredicate(where),
     )
     stage.excludeConnections(toExclude)
@@ -97,5 +107,8 @@ export function resolveAllIncomingRelations<A extends AnyAux>(
   modelRef: FqnExpr.ModelRef<A>,
 ): Set<RelationshipModel<A>> {
   const targets = resolveModelElements(model, modelRef)
-  return new Set(targets.flatMap(e => [...e.allIncoming]))
+  return new Set(targets.flatMap(e => [
+    ...e.allIncoming,
+    ...[...e.allOutgoing].filter(isBidirectionalRelation),
+  ]))
 }

--- a/packages/core/src/compute-view/deployment-view/utils.ts
+++ b/packages/core/src/compute-view/deployment-view/utils.ts
@@ -17,11 +17,44 @@ import { stringHash } from '../../utils/string-hash'
 import { applyViewRuleStyle } from '../utils/applyViewRuleStyles'
 import type { ComputedNodeSource } from '../utils/buildComputedNodes'
 import { buildComputedNodes } from '../utils/buildComputedNodes'
+import { isBidirectionalRelation } from '../utils/is-bidirectional-relation'
 import { mergePropsFromRelationships } from '../utils/merge-props-from-relationships'
 import type { ShouldExpandPredicate } from '../utils/relationExpressionToPredicates'
 import type { Memory } from './_types'
 
 export const { findConnection, findConnectionsBetween, findConnectionsWithin } = deploymentConnection
+
+/**
+ * Resolve connections that can originate at `source`.
+ *
+ * Relationships declared as bidirectional can be selected from either endpoint,
+ * while their connection retains the direction declared in the model.
+ */
+export function findConnectionsFrom<A extends AnyAux>(
+  source: DeploymentElementModel<A>,
+  targets: Iterable<DeploymentElementModel<A>>,
+): readonly DeploymentConnectionModel<A>[] {
+  return findConnectionsBetween(source, targets, 'both').flatMap(connection => {
+    if (connection.source === source) {
+      return [connection]
+    }
+    return narrowToBidirectional(connection)
+  })
+}
+
+/**
+ * Keeps only bidirectional relations of the connection, drops the connection if none left.
+ */
+export function narrowToBidirectional<A extends AnyAux>(
+  connection: DeploymentConnectionModel<A>,
+): readonly DeploymentConnectionModel<A>[] {
+  const model = new Set([...connection.relations.model].filter(isBidirectionalRelation))
+  const deployment = new Set([...connection.relations.deployment].filter(isBidirectionalRelation))
+  if (model.size === 0 && deployment.size === 0) {
+    return []
+  }
+  return [connection.update({ model, deployment })]
+}
 
 type Predicate<T> = (x: T) => boolean
 

--- a/packages/core/src/compute-view/element-view/__test__/incoming-expr.spec.ts
+++ b/packages/core/src/compute-view/element-view/__test__/incoming-expr.spec.ts
@@ -16,7 +16,7 @@ describe('incoming-expr', () => {
         _(
           component('a'),
           component('b'),
-          rel('a', 'b', { tail: 'normal' }),
+          rel('a', 'b', { isBidirectional: true }),
         )
       )
     const test = TestHelper.from(builder)

--- a/packages/core/src/compute-view/element-view/predicates/_utils.ts
+++ b/packages/core/src/compute-view/element-view/predicates/_utils.ts
@@ -1,15 +1,14 @@
 import { anyPass } from 'remeda'
-import type { ConnectionModel, ElementModel, LikeC4Model, RelationshipModel } from '../../../model'
+import type { ConnectionModel, ElementModel, LikeC4Model } from '../../../model'
 import { modelConnection } from '../../../model'
 import { type AnyAux, FqnRef, ModelFqnExpr } from '../../../types'
 import { ifilter, isDescendantOf, nonexhaustive, toArray } from '../../../utils'
+import { isBidirectionalRelation } from '../../utils/is-bidirectional-relation'
 import type { Elem, Memory, PredicateCtx } from '../_types'
 
 export const { findConnection, findConnectionsBetween, findConnectionsWithin } = modelConnection
 
-export function isBidirectionalRelation<A extends AnyAux>(relation: RelationshipModel<A>): boolean {
-  return relation.isBidirectional || relation.tail === 'normal'
-}
+export { isBidirectionalRelation }
 
 /**
  * Resolve connections that can originate at an element.

--- a/packages/core/src/compute-view/utils/is-bidirectional-relation.ts
+++ b/packages/core/src/compute-view/utils/is-bidirectional-relation.ts
@@ -1,0 +1,10 @@
+import type { AnyRelationshipModel } from '../../model'
+import type { AnyAux } from '../../types'
+
+/**
+ * Relationship is traversable from both endpoints,
+ * either because it was declared with `<->` or because it renders arrows on both ends.
+ */
+export function isBidirectionalRelation<A extends AnyAux>(relation: AnyRelationshipModel<A>): boolean {
+  return relation.isBidirectional || relation.tail === 'normal'
+}

--- a/packages/core/src/compute-view/utils/is-bidirectional-relation.ts
+++ b/packages/core/src/compute-view/utils/is-bidirectional-relation.ts
@@ -2,9 +2,8 @@ import type { AnyRelationshipModel } from '../../model'
 import type { AnyAux } from '../../types'
 
 /**
- * Relationship is traversable from both endpoints,
- * either because it was declared with `<->` or because it renders arrows on both ends.
+ * Relationship is traversable from both endpoints.
  */
 export function isBidirectionalRelation<A extends AnyAux>(relation: AnyRelationshipModel<A>): boolean {
-  return relation.isBidirectional || relation.tail === 'normal'
+  return relation.isBidirectional
 }

--- a/packages/core/src/model/DeploymentElementModel.ts
+++ b/packages/core/src/model/DeploymentElementModel.ts
@@ -667,6 +667,10 @@ export class DeploymentRelationModel<A extends Any = Any> implements AnyRelation
     return this.$relationship.tail
   }
 
+  get isBidirectional(): boolean {
+    return this.$relationship.isBidirectional === true
+  }
+
   public *views(): IteratorLike<LikeC4ViewModel.DeploymentView<A>> {
     for (const view of this.$model.views()) {
       if (view.includesRelation(this.id)) {

--- a/packages/core/src/model/RelationModel.ts
+++ b/packages/core/src/model/RelationModel.ts
@@ -38,6 +38,7 @@ export interface AnyRelationshipModel<A extends AnyAux = AnyAux> extends WithTag
   readonly line: RelationshipLineType
   readonly head: RelationshipArrowType
   readonly tail: RelationshipArrowType | undefined
+  readonly isBidirectional: boolean
   isDeploymentRelation(): this is DeploymentRelationModel<A>
   isModelRelation(): this is RelationshipModel<A>
   views(): ViewsIterator<A>

--- a/packages/core/src/types/model-deployment.ts
+++ b/packages/core/src/types/model-deployment.ts
@@ -62,6 +62,7 @@ export function isDeployedInstance<A extends AnyAux>(el: DeploymentElement<A>): 
 export interface DeploymentRelationship<A extends AnyAux = Unknown> extends AbstractRelationship<A> {
   readonly source: FqnRef.DeploymentRef<A>
   readonly target: FqnRef.DeploymentRef<A>
+  readonly isBidirectional?: boolean
 }
 /**
  * Backward compatibility alias

--- a/packages/generators/src/likec4/operators/deployment.spec.ts
+++ b/packages/generators/src/likec4/operators/deployment.spec.ts
@@ -444,4 +444,35 @@ describe('deployment', () => {
       }"
     `)
   })
+
+  it('should print bidirectional relations', () => {
+    expectDeployment({
+      elements: [
+        { id: 'n1', kind: 'node' },
+        { id: 'n2', kind: 'node' },
+        { id: 'n3', kind: 'node' },
+      ],
+      relations: [
+        { source: { deployment: 'n1' }, target: { deployment: 'n2' }, title: 'syncs', isBidirectional: true },
+        {
+          source: { deployment: 'n1' },
+          target: { deployment: 'n3' },
+          kind: 'async',
+          isBidirectional: true,
+        },
+      ],
+    }).toMatchInlineSnapshot(`
+      "deployment {
+        n1 = node
+        
+        n2 = node
+        
+        n3 = node
+        
+        n1 <-> n2 'syncs'
+        
+        n1 -[async]<-> n3
+      }"
+    `)
+  })
 })

--- a/packages/generators/src/likec4/operators/deployment.ts
+++ b/packages/generators/src/likec4/operators/deployment.ts
@@ -25,6 +25,7 @@ import {
   descriptionProperty,
   linksProperty,
   metadataProperty,
+  relationConnector,
   styleProperties,
   summaryProperty,
   tagsProperty,
@@ -203,7 +204,7 @@ function hasRelationProps(rel: schemas.deployment.relationship.Data): boolean {
 export const relationship = zodOp(schemas.deployment.relationship)(
   spaceBetween(
     property('source', fqnRef()),
-    print(rel => rel.kind ? `-[${rel.kind}]->` : '->'),
+    print(rel => relationConnector(rel.kind, rel.isBidirectional)),
     property('target', fqnRef()),
     property(
       'title',

--- a/packages/generators/src/likec4/operators/model.ts
+++ b/packages/generators/src/likec4/operators/model.ts
@@ -24,6 +24,7 @@ import {
   descriptionProperty,
   linksProperty,
   metadataProperty,
+  relationConnector,
   styleProperties,
   summaryProperty,
   tagsProperty,
@@ -162,7 +163,7 @@ function hasRelationProps(rel: schemas.model.relationship.Data): boolean {
 export const relationship = zodOp(schemas.model.relationship)(
   spaceBetween(
     property('source', fqnRef()),
-    print(rel => rel.kind ? `-[${rel.kind}]->` : '->'),
+    print(rel => relationConnector(rel.kind, rel.isBidirectional)),
     property('target', fqnRef()),
     property(
       'title',

--- a/packages/generators/src/likec4/operators/properties.ts
+++ b/packages/generators/src/likec4/operators/properties.ts
@@ -242,3 +242,14 @@ export const styleProperties = zodOp(common.style)(
     property('multiple'),
   ),
 )
+
+/**
+ * Renders the arrow between relationship endpoints, e.g. `->`, `<->` or `-[async]<->`.
+ */
+export function relationConnector(
+  kind: string | undefined | null,
+  isBidirectional: boolean | undefined | null,
+): string {
+  const arrow = isBidirectional ? '<->' : '->'
+  return kind ? `-[${kind}]${arrow}` : arrow
+}

--- a/packages/generators/src/likec4/schemas/deployment.ts
+++ b/packages/generators/src/likec4/schemas/deployment.ts
@@ -85,6 +85,7 @@ export const relationship = common.props
     title: z.string().nullish(),
     source: relationshipEndpoint,
     target: relationshipEndpoint,
+    isBidirectional: z.boolean().nullish(),
     navigateTo: common.viewId.nullish(),
     color: common.color.nullish(),
     kind: common.kind.nullish(),

--- a/packages/generators/src/likec4/schemas/model.ts
+++ b/packages/generators/src/likec4/schemas/model.ts
@@ -79,6 +79,7 @@ export const relationship = z.object({
   title: z.string().nullish(),
   source: relationshipEndpoint,
   target: relationshipEndpoint,
+  isBidirectional: z.boolean().nullish(),
   navigateTo: common.viewId.nullish(),
   color: common.color.nullish(),
   kind: common.kind.nullish(),

--- a/packages/language-server/src/__tests__/deployment.spec.ts
+++ b/packages/language-server/src/__tests__/deployment.spec.ts
@@ -213,4 +213,55 @@ describe('Deployment model:', () => {
       ])
     })
   })
+
+  describe('bidirectional relations', () => {
+    test('valid bidirectional deployment relation').valid`
+      specification {
+        deploymentNode node
+      }
+      deployment {
+        node n1
+        node n2
+        n1 <-> n2
+      }
+    `
+
+    test('valid kinded bidirectional deployment relation').valid`
+      specification {
+        deploymentNode node
+        relationship sync
+      }
+      deployment {
+        node n1
+        node n2
+        n1 -[sync]<-> n2
+      }
+    `
+
+    it('builds a bidirectional deployment relation with a tail arrow', async ({ expect }) => {
+      const { parse, validateAll, buildModel } = createTestServices()
+      await parse(`
+        specification {
+          deploymentNode node
+        }
+        deployment {
+          node n1
+          node n2
+          n1 <-> n2 'syncs'
+        }
+      `)
+      const { errors } = await validateAll()
+      expect(errors).toEqual([])
+
+      const model = await buildModel()
+      const relation = Object.values(model.deployments.relations)[0]
+      expect(relation).toMatchObject({
+        source: { deployment: 'n1' },
+        target: { deployment: 'n2' },
+        title: 'syncs',
+        isBidirectional: true,
+        tail: 'normal',
+      })
+    })
+  })
 })

--- a/packages/language-server/src/like-c4.langium
+++ b/packages/language-server/src/like-c4.langium
@@ -885,11 +885,7 @@ ExtendDeploymentBody:  '{'
 
 DeploymentRelation<isExplicit>:
   (<isExplicit> source=FqnRef | <!isExplicit> source=FqnRef?)
-  (
-    dotKind=RelationKindDotRef |
-    '-[' kind=[RelationshipKind] ']->' |
-    '->'
-  )
+  RelationConnector
   target=FqnRef
   (title=String  // title
     (description=String  // description

--- a/packages/language-server/src/model/builder/MergedSpecification.ts
+++ b/packages/language-server/src/model/builder/MergedSpecification.ts
@@ -299,8 +299,18 @@ export class MergedSpecification {
     links,
     id,
     tags,
+    isBidirectional,
     ...model
   }: ParsedAstDeploymentRelation): c4.DeploymentRelationship | null => {
+    const bidirectionalRelationship = (relationship: c4.DeploymentRelationship): c4.DeploymentRelationship =>
+      isBidirectional
+        ? {
+          ...relationship,
+          isBidirectional,
+          tail: relationship.tail ?? relationship.head ?? 'normal',
+        }
+        : relationship
+
     if (isNonNullish(kind) && this.specs.relationships[kind as c4.RelationshipKind]) {
       const spec = this.specs.relationships[kind as c4.RelationshipKind]!
       const { multiple: _multiple, tags: specTags, ...restSpec } = spec
@@ -312,24 +322,28 @@ export class MergedSpecification {
           ])
           : specTags
       }
-      return {
-        ...restSpec,
-        ...model,
+      return bidirectionalRelationship(
+        {
+          ...restSpec,
+          ...model,
+          ...(links && { links }),
+          ...(tags && { tags }),
+          source,
+          target,
+          kind,
+          id,
+        } satisfies c4.DeploymentRelationship,
+      )
+    }
+    return bidirectionalRelationship(
+      {
         ...(links && { links }),
+        ...model,
         ...(tags && { tags }),
         source,
         target,
-        kind,
         id,
-      } satisfies c4.DeploymentRelationship
-    }
-    return {
-      ...(links && { links }),
-      ...model,
-      ...(tags && { tags }),
-      source,
-      target,
-      id,
-    } satisfies c4.DeploymentRelationship
+      } satisfies c4.DeploymentRelationship,
+    )
   }
 }

--- a/packages/language-server/src/model/builder/MergedSpecification.ts
+++ b/packages/language-server/src/model/builder/MergedSpecification.ts
@@ -51,6 +51,29 @@ export function deriveTechnologyFromIcon(icon: string | undefined): string | und
 }
 
 /**
+ * Marks the relationship as bidirectional and defaults its tail, so it renders an arrow on both ends.
+ * An explicitly styled tail wins.
+ */
+function applyBidirectional(rel: c4.Relationship, isBidirectional: boolean | undefined): c4.Relationship
+function applyBidirectional(
+  rel: c4.DeploymentRelationship,
+  isBidirectional: boolean | undefined,
+): c4.DeploymentRelationship
+function applyBidirectional(
+  rel: c4.Relationship | c4.DeploymentRelationship,
+  isBidirectional: boolean | undefined,
+): c4.Relationship | c4.DeploymentRelationship {
+  if (!isBidirectional) {
+    return rel
+  }
+  return {
+    ...rel,
+    isBidirectional,
+    tail: rel.tail ?? rel.head ?? 'normal',
+  }
+}
+
+/**
  * The `MergedSpecification` class is responsible for merging multiple parsed
  * LikeC4Langium documents into a single specification. It consolidates tags,
  * elements, deployments, relationships, and colors from the provided documents
@@ -198,15 +221,6 @@ export class MergedSpecification {
     isBidirectional,
     ...model
   }: ParsedAstRelation): c4.Relationship | null => {
-    const bidirectionalRelationship = (relationship: c4.Relationship): c4.Relationship =>
-      isBidirectional
-        ? {
-          ...relationship,
-          isBidirectional,
-          tail: relationship.tail ?? relationship.head ?? 'normal',
-        }
-        : relationship
-
     if (isNonNullish(kind) && this.specs.relationships[kind]) {
       const { multiple: _multiple, tags: specTags, ...spec } = this.specs.relationships[kind]
       if (specTags && isNonEmptyArray(specTags)) {
@@ -217,7 +231,7 @@ export class MergedSpecification {
           ])
           : specTags
       }
-      return bidirectionalRelationship(
+      return applyBidirectional(
         {
           ...spec,
           ...model,
@@ -230,9 +244,10 @@ export class MergedSpecification {
           kind,
           id,
         } satisfies c4.Relationship,
+        isBidirectional,
       )
     }
-    return bidirectionalRelationship(
+    return applyBidirectional(
       {
         ...(links && { links }),
         ...model,
@@ -242,6 +257,7 @@ export class MergedSpecification {
         id,
         title,
       } satisfies c4.Relationship,
+      isBidirectional,
     )
   }
 
@@ -302,15 +318,6 @@ export class MergedSpecification {
     isBidirectional,
     ...model
   }: ParsedAstDeploymentRelation): c4.DeploymentRelationship | null => {
-    const bidirectionalRelationship = (relationship: c4.DeploymentRelationship): c4.DeploymentRelationship =>
-      isBidirectional
-        ? {
-          ...relationship,
-          isBidirectional,
-          tail: relationship.tail ?? relationship.head ?? 'normal',
-        }
-        : relationship
-
     if (isNonNullish(kind) && this.specs.relationships[kind as c4.RelationshipKind]) {
       const spec = this.specs.relationships[kind as c4.RelationshipKind]!
       const { multiple: _multiple, tags: specTags, ...restSpec } = spec
@@ -322,7 +329,7 @@ export class MergedSpecification {
           ])
           : specTags
       }
-      return bidirectionalRelationship(
+      return applyBidirectional(
         {
           ...restSpec,
           ...model,
@@ -333,9 +340,10 @@ export class MergedSpecification {
           kind,
           id,
         } satisfies c4.DeploymentRelationship,
+        isBidirectional,
       )
     }
-    return bidirectionalRelationship(
+    return applyBidirectional(
       {
         ...(links && { links }),
         ...model,
@@ -344,6 +352,7 @@ export class MergedSpecification {
         target,
         id,
       } satisfies c4.DeploymentRelationship,
+      isBidirectional,
     )
   }
 }

--- a/packages/language-server/src/model/parser/DeploymentModelParser.ts
+++ b/packages/language-server/src/model/parser/DeploymentModelParser.ts
@@ -227,6 +227,7 @@ export function DeploymentModelParser<TBase extends WithExpressionV2>(B: TBase) 
         id,
         source,
         target,
+        isBidirectional: astNode.isBidirectional || undefined,
         ...titleDescAndTech,
         metadata,
         kind,

--- a/skills/likec4-dsl/references/deployment.md
+++ b/skills/likec4-dsl/references/deployment.md
@@ -98,6 +98,8 @@ deployment {
     }
     // Deployment-level relationship not in the logical model
     AppTier -> DataTier "internal traffic" { technology "TCP/5432" }
+    // Bidirectional, `-[kind]<->` is also supported
+    AppTier <-> DataTier "replicates"
   }
 }
 ```

--- a/skills/likec4-dsl/references/relationships-bidirectional.md
+++ b/skills/likec4-dsl/references/relationships-bidirectional.md
@@ -5,6 +5,7 @@
 LikeC4 supports `<->` in two places with related but different meanings:
 
 - In `model { ... }`, `<->` declares one semantic bidirectional relationship.
+- In `deployment { ... }`, `<->` declares one semantic bidirectional deployment relationship.
 - In `views { ... }`, `A <-> B` is a binary predicate that includes relationships between two element sets in either direction.
 
 ## Declaring relationships in the model
@@ -51,6 +52,36 @@ model {
 ```
 
 The relationship kind participates in extension matching. When extending a kinded relationship, include the kind in `extend`; also include the title whenever the relationship is titled.
+
+## Bidirectional deployment relationships
+
+Deployment relationships use the same notation and semantics:
+
+```likec4
+specification {
+  element component
+  deploymentNode vm
+  relationship sync
+}
+
+model {
+  component database
+}
+
+deployment {
+  vm vm1 {
+    db = instanceOf database
+  }
+  vm vm2 {
+    db = instanceOf database
+  }
+
+  vm1.db <-> vm2.db "replicates"
+  vm1 -[sync]<-> vm2 "heartbeat"
+}
+```
+
+There is no `extend` for deployment relationships, so extension matching does not apply here.
 
 ## Extending bidirectional relationships
 
@@ -133,6 +164,7 @@ There is no prefix `<-> X` predicate. Use `-> X ->` when you need both incoming 
 | ------------------- | -------------- | ----------------------------------------------------------- |
 | `A -> B`            | model          | Directed relationship: A initiates/calls/sends to B         |
 | `A <-> B`           | model          | One bidirectional relationship between A and B              |
+| `A <-> B`           | deployment     | One bidirectional deployment relationship between A and B   |
 | `A -[kind]-> B`     | model          | Directed relationship with relationship kind                |
 | `A -[kind]<-> B`    | model          | Bidirectional relationship with relationship kind           |
 | `A -> B` + `B -> A` | model          | Two separate directed relationships                         |


### PR DESCRIPTION
Extends the bidirectional relationship notation (`<->` and `-[kind]<->`) from PR #2949 to deployment relationships.

- like-c4.langium: DeploymentRelation reuses the shared RelationConnector fragment, so it accepts `<->` and `-[kind]<->` like logical relations.
- language-server: DeploymentModelParser and MergedSpecification propagate isBidirectional to render arrows on both ends.
- core: DeploymentRelationship/DeploymentRelationModel expose isBidirectional; the deployment-view incoming predicate can include and exclude bidirectional relations from either endpoint (findConnectionsFrom/ narrowToBidirectional); shared isBidirectionalRelation helper moved to compute-view/utils so element-view and deployment-view use the same logic.
- builder: NewDeploymentRelationProps no longer strips isBidirectional, so it can be set from the Builder API.
- generators: deployment and model relationship emitters share a relationConnector helper and emit `<->`/`-[kind]<->`; isBidirectional added to both zod schemas.
- docs/skill: documented bidirectional deployment relationships in apps/docs and the likec4-dsl skill references.
- tests: language-server parsing tests, a deployment-view compute spec for include/exclude symmetry, and a generator snapshot.
- added a changeset for @likec4/core, @likec4/language-server and @likec4/generators.

Fixes #3219

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask, and propose improvements. We're here to help. -->

- [x] I've thoroughly read the latest [contribution guidelines](https://github.com/likec4/likec4/blob/main/CONTRIBUTING.md).
- [x] I've rebased my branch onto `main` **before** creating this PR.
- [x] I've added tests to cover my changes (if applicable).
- [x] I've verified `pnpm typecheck` and `pnpm test`.
- [x] I've added [changesets](https://changesets-docs.vercel.app/) (you can use `/changeset-generator` SKILL).
- [x] My change requires documentation updates.
- [x] I've updated the documentation accordingly (or will do in follow-up PR).
