### PR TITLE
fix: honor workspace exclusions during filesystem discovery

### DIFF
--- a/.changeset/tidy-workspace-discovery.md
+++ b/.changeset/tidy-workspace-discovery.md
@@ -1,0 +1,6 @@
+---
+"@likec4/language-server": patch
+"likec4-vscode": patch
+---
+
+Honor editor workspace exclusions before traversing folders during project and model discovery, avoiding unnecessary scans of excluded generated files and runtime storage.

--- a/packages/language-server/src/filesystem/LikeC4FileSystem.spec.ts
+++ b/packages/language-server/src/filesystem/LikeC4FileSystem.spec.ts
@@ -1,0 +1,89 @@
+import { URI } from 'langium'
+import fs from 'node:fs'
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, relative } from 'node:path'
+import { afterEach, beforeEach, describe, it, vi } from 'vitest'
+import { createLanguageServices } from '../module'
+import { WithFileSystem } from './LikeC4FileSystem'
+
+describe('workspace filesystem exclusions', () => {
+  let root: string
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'likec4-scan-test-'))
+    for (const dir of ['model', 'excluded/deep', 'node_modules/deep']) {
+      await mkdir(join(root, dir), { recursive: true })
+      await writeFile(join(root, dir, 'model.c4'), 'specification { element component }')
+      await writeFile(join(root, dir, 'likec4.config.json'), '{"name":"fixture"}')
+    }
+  })
+
+  afterEach(async () => {
+    vi.restoreAllMocks()
+    await rm(root, { recursive: true, force: true })
+  })
+
+  function setup(patterns: string[]) {
+    const { shared } = createLanguageServices(WithFileSystem())
+    shared.workspace.ProjectsManager.setWorkspaceExcludePatterns(patterns)
+    return shared.workspace
+  }
+
+  for (const operation of ['readDirectory', 'scanProjectFiles', 'scanDirectory'] as const) {
+    it(`${operation} prunes excluded directories before reading them`, async ({ expect }) => {
+      const { FileSystemProvider: provider } = setup(['**/excluded/**'])
+      const readdir = vi.spyOn(fs, 'readdir')
+      const files = operation === 'scanDirectory'
+        ? await provider.scanDirectory(URI.file(root), () => true)
+        : await provider[operation](URI.file(root))
+
+      expect(files.map(file => relative(root, file.uri.fsPath).replaceAll('\\', '/')).sort()).toEqual(
+        operation === 'readDirectory' ?
+          ['model/model.c4']
+          : operation === 'scanProjectFiles' ?
+          ['model/likec4.config.json']
+          : ['model/likec4.config.json', 'model/model.c4'],
+      )
+      // Checking results alone would also pass with filtering after traversal.
+      const visited = readdir.mock.calls.map(([path]) => String(path))
+      expect(visited.some(path => path.includes('model'))).toBe(true)
+      expect(visited.some(path => path.includes('excluded'))).toBe(false)
+      expect(visited.some(path => path.includes('node_modules'))).toBe(false)
+    })
+  }
+
+  it('does not traverse an explicitly excluded scan root', async ({ expect }) => {
+    const { FileSystemProvider: provider } = setup(['**/excluded/**'])
+    const readdir = vi.spyOn(fs, 'readdir')
+    const excluded = URI.file(join(root, 'excluded'))
+    expect(await provider.readDirectory(excluded)).toEqual([])
+    expect(await provider.scanProjectFiles(excluded)).toEqual([])
+    expect(await provider.scanDirectory(excluded, () => true)).toEqual([])
+    expect(readdir).not.toHaveBeenCalled()
+  })
+
+  it('filters individual files and uses updated exclusions on the next scan', async ({ expect }) => {
+    const { FileSystemProvider: provider, ProjectsManager: projects } = setup(['**/excluded/**', '**/model.c4'])
+    expect(await provider.readDirectory(URI.file(root))).toEqual([])
+    projects.setWorkspaceExcludePatterns(['**/excluded/**', '**/likec4.config.json'])
+    expect(await provider.scanProjectFiles(URI.file(root))).toEqual([])
+    expect((await provider.readDirectory(URI.file(root))).map(file => file.uri.fsPath))
+      .toEqual([join(root, 'model/model.c4')])
+  })
+
+  it('prunes an excluded directory symlink while retaining supported symlink discovery', async ({ expect }) => {
+    const target = await mkdtemp(join(tmpdir(), 'likec4-link-test-'))
+    try {
+      await writeFile(join(target, 'linked.c4'), 'model {}')
+      await symlink(target, join(root, 'ignored-link'), 'junction')
+      await symlink(target, join(root, 'allowed-link'), 'junction')
+      const { FileSystemProvider: provider } = setup(['**/excluded/**', '**/ignored-link/**'])
+      const files = await provider.readDirectory(URI.file(root))
+      expect(files.some(file => file.uri.fsPath.includes('ignored-link'))).toBe(false)
+      expect(files.some(file => file.uri.fsPath.includes('allowed-link'))).toBe(true)
+    } finally {
+      await rm(target, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/language-server/src/filesystem/LikeC4FileSystem.ts
+++ b/packages/language-server/src/filesystem/LikeC4FileSystem.ts
@@ -1,6 +1,5 @@
 import type { LikeC4ProjectConfig } from '@likec4/config'
 import { isLikeC4Config, loadConfig } from '@likec4/config/node'
-import { compareNaturalHierarchically } from '@likec4/core/utils'
 import { fdir } from 'fdir'
 import { URI } from 'langium'
 import { NodeFileSystemProvider } from 'langium/node'
@@ -9,6 +8,7 @@ import { unlink, writeFile as fsWriteFile } from 'node:fs/promises'
 import { basename, dirname } from 'node:path'
 import { Content, isLikeC4Builtin } from '../likec4lib'
 import { logger as rootLogger } from '../logger'
+import type { LikeC4SharedServices } from '../module'
 import { compareByUri, compareByUriDeepFirst } from '../utils'
 import { WithChokidarWatcher } from './ChokidarWatcher'
 import { NoFileSystemWatcher } from './noop'
@@ -25,7 +25,7 @@ function isLikeC4File(path: string, isDirectory: boolean = false): boolean {
 export const WithFileSystem = (
   enableWatcher = false,
 ): FileSystemModuleContext => ({
-  fileSystemProvider: () => new SymLinkTraversingFileSystemProvider(),
+  fileSystemProvider: services => new SymLinkTraversingFileSystemProvider(services),
   ...(enableWatcher ? WithChokidarWatcher : NoFileSystemWatcher),
 })
 
@@ -35,6 +35,20 @@ export const WithFileSystem = (
  */
 class SymLinkTraversingFileSystemProvider extends NodeFileSystemProvider implements FileSystemProvider {
   #logger = rootLogger.getChild('filesystem')
+
+  constructor(private services: LikeC4SharedServices) {
+    super()
+  }
+
+  private isExcluded(path: string): boolean {
+    // Read the current matcher lazily: editor exclusions are configured after
+    // service construction and can change before a project reload.
+    return this.services.workspace.ProjectsManager.isExcludedByWorkspace(URI.file(path))
+  }
+
+  private excludeDirectory = (name: string, path: string): boolean => {
+    return isNodeModulesOrRepo(name) || this.isExcluded(path)
+  }
 
   override async readFile(uri: URI): Promise<string> {
     if (isLikeC4Builtin(uri)) {
@@ -52,6 +66,9 @@ class SymLinkTraversingFileSystemProvider extends NodeFileSystemProvider impleme
     folderPath: URI,
     opts?: { recursive?: boolean; maxDepth?: number },
   ): Promise<FileNode[]> {
+    if (this.isExcluded(folderPath.fsPath)) {
+      return []
+    }
     const recursive = opts?.recursive ?? true
     const maxDepth = opts?.maxDepth ?? Infinity
     const entries = [] as FileNode[]
@@ -59,9 +76,9 @@ class SymLinkTraversingFileSystemProvider extends NodeFileSystemProvider impleme
     try {
       let crawler = new fdir()
         .withSymlinks({ resolvePaths: false })
-        .exclude(isNodeModulesOrRepo)
+        .exclude(this.excludeDirectory)
         .withFullPaths()
-        .filter(isLikeC4File)
+        .filter(path => isLikeC4File(path) && !this.isExcluded(path))
 
       if (!recursive) {
         crawler = crawler.withMaxDepth(1)
@@ -98,13 +115,16 @@ class SymLinkTraversingFileSystemProvider extends NodeFileSystemProvider impleme
     directory: URI,
     filter: (filepath: string, isDirectory: boolean) => boolean,
   ): Promise<FileNode[]> {
+    if (this.isExcluded(directory.fsPath)) {
+      return []
+    }
     const entries = [] as FileNode[]
     try {
       const crawled = await new fdir()
         .withSymlinks({ resolvePaths: false })
-        .exclude(isNodeModulesOrRepo)
+        .exclude(this.excludeDirectory)
         .withFullPaths()
-        .filter(filter)
+        .filter((path, isDirectory) => !this.isExcluded(path) && filter(path, isDirectory))
         .crawl(directory.fsPath)
         .withPromise()
       for (const path of crawled) {

--- a/packages/language-server/src/filesystem/types.ts
+++ b/packages/language-server/src/filesystem/types.ts
@@ -61,7 +61,7 @@ export interface FileSystemProvider extends LangiumFileSystemProvider {
 }
 
 export interface FileSystemModuleContext extends FileSystemWatcherModuleContext {
-  fileSystemProvider: () => FileSystemProvider
+  fileSystemProvider: (services: LikeC4SharedServices) => FileSystemProvider
 }
 
 export interface FileSystemWatcherModuleContext {

--- a/packages/language-server/src/module.ts
+++ b/packages/language-server/src/module.ts
@@ -18,7 +18,7 @@ import type {
   LikeC4ManualLayouts,
   LikeC4ManualLayoutsModuleContext,
 } from './filesystem'
-import { NoFileSystem, NoLikeC4ManualLayouts } from './filesystem/noop'
+import { NoFileSystem, NoLikeC4ManualLayouts, NoopFileSystemProvider } from './filesystem/noop'
 import { LikeC4Formatter } from './formatting/LikeC4Formatter'
 import {
   LikeC4GeneratedModule,
@@ -111,7 +111,7 @@ function createLikeC4SharedModule(context: LikeC4SharedModuleContext): Module<
       LangiumDocuments: services => new LangiumDocuments(services),
       ProjectsManager: services => new ProjectsManager(services),
       WorkspaceManager: services => new LikeC4WorkspaceManager(services),
-      FileSystemProvider: () => context.fileSystemProvider(),
+      FileSystemProvider: services => context.fileSystemProvider(services),
       FileSystemWatcher: services => context.fileSystemWatcher(services),
       ManualLayouts: services => context.manualLayouts(services),
     },
@@ -314,7 +314,11 @@ export function createSharedServices(context: Partial<LanguageServicesContext> =
     ...context,
   }
   return inject(
-    createDefaultSharedModule(moduleContext),
+    createDefaultSharedModule({
+      ...moduleContext,
+      // The LikeC4 module below supplies the provider with the extended services.
+      fileSystemProvider: () => new NoopFileSystemProvider(),
+    }),
     LikeC4GeneratedSharedModule,
     createLikeC4SharedModule(moduleContext),
   )


### PR DESCRIPTION
Workspace exclusions are currently checked when assigning files to projects, but the Node filesystem provider does not use them while crawling for project configuration and model files. Consequently, an excluded generated/runtime directory is still traversed during startup and project reloads.

This change passes the shared services to the filesystem provider and consults the current workspace exclusion matcher before descending into directories, before scanning an excluded root, and when selecting individual files. The existing built-in directory exclusions and supported directory-symlink discovery remain intact. Project-specific exclusions and Git ignore handling are unchanged.

Validation:
- Six synthetic filesystem regression tests fail on the original implementation and pass with the fix. Directory-read spies distinguish traversal pruning from filtering results afterward.
- The language-server suite passes: 823 passed, 3 skipped, 2 todo across 66 files.
- `pnpm exec tsc -b packages/language-server` passes.
- Scoped oxlint and dprint checks pass.

The tests use small temporary fixtures only; no real workspace files, logs, data, or screenshots are included. This fixes exclusion-aware discovery; it does not change language-client crash/restart policy or introduce automatic `.gitignore` support.
