### PR TITLE
docs: expand Brazilian Portuguese guides and DSL documentation

### DIFF
--- a/apps/docs/src/content/docs/pt-br/dsl/intro.mdx
+++ b/apps/docs/src/content/docs/pt-br/dsl/intro.mdx
@@ -37,7 +37,7 @@ Um arquivo-fonte deve ter pelo menos uma destas declarações:
 - `specification` - define os tipos de elementos usados no modelo, como **system**, **app**, **microservice**...
 - `model` - elementos de arquitetura, hierarquias, composições e relacionamentos
 - `views` - visualizações
-- `global` - predicados compartilhados globalmente (explicados mais adiante em [Views](/dsl/views/predicates/#shared-global-styles))
+- `global` - predicados compartilhados globalmente (explicados mais adiante em [views](/dsl/views/predicates/#shared-global-styles))
 
 ```likec4
 // example.c4
@@ -73,5 +73,5 @@ views {
 :::tip
 Por exemplo, o bloco `views` permite _"estilos locais"_ que se aplicam às visões no mesmo bloco.
 Assim, você pode agrupar visões que têm os mesmos estilos e evitar repetição.
-Explicado mais adiante em [Views](/dsl/views/predicates/#shared-local-styles).
+Explicado mais adiante em [views](/dsl/views/predicates/#shared-local-styles).
 :::

--- a/apps/docs/src/content/docs/pt-br/dsl/intro.mdx
+++ b/apps/docs/src/content/docs/pt-br/dsl/intro.mdx
@@ -1,0 +1,77 @@
+---
+title: Introdução
+description: Primeiros pontos para conhecer ao começar com o LikeC4
+prev: false
+sidebar:
+  order: 1
+---
+
+import { FileTree } from '@astrojs/starlight/components';
+
+LikeC4 é uma DSL para descrever arquitetura de software.
+
+Os arquivos-fonte devem ter as extensões `.likec4` ou `.c4`.
+Todas as fontes são combinadas em _um único modelo_ (explicado mais adiante em [estender o modelo](/dsl/extend)).
+
+Um projeto pode ter esta aparência:
+
+<FileTree>
+- backend
+  - service1
+    - model.c4
+    - views.c4
+  - service2
+    - model.c4
+  - ...
+- externals
+  - amazon.c4
+  - ...
+- landscape.c4
+- specs.c4
+</FileTree>
+
+## Declarações de nível superior
+
+Um arquivo-fonte deve ter pelo menos uma destas declarações:
+
+- `specification` - define os tipos de elementos usados no modelo, como **system**, **app**, **microservice**...
+- `model` - elementos de arquitetura, hierarquias, composições e relacionamentos
+- `views` - visualizações
+- `global` - predicados compartilhados globalmente (explicados mais adiante em [Views](/dsl/views/predicates/#shared-global-styles))
+
+```likec4
+// example.c4
+specification {
+  //...
+}
+
+global {
+  //...
+}
+
+model {
+  //...
+}
+
+views {
+  //...
+}
+```
+
+Você pode ter várias declarações do mesmo tipo:
+
+```likec4
+// Views group 1
+views {
+}
+
+// Views group 2
+views {
+}
+```
+
+:::tip
+Por exemplo, o bloco `views` permite _"estilos locais"_ que se aplicam às visões no mesmo bloco.
+Assim, você pode agrupar visões que têm os mesmos estilos e evitar repetição.
+Explicado mais adiante em [Views](/dsl/views/predicates/#shared-local-styles).
+:::

--- a/apps/docs/src/content/docs/pt-br/dsl/model.mdx
+++ b/apps/docs/src/content/docs/pt-br/dsl/model.mdx
@@ -16,7 +16,7 @@ O `model` descreve a arquitetura como um conjunto de elementos hierárquicos e r
 ## Elemento
 
 Um elemento é um bloco básico de construção. Ele representa uma parte lógica da arquitetura.
-Qualquer elemento deve ter um [`kind`](/dsl/specification#element-kind) e um `name` (_identifier_):
+Qualquer elemento deve ter um [`kind`](/pt-br/dsl/specification/#tipo-de-elemento) e um `name` (_identifier_):
 
 ```likec4
 specification {
@@ -152,7 +152,7 @@ model {
 ```
 
 :::tip
-Você pode definir propriedades de elementos na [especificação](/dsl/specification#element-kind) quando elas forem comuns a todos os elementos daquele tipo:
+Você pode definir propriedades de elementos na [especificação](/pt-br/dsl/specification/#tipo-de-elemento) quando elas forem comuns a todos os elementos daquele tipo:
 
 ```likec4
 specification {
@@ -180,7 +180,7 @@ Esse comportamento é habilitado por padrão. Para desativá-lo, defina `inferTe
 
 ### Tags
 
-[Tags](/dsl/specification/#tag) de elementos são definidas em um bloco aninhado e devem vir primeiro, antes de qualquer outra propriedade:
+[Tags](/pt-br/dsl/specification/#tag) de elementos são definidas em um bloco aninhado e devem vir primeiro, antes de qualquer outra propriedade:
 
 ```likec4 copy
 model {
@@ -205,7 +205,7 @@ model {
 
 :::tip
 
-Você pode adicionar tags na [especificação](/dsl/specification/#tag), quando isso for comum a todos os elementos do tipo:
+Você pode adicionar tags na [especificação](/pt-br/dsl/specification/#tag), quando isso for comum a todos os elementos do tipo:
 
 ```likec4
 specification {
@@ -568,7 +568,7 @@ e:
 
 :::caution
 Você não pode ter elementos com o mesmo nome dentro do mesmo pai.
-Isso é explicado em detalhes em [referências](/dsl/references).
+Isso é explicado em detalhes em [referências](/pt-br/dsl/references).
 
 ```likec4 filename="nested-elements.c4"
 model {

--- a/apps/docs/src/content/docs/pt-br/dsl/model.mdx
+++ b/apps/docs/src/content/docs/pt-br/dsl/model.mdx
@@ -271,7 +271,8 @@ model {
 }
 ```
 
-Apenas valores string são permitidos, mas você pode usar formato JSON ou YAML para dados complexos.
+Valores de metadados podem ser strings, booleanos sem aspas ou arrays de strings.
+Para dados complexos, você pode usar strings em formato JSON ou YAML.
 
 ### Valores de array
 
@@ -392,106 +393,6 @@ model {
 ```
 
 Esse comportamento se aplica a **todas as chaves duplicadas**.
-
-Todas as propriedades de metadados são exibidas em ordem alfabética, independentemente da ordem de definição.
-
-```likec4 copy
-model {
-  api = service 'API Gateway' {
-    metadata {
-      version '3.2.1'
-      maintainer 'Platform Team'
-      tags ['backend', 'gateway', 'microservice']
-      regions ['us-east-1', 'eu-west-1']
-      critical true
-    }
-  }
-}
-```
-
-Veja mais exemplos com vários padrões de metadados mistos:
-
-```likec4 copy
-model {
-  // E-commerce application with mixed metadata types
-  frontend = application 'Frontend App' {
-    metadata {
-      framework 'React'
-      version '18.2.0'
-      features ['shopping-cart', 'user-auth', 'payment', 'search']
-      deployment_targets ['staging', 'production']
-      team_lead 'Alice Johnson'
-      developers ['Bob Smith', 'Carol Davis', 'David Wilson']
-      release_cycle 'weekly'
-      supported_browsers ['Chrome', 'Firefox', 'Safari', 'Edge']
-      accessibility_level 'WCAG 2.1 AA'
-      has_mobile_app true
-    }
-  }
-
-  // Database service with operational metadata
-  database = service 'PostgreSQL Cluster' {
-    metadata {
-      engine 'PostgreSQL'
-      version '15.3'
-      instances ['primary', 'replica-1', 'replica-2']
-      backup_schedule 'daily'
-      backup_retention_days '30'
-      monitoring_endpoints ['metrics', 'logs', 'traces']
-      alert_channels ['slack', 'email', 'pagerduty']
-      maintenance_window 'Sunday 2-4 AM UTC'
-      data_classification 'sensitive'
-      encryption_at_rest true
-    }
-  }
-
-  // Microservice with complex deployment metadata
-  payment = service 'Payment Service' {
-    metadata {
-      language 'Go'
-      version '2.1.4'
-      port '8080'
-      health_check_path '/health'
-      dependencies ['database', 'redis', 'external-payment-api']
-      environments ['dev', 'test', 'stage', 'prod']
-      scaling_policy 'auto'
-      min_replicas '2'
-      max_replicas '10'
-      circuit_breaker_enabled true
-      rate_limits ['1000/minute', '100/second']
-      compliance_standards ['PCI-DSS', 'SOC2']
-    }
-  }
-}
-```
-
-```likec4 copy
-model {
-  api = service 'API Gateway' {
-    metadata {
-      version '3.2.1'
-      maintainer 'Platform Team'
-      tags ['backend', 'gateway', 'microservice']
-      regions ['us-east-1', 'eu-west-1']
-      critical true
-    }
-  }
-}
-```
-
-```likec4 copy
-model {
-  api = service 'API Gateway' {
-    metadata {
-      version '3.2.1'
-      maintainer 'Platform Team'
-      tags ['backend', 'gateway', 'microservice']
-      regions ['us-east-1', 'eu-west-1']
-      critical true
-    }
-  }
-}
-```
 
 ## Usando Markdown
 

--- a/apps/docs/src/content/docs/pt-br/dsl/model.mdx
+++ b/apps/docs/src/content/docs/pt-br/dsl/model.mdx
@@ -1,0 +1,593 @@
+---
+title: Modelo
+description: Como definir elementos de arquitetura no LikeC4
+sidebar:
+  label: Modelo
+  order: 3
+tableOfContents:
+  # minHeadingLevel: 3
+  maxHeadingLevel: 4
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+O `model` descreve a arquitetura como um conjunto de elementos hierárquicos e relacionamentos entre eles.
+
+## Elemento
+
+Um elemento é um bloco básico de construção. Ele representa uma parte lógica da arquitetura.
+Qualquer elemento deve ter um [`kind`](/dsl/specification#element-kind) e um `name` (_identifier_):
+
+```likec4
+specification {
+  element actor
+  element service
+}
+
+model {
+  // element of kind 'actor' with the name 'customer'
+  actor customer
+  // element of kind 'service' named as 'cloud'
+  service cloud
+
+  // also possible with '=' and the name goes first
+  cloud = service
+}
+```
+
+O nome de um elemento é necessário para referências.
+Ele pode conter letras, dígitos, hifens e underscores, mas não pode começar com um dígito nem conter `.`
+
+| nome       | válido |
+| :--------- | :----- |
+| api        | ✅     |
+| Api2       | ✅     |
+| \_api      | ✅     |
+| \__Api-1   | ✅     |
+| 1api       | ⛔️    |
+| a.pi       | ⛔️    |
+
+
+## Propriedades do elemento
+
+### Título
+
+```likec4 'SaaS' copy
+specification {
+  element softwareSystem
+}
+model {
+  // Title can be inlined
+  saas = softwareSystem 'SaaS'
+
+  // or nested
+  saas = softwareSystem {
+    title 'SaaS'
+
+    // You can use `:` (optional)
+    title: 'SaaS'
+  }
+
+  // If title is not specified, name will be used by default
+  saas = softwareSystem
+}
+```
+
+:::note
+Você pode usar aspas simples ou duplas:
+```likec4
+model {
+  service cloud 'Cloud Service'
+  // Or
+  service cloud "Cloud Service"
+}
+```
+Se precisar de aspas dentro da string, escape com uma barra invertida:
+```likec4
+model {
+  service cloud 'Cloud\'s Service'
+  service cloud "Cloud\"s Service"
+}
+```
+:::
+
+### Descrição
+
+```likec4  'Provides services to customers' copy
+model {
+  // Can be inlined
+  saas = softwareSystem 'SaaS' 'Provides services to customers'
+
+  // or nested
+  saas = softwareSystem {
+    title 'SaaS'
+    description 'Provides services to customers'
+  }
+}
+```
+
+Um elemento pode ter um `summary` curto (opcional; usa `description` como fallback):
+
+```likec4 copy
+model {
+  saas = softwareSystem {
+    title 'SaaS'
+    summary 'Provides services to customers'
+    description '
+      Detailed description
+      ...
+    '
+  }
+}
+```
+
+Se `summary` for informado, ele será exibido no diagrama, e a `description` será exibida no diálogo de detalhes.
+Se você não informar `description`, o summary será usado.
+
+Para definição inline:
+```likec4 copy
+model {
+  // [title] [summary]
+  saas = softwareSystem 'SaaS' 'Provides services to customers' {
+    description '
+      Detailed description
+      ...
+    '
+  }
+}
+```
+
+### Tecnologia
+
+```likec4 copy
+model {
+  api = service {
+    technology 'REST'
+  }
+
+  // Structurizr DSL style:
+  // <name> = softwareSystem [title] [summary] [technology]
+  saas = softwareSystem 'SaaS' 'Provides services to customers' 'SaaS'
+}
+```
+
+:::tip
+Você pode definir propriedades de elementos na [especificação](/dsl/specification#element-kind) quando elas forem comuns a todos os elementos daquele tipo:
+
+```likec4
+specification {
+  element mobileApp {
+    title 'Mobile App'
+    description 'Universal mobile application'
+    technology 'React Native'
+  }
+}
+```
+
+Isso permite definir propriedades uma vez e reutilizá-las no modelo.
+Propriedades da definição do elemento sobrescrevem as propriedades da especificação.
+:::
+
+:::note[Tecnologia inferida automaticamente]
+Se um elemento tiver um ícone incluído (`aws:`, `azure:`, `gcp:` ou `tech:`), mas nenhuma tecnologia explícita,
+o LikeC4 deriva automaticamente um rótulo de tecnologia legível a partir do nome do ícone.
+Por exemplo, `icon tech:apache-flink` produz a tecnologia **"Apache Flink"**, e `icon aws:simple-storage-service` produz **"Simple Storage Service"**.
+
+Ícones `bootstrap:` são excluídos porque são ícones genéricos de UI.
+
+Esse comportamento é habilitado por padrão. Para desativá-lo, defina `inferTechnologyFromIcon` como `false` na [configuração do projeto](/dsl/config).
+:::
+
+### Tags
+
+[Tags](/dsl/specification/#tag) de elementos são definidas em um bloco aninhado e devem vir primeiro, antes de qualquer outra propriedade:
+
+```likec4 copy
+model {
+  appV1 = application 'App v1' {
+    #deprecated
+    description 'Old version of the application'
+  }
+
+  // multiple tags
+  appV2 = application {
+    #next, #serverless
+    #team2
+    title 'App v2'
+  }
+
+  appV3 = application {
+    title 'App v3'
+    #team3 // ⛔️ Error: tags must be defined first
+  }
+}
+```
+
+:::tip
+
+Você pode adicionar tags na [especificação](/dsl/specification/#tag), quando isso for comum a todos os elementos do tipo:
+
+```likec4
+specification {
+  element lambda {
+    #serverless
+  }
+}
+```
+:::
+
+### Links
+
+Um elemento pode ter vários links:
+
+```likec4 copy
+model {
+  bastion = application 'Bastion' {
+    // External link
+    link https://any-external-link.com
+
+    // With label
+    link https://github.com/likec4/likec4 'Repository'
+
+    // or any URI
+    link ssh://bastion.internal 'SSH'
+
+    // or relative link to navigate to sources
+    link ../src/index.ts#L1-L10
+  }
+}
+```
+
+### Metadados
+
+Metadados de elementos são um conjunto de pares chave-valor definidos em um bloco aninhado:
+
+```likec4 copy
+model {
+  app = application 'App' {
+    metadata {
+      prop1 'value1'
+      prop2 '
+        apiVersion: apps/v1
+        kind: StatefulSet
+        metadata:
+          name: app-statefulset
+        spec: {}
+      '
+      prop3 '{
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "age": {
+            "type": "integer"
+          }
+        }
+      }'
+    }
+  }
+}
+```
+
+Apenas valores string são permitidos, mas você pode usar formato JSON ou YAML para dados complexos.
+
+### Valores de array
+
+Você também pode usar arrays para valores de metadados com sintaxe de array literal:
+
+```likec4 copy
+model {
+  app = application 'App' {
+    metadata {
+      tags ['frontend', 'react', 'typescript']
+      environments ['dev', 'staging', 'prod']
+      version '2.1.0'
+    }
+  }
+}
+```
+
+Valores simples e arrays podem ser misturados no mesmo bloco de metadados:
+
+```likec4 copy
+model {
+  api = service 'API Gateway' {
+    metadata {
+      version '3.2.1'
+      maintainer 'Platform Team'
+      tags ['backend', 'gateway', 'microservice']
+      regions ['us-east-1', 'eu-west-1']
+      critical true
+    }
+  }
+}
+```
+
+Veja mais exemplos com vários padrões de metadados mistos:
+
+```likec4 copy
+model {
+  // E-commerce application with mixed metadata types
+  frontend = application 'Frontend App' {
+    metadata {
+      framework 'React'
+      version '18.2.0'
+      features ['shopping-cart', 'user-auth', 'payment', 'search']
+      deployment_targets ['staging', 'production']
+      team_lead 'Alice Johnson'
+      developers ['Bob Smith', 'Carol Davis', 'David Wilson']
+      release_cycle 'weekly'
+      supported_browsers ['Chrome', 'Firefox', 'Safari', 'Edge']
+      accessibility_level 'WCAG 2.1 AA'
+      has_mobile_app true
+    }
+  }
+
+  // Database service with operational metadata
+  database = service 'PostgreSQL Cluster' {
+    metadata {
+      engine 'PostgreSQL'
+      version '15.3'
+      instances ['primary', 'replica-1', 'replica-2']
+      backup_schedule 'daily'
+      backup_retention_days '30'
+      monitoring_endpoints ['metrics', 'logs', 'traces']
+      alert_channels ['slack', 'email', 'pagerduty']
+      maintenance_window 'Sunday 2-4 AM UTC'
+      data_classification 'sensitive'
+      encryption_at_rest true
+    }
+  }
+
+  // Microservice with complex deployment metadata
+  payment = service 'Payment Service' {
+    metadata {
+      language 'Go'
+      version '2.1.4'
+      port '8080'
+      health_check_path '/health'
+      dependencies ['database', 'redis', 'external-payment-api']
+      environments ['dev', 'test', 'stage', 'prod']
+      scaling_policy 'auto'
+      min_replicas '2'
+      max_replicas '10'
+      circuit_breaker_enabled true
+      rate_limits ['1000/minute', '100/second']
+      compliance_standards ['PCI-DSS', 'SOC2']
+    }
+  }
+}
+```
+
+### Comportamento das propriedades de metadados
+
+**Ordenação alfabética**: propriedades de metadados são ordenadas automaticamente em ordem alfabética quando exibidas, independentemente da ordem em que foram definidas na DSL. Isso garante uma apresentação consistente em todos os elementos.
+
+**Duplicação de propriedades**: quando o mesmo nome de propriedade é definido várias vezes, todos os valores são reunidos em um array, preservando a ordem de definição:
+
+```likec4 copy
+model {
+  service = component 'Payment Service' {
+    metadata {
+      version '1.0.0'               // First value
+      version '2.0.0'               // Second value
+      // Result: version: ['1.0.0', '2.0.0']
+
+      owner ['team-a', 'team-b']    // First: array values
+      owner 'team-c'                // Second: single value
+      // Result: owner: ['team-a', 'team-b', 'team-c']
+
+      tags 'primary'                // First: single value
+      tags ['backend', 'critical']  // Second: array values
+      // Result: tags: ['primary', 'backend', 'critical']
+
+      ports ['8080', '9090']        // First: array values
+      ports ['3000', '4000']        // Second: array values
+      // Result: ports: ['8080', '9090', '3000', '4000']
+    }
+  }
+}
+```
+
+Esse comportamento se aplica a **todas as chaves duplicadas**.
+
+Todas as propriedades de metadados são exibidas em ordem alfabética, independentemente da ordem de definição.
+
+```likec4 copy
+model {
+  api = service 'API Gateway' {
+    metadata {
+      version '3.2.1'
+      maintainer 'Platform Team'
+      tags ['backend', 'gateway', 'microservice']
+      regions ['us-east-1', 'eu-west-1']
+      critical true
+    }
+  }
+}
+```
+
+Veja mais exemplos com vários padrões de metadados mistos:
+
+```likec4 copy
+model {
+  // E-commerce application with mixed metadata types
+  frontend = application 'Frontend App' {
+    metadata {
+      framework 'React'
+      version '18.2.0'
+      features ['shopping-cart', 'user-auth', 'payment', 'search']
+      deployment_targets ['staging', 'production']
+      team_lead 'Alice Johnson'
+      developers ['Bob Smith', 'Carol Davis', 'David Wilson']
+      release_cycle 'weekly'
+      supported_browsers ['Chrome', 'Firefox', 'Safari', 'Edge']
+      accessibility_level 'WCAG 2.1 AA'
+      has_mobile_app true
+    }
+  }
+
+  // Database service with operational metadata
+  database = service 'PostgreSQL Cluster' {
+    metadata {
+      engine 'PostgreSQL'
+      version '15.3'
+      instances ['primary', 'replica-1', 'replica-2']
+      backup_schedule 'daily'
+      backup_retention_days '30'
+      monitoring_endpoints ['metrics', 'logs', 'traces']
+      alert_channels ['slack', 'email', 'pagerduty']
+      maintenance_window 'Sunday 2-4 AM UTC'
+      data_classification 'sensitive'
+      encryption_at_rest true
+    }
+  }
+
+  // Microservice with complex deployment metadata
+  payment = service 'Payment Service' {
+    metadata {
+      language 'Go'
+      version '2.1.4'
+      port '8080'
+      health_check_path '/health'
+      dependencies ['database', 'redis', 'external-payment-api']
+      environments ['dev', 'test', 'stage', 'prod']
+      scaling_policy 'auto'
+      min_replicas '2'
+      max_replicas '10'
+      circuit_breaker_enabled true
+      rate_limits ['1000/minute', '100/second']
+      compliance_standards ['PCI-DSS', 'SOC2']
+    }
+  }
+}
+```
+
+```likec4 copy
+model {
+  api = service 'API Gateway' {
+    metadata {
+      version '3.2.1'
+      maintainer 'Platform Team'
+      tags ['backend', 'gateway', 'microservice']
+      regions ['us-east-1', 'eu-west-1']
+      critical true
+    }
+  }
+}
+```
+
+```likec4 copy
+model {
+  api = service 'API Gateway' {
+    metadata {
+      version '3.2.1'
+      maintainer 'Platform Team'
+      tags ['backend', 'gateway', 'microservice']
+      regions ['us-east-1', 'eu-west-1']
+      critical true
+    }
+  }
+}
+```
+
+## Usando Markdown
+
+Você pode usar Markdown em `description` (e `summary`) com aspas triplas:
+
+```likec4 copy
+model {
+  mobile = application {
+    title 'Mobile Application'
+    description '''
+      ### Multi-platform application
+
+      [React Native](https://reactnative.dev)
+    '''
+  }
+
+  web = application {
+    description """
+      ### Web Application
+
+      > Provides services to customers through
+      > the web interface.
+
+      | checks     |     |
+      | :--------- | :-- |
+      | check 1    | ✅  |
+      | check 2    | ⛔️  |
+      | check 3    | ✅  |
+    """
+  }
+}
+```
+
+## Estruturando o modelo
+
+Qualquer elemento pode atuar como um contêiner e incluir outros elementos.
+Assim, você define a estrutura e os detalhes internos do elemento.
+
+```likec4 filename="nested-elements.c4"
+model {
+  // service1 has backend and frontend
+  service service1 {
+    component backend {
+      // backend has api
+      component api
+    }
+    component frontend
+  }
+
+  // or use '='
+  service2 = service {
+    backend = component {
+      api = component
+    }
+    frontend = component
+  }
+}
+```
+
+Elementos aninhados são _"namespaced"_: o nome do pai é usado como prefixo.
+Assim, o modelo acima tem elementos com estes nomes totalmente qualificados:
+
+- `service1`
+- `service1.backend`
+- `service1.backend.api`
+- `service1.frontend`
+
+e:
+
+- `service2`
+- `service2.backend`
+- `service2.backend.api`
+- `service2.frontend`
+
+:::caution
+Você não pode ter elementos com o mesmo nome dentro do mesmo pai.
+Isso é explicado em detalhes em [referências](/dsl/references).
+
+```likec4 filename="nested-elements.c4"
+model {
+
+  service service1 'Service 1' {
+    component backend
+
+    component backend // ⛔️ Error: 'service1.backend' already defined
+  }
+
+  service service2 'Service 2' {
+    component backend // ✅ This is OK - 'service2.backend'
+
+    component legacy {
+      component backend // ✅ This is OK - 'service2.legacy.backend'
+    }
+  }
+
+  component backend // ✅ This is OK - 'backend'
+}
+```
+:::

--- a/apps/docs/src/content/docs/pt-br/dsl/notations.mdx
+++ b/apps/docs/src/content/docs/pt-br/dsl/notations.mdx
@@ -1,0 +1,133 @@
+---
+title: Notações de visões
+description: Como definir a chave/legenda das visões
+sidebar:
+  label: Notações
+  order: 10
+tableOfContents:
+  minHeadingLevel: 3
+  maxHeadingLevel: 5
+---
+
+import { Card, Aside } from '@astrojs/starlight/components';
+import LikeC4ThemeView from '@components/likec4-theme/LikeC4ThemeView.astro';
+
+<Aside type='caution' title="Experimental">
+  A implementação é experimental e pode mudar no futuro.
+  O objetivo principal é coletar feedback, sugestões e ideias.
+</Aside>
+
+<Aside type='caution' title="Em andamento">
+  Notações de relacionamentos estão em andamento.
+</Aside>
+
+Notações de visões (ou chave/legenda) fornecem informações sobre os significados das formas e dos estilos.
+É importante fornecer uma chave que explique a diferença entre cores e formas.
+
+É possível definir notações globais (por tipo de elemento) e locais (por visão).
+
+#### Notações globais
+
+Como o nome indica, notações globais se aplicam a todas as visões e são definidas no bloco `specification`:
+
+```likec4 copy {4, 12}
+specification {
+
+  element customer {
+    notation "Person, Customer"
+    style {
+      shape person
+      color green
+    }
+  }
+
+  element staff {
+    notation "Person, Staff"
+    style {
+      shape person
+    }
+  }
+}
+```
+
+As notações serão aplicadas a todas as visões com esses elementos e exibidas assim:
+
+<div style="max-width:400px;margin: 1rem auto">
+![notations](../../../../assets/notations.png)
+</div>
+
+Exemplo ao vivo.
+Expanda a visão a seguir e clique no ícone de ajuda no canto inferior direito:
+
+<LikeC4ThemeView viewId="notations_example"/>
+
+#### Notações locais
+
+Notações locais sobrescrevem as globais e se aplicam a uma visão específica.
+
+##### Com predicado de estilo
+
+Quando você altera o estilo, pode adicionar uma notação para explicar o significado:
+
+```likec4
+view {
+
+  style webApp1, webApp2 {
+    notation "Application under development"
+    color amber
+  }
+
+  style element.tag = #deprecated {
+    notation "Deprecated"
+    color muted
+  }
+
+}
+```
+
+As notações não são mescladas nem agrupadas; a última será aplicada.
+
+:::tip
+
+Você pode ter a mesma notação para estilos diferentes:
+
+```likec4
+view {
+
+  style webApp1 {
+    notation "Web Application"
+    color amber
+  }
+
+  style webApp2 {
+    notation "Web Application"
+    color green
+  }
+}
+```
+:::
+
+##### Com sobrescritas
+
+Defina a notação ao incluir elementos:
+
+```likec4
+view {
+
+  include *
+    where kind is microservice
+      and tag is #deprecated
+      with {
+        notation "Deprecated microservice"
+        shape rectangle
+        color muted
+      }
+
+}
+```
+
+Essa sobrescrita tem a prioridade mais alta; depois vêm as notações definidas em predicados de estilo e, por fim, as notações globais.
+
+:::note
+Compartilhe suas ideias nas <a href="https://github.com/likec4/likec4/discussions/" target='_blank'>GitHub discussions</a> sobre como melhorar notações e torná-las reutilizáveis ou mais flexíveis.
+:::

--- a/apps/docs/src/content/docs/pt-br/dsl/references.mdx
+++ b/apps/docs/src/content/docs/pt-br/dsl/references.mdx
@@ -1,0 +1,194 @@
+---
+title: Referências
+description: Como referenciar elementos no LikeC4
+sidebar:
+  label: Referências
+  order: 5
+tableOfContents:
+  minHeadingLevel: 2
+  maxHeadingLevel: 4
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+O LikeC4 usa escopo léxico com hoisting, quase como no JavaScript.
+
+## Escopo
+
+Para entender referências, precisamos primeiro entender escopos.
+Exemplo:
+
+```likec4
+model {
+  service service1 {
+    component api
+    component frontend
+  }
+}
+```
+
+Cada elemento é único no modelo, então podemos adicionar um relacionamento referenciando-os, assim:
+
+```likec4 'frontend -> api'
+model {
+  service service1 {
+    component api
+    component frontend
+  }
+  frontend -> api
+}
+```
+
+Mas, se adicionarmos `service2` com outra `api`:
+
+```diff lang="likec4"
+model {
+  service service1 {
+    component api
+    component frontend
+  }
++  service service2 {
++    component api
++  }
+
+  frontend -> api // ⛔️ Error: 'api' not found
+}
+```
+
+A referência fica ambígua, pois há dois componentes `api` no modelo.
+
+Cada elemento cria um novo escopo dentro de `{...}`, então `api` é único dentro de `service1` e `service2`,
+mas não no escopo de `model`.
+
+Podemos resolver isso movendo o relacionamento para o escopo de `service2`:
+
+```likec4 {9-11}
+model {
+  service service1 {
+    component api
+    component frontend
+  }
+  service service2 {
+    component api
+
+    frontend -> api // ✅ This is OK,
+                    //    'api' is unique in 'service2'
+                    //    'frontend' is unique in 'model'
+  }
+}
+```
+
+## Hoisting
+
+<Aside>
+  **Hoisting** é um mecanismo que move a referência para o topo do escopo.
+</Aside>
+
+No LikeC4, além de passar por hoisting em seu escopo, o elemento também _"sobe"_ para os escopos superiores se permanecer único.
+
+Podemos referenciar algo que ainda não foi declarado, mas que passará por hoisting mais adiante.
+O relacionamento na linha 8 referencia `graphql`, definido abaixo na linha 15:
+
+```likec4 showLineNumbers copy
+model {
+
+  service service1 {
+    component api
+    component frontend
+
+    frontend -> api // ✅ This is OK, references to 'api' from 'service1'
+    frontend -> graphql // ✅ This is OK, references to unique 'graphql'
+  }
+
+  frontend -> api // ⛔️ Error: 'api' is ambiguous
+
+  service service2 {
+    component api
+    component graphql
+
+    frontend -> api  // ✅ This is OK, references to 'api' from 'service2'
+  }
+
+}
+```
+
+<Aside>
+As linhas 7 e 17 são iguais: `frontend -> api`
+Mas elas referenciam elementos diferentes:
+{'-'} A linha 7 referencia `service1.api`
+{'-'} A linha 17 referencia `service2.api`
+</Aside>
+
+## Nomes totalmente qualificados
+
+Elementos de nível superior (posicionados diretamente no bloco `model`) ficam disponíveis globalmente.
+Você pode usar nomes totalmente qualificados (FQN) para referenciar elementos aninhados.
+
+Exemplo:
+
+```likec4 {11,12}
+model {
+  service service1 {
+    component api
+    component frontend
+  }
+  service service2 {
+    component api
+  }
+
+  frontend -> api // ⛔️ Error: 'api' not found
+  frontend -> service1.api // ✅ This is OK
+  frontend -> service2.api // ✅ This is OK
+}
+```
+
+Ou ainda:
+
+```likec4 {6}
+model {
+  service service1 {
+    component api
+    component frontend {
+      -> api
+      -> service2.api    // references to outer scope
+    }
+  }
+  service service2 {
+    component api
+  }
+}
+```
+
+Algumas partes podem ser omitidas se o FQN permanecer único:
+
+```likec4
+model {
+  service service {
+    component backend1  {
+      component api
+    }
+    component backend2  {
+      component api
+      component graphql
+    }
+  }
+
+  frontend -> service.backend1.api // ✅ Non-ambiguous fully qualified name
+
+  frontend -> backend1.api  // ✅ This is OK, 'api' is unique in 'backend1',
+                            //    and 'backend1' is unique in the model
+                            //    We may omit 'service'
+
+  frontend -> backend2.api  // ✅ This is also OK
+
+  frontend -> service.api   // ⛔️ Error: 'api' is ambiguous in 'service'
+
+  frontend -> service.graphql // ✅ This is also OK, we omit 'backend2'
+                              //    as 'graphql' is unique in 'service'
+}
+```
+
+<Aside type='caution'>
+Embora omitir partes do FQN deixe o código mais legível e as referências mais curtas,
+isso pode causar erros quando você refatora o modelo.
+</Aside>

--- a/apps/docs/src/content/docs/pt-br/dsl/relationships.mdx
+++ b/apps/docs/src/content/docs/pt-br/dsl/relationships.mdx
@@ -1,0 +1,299 @@
+---
+title: Relacionamentos
+description: Como definir conexões, fluxos de dados e interações no seu modelo
+sidebar:
+  label: Relacionamentos
+  order: 4
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+Relacionamentos descrevem as conexões, os fluxos de dados e as interações dentro do seu modelo.
+
+## Definição de relacionamento
+
+Relacionamentos normalmente são definidos com o operador **`->`**:
+
+```likec4
+model {
+  customer = actor 'Customer'
+  cloud = service 'Cloud'
+
+  customer -> cloud
+}
+```
+
+Use **`<->`** quando os dois elementos se comunicam ativamente entre si:
+
+```likec4
+model {
+  frontend = component 'Frontend'
+  backend = component 'Backend'
+
+  frontend <-> backend 'Sync'
+}
+```
+
+Relacionamentos bidirecionais são renderizados com setas nas duas pontas por padrão. Use-os para interações mútuas,
+como replicação sincronizada ou protocolos em que os dois lados iniciam comunicação significativa. O estilo do
+relacionamento ainda pode sobrescrever a ponta renderizada. Para chamadas request-response em que um lado inicia a
+interação, prefira `->`.
+
+Relacionamentos podem ser aninhados
+
+```likec4
+model {
+  service cloud {
+    component backend
+    component frontend
+
+    frontend -> backend
+    customer -> frontend
+  }
+}
+```
+
+Em relacionamentos aninhados, você pode usar `it` ou `this` para se referir ao pai:
+
+```likec4
+model {
+  customer = actor {
+    // as a source
+    it -> frontend
+    // as a target
+    frontend -> this
+  }
+}
+```
+
+Relacionamentos aninhados podem não declarar a origem (_"sourceless"_); nesse caso, a origem é o elemento pai
+
+```likec4
+model {
+  actor customer {
+    // same as customer -> frontend
+    -> frontend
+  }
+  service cloud {
+    component backend
+    component frontend {
+      // same as frontend -> backend
+      -> backend
+    }
+  }
+}
+```
+
+:::caution
+
+Relacionamentos _"sourceless"_ devem estar aninhados:
+
+```likec4
+model {
+  -> backend // ⛔️ Error: model can't be a source
+}
+```
+:::
+
+## Tipos de relacionamento
+
+Relacionamentos podem ter um tipo (_kind_):
+
+```likec4
+specification {
+  element system
+  // Define relationship kind
+  relationship async
+  relationship uses
+}
+
+model {
+  system1 = system 'System 1'
+  system2 = system 'System 2'
+  system3 = system 'System 3'
+
+  system1 -[async]-> system2
+  system1 -[async]<-> system3
+
+  // Or prefix with '.' to use the kind
+  system1 .uses system2
+}
+```
+
+Use `-[kind]<->` quando um relacionamento bidirecional também deve herdar um tipo de relacionamento.
+
+Isso permite adicionar semânticas mais ricas às interações entre elementos, por exemplo,
+sob uma perspectiva de tecnologia (REST, gRPC, GraphQL, Sync/Async etc.)
+ou sob uma perspectiva de negócio (delegação, informação, responsabilidade etc.).
+
+Você pode definir os tipos de relacionamento que fizerem mais sentido para o seu contexto.
+
+Um tipo de relacionamento também pode definir [tags](#tags) e propriedades padrão — `title`, `description`, `technology`, `notation` e [links](#links) — herdadas por todo relacionamento desse tipo (um relacionamento pode sobrescrever qualquer uma das propriedades; tags são combinadas):
+
+```likec4
+specification {
+  relationship async {
+    #tcp
+    title 'Asynchronous'
+    technology 'Kafka'
+  }
+  tag tcp
+}
+model {
+  // inherits tag #tcp, title 'Asynchronous' and technology 'Kafka'
+  system1 .async system2
+
+  // overrides the title, keeps the inherited tag and technology
+  system1 .async system3 'publishes events'
+}
+```
+
+<Aside type='tip'>
+  Com tipos, você pode personalizar o estilo dos relacionamentos; consulte [styling](/dsl/styling#relationship)
+</Aside>
+
+## Propriedades de relacionamento
+
+### Título
+
+Relacionamentos podem ter um título (e é melhor que tenham):
+
+```likec4 'opens in browser'
+model {
+  customer -> frontend 'opens in browser'
+  // or nested
+  customer -> frontend {
+    title 'opens in browser'
+  }
+}
+```
+
+### Descrição
+
+```likec4 'Customer opens...'
+model {
+  customer -> frontend 'opens in browser' {
+    description 'Customer opens...'
+  }
+
+  // Or in a shorter way
+  customer -> frontend 'opens in browser' 'Customer opens...'
+}
+```
+
+Assim como nos elementos, você pode [usar Markdown](/pt-br/dsl/model#usando-markdown) em `description` com aspas triplas:
+
+```likec4
+model {
+  customer -> frontend 'opens in browser' {
+    description '''
+      **Customer** opens the frontend in the browser
+      to interact with the system
+
+
+      | checks    |    |
+      |:--------- |:-- |
+      | check 1   | ✅ |
+      | check 2   | ⛔️ |
+      | check 3   | ✅ |
+    '''
+  }
+}
+```
+
+Blocos de código cercados por crases recebem destaque de sintaxe quando especificam uma linguagem. Para diffs, use `diff-<language>` para destacar tanto as alterações quanto a linguagem-fonte, por exemplo `diff-ts` ou `diff-python`.
+
+### Tecnologia
+
+```likec4
+model {
+  customer -> frontend 'opens in browser' {
+    technology 'HTTPS'
+  }
+
+  // Or in a shorter way
+  // order is [title] [description] [technology]
+  customer -> frontend 'opens in browser'  'Customer opens...' 'HTTPS'
+}
+```
+
+
+### Tags
+
+Relacionamentos podem ter tags:
+
+```likec4
+model {
+  // inlined
+  frontend -> backend 'requests data' #graphql #team1
+
+  // or nested
+  customer -> frontend 'opens in browser' {
+    #graphql #team1
+  }
+}
+```
+
+### Links
+
+Relacionamentos podem ter vários links:
+
+```likec4 copy
+model {
+  customer -> frontend 'opens in browser' {
+    // External link
+    link https://any-external-link.com
+
+    // With label
+    link https://github.com/likec4/likec4 'Repository'
+
+    // or any URI
+    link ssh://bastion.internal 'SSH'
+
+    // or relative link to navigate to sources
+    link ../src/index.ts#L1-L10
+  }
+}
+```
+
+
+### Navigate To
+
+Um relacionamento pode ter uma propriedade `navigateTo`, que aponta para uma [dynamic view](/dsl/views/dynamic).
+Isso permite fazer _"zoom-in"_ e ver mais detalhes sobre esse relacionamento.
+
+```likec4 copy
+model {
+  webApp -> backend.api {
+    title 'requests data for the dashboard'
+    navigateTo dashboard-request-flow
+  }
+
+}
+```
+
+## Metadados de relacionamentos
+
+Igual aos [metadados de elementos](/pt-br/dsl/model/#metadados):
+
+```likec4
+model {
+  customer -> frontend 'opens in browser' {
+    metadata {
+      prop1 'value1'
+      prop2 '{
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "age": {
+            "type": "integer"
+          }
+        }
+      }'
+    }
+  }
+}
+```

--- a/apps/docs/src/content/docs/pt-br/dsl/relationships.mdx
+++ b/apps/docs/src/content/docs/pt-br/dsl/relationships.mdx
@@ -149,7 +149,7 @@ model {
 ```
 
 <Aside type='tip'>
-  Com tipos, você pode personalizar o estilo dos relacionamentos; consulte [styling](/dsl/styling#relationship)
+  Com tipos, você pode personalizar o estilo dos relacionamentos; consulte [estilização](/dsl/styling#relationship)
 </Aside>
 
 ## Propriedades de relacionamento
@@ -259,7 +259,7 @@ model {
 
 ### Navigate To
 
-Um relacionamento pode ter uma propriedade `navigateTo`, que aponta para uma [dynamic view](/dsl/views/dynamic).
+Um relacionamento pode ter uma propriedade `navigateTo`, que aponta para uma [visão dinâmica](/dsl/views/dynamic).
 Isso permite fazer _"zoom-in"_ e ver mais detalhes sobre esse relacionamento.
 
 ```likec4 copy

--- a/apps/docs/src/content/docs/pt-br/dsl/specification.mdx
+++ b/apps/docs/src/content/docs/pt-br/dsl/specification.mdx
@@ -1,0 +1,152 @@
+---
+title: Especificação
+description: Como adaptar o LikeC4 ao seu contexto, termos e necessidades
+sidebar:
+  label: Especificação
+  order: 2
+tableOfContents:
+  maxHeadingLevel: 6
+---
+
+Na `specification`, você define sua notação.
+
+## Tipo de elemento
+
+Define os tipos de elementos usados no modelo:
+
+```likec4 copy
+specification {
+  // Define whatever you want
+  element user
+  element cloud
+  element system
+  element application
+  element component
+  element controller
+  element microservice
+  element queue
+  element restapi
+  element graphqlMutation
+  element repository
+  element database
+  element pgTable
+}
+```
+
+Mais adiante, você verá que tipos de elementos podem ter propriedades e definir estilos:
+
+```likec4
+specification {
+  element queue {
+    title 'Kafka'
+    description 'Kafka queue'
+    technology 'kafka topic'
+    notation 'Kafka Topic'
+    style {
+      shape queue
+    }
+  }
+}
+```
+
+## Relacionamento
+
+Tipos de relacionamento podem definir tags, propriedades (`title`, `description`, `technology`, `notation`, links) e estilos visuais:
+
+```likec4
+specification {
+  relationship async {
+    #tcp
+    title 'Asynchronous'
+    description 'Communication over a message broker'
+    technology 'Kafka'
+    notation 'Async'
+    link https://example.com/async
+    multiple true
+    line dotted
+    color amber
+  }
+  relationship subscribes
+  relationship is-downstream-of
+
+  tag tcp
+}
+```
+
+Essas propriedades são herdadas por todo relacionamento desse tipo, a menos que o relacionamento as sobrescreva (tags são combinadas):
+
+```likec4
+model {
+  // inherits the title and style defined for the 'async' kind
+  ui .async backend
+
+  // overrides the title, keeps the inherited style
+  ui .async db 'reads from'
+}
+```
+
+Mais em [relacionamentos](/pt-br/dsl/relationships/#tipos-de-relacionamento).
+
+## Tag
+
+Tags podem ser usadas para marcar, agrupar ou filtrar elementos/relacionamentos/visões, ou para adicionar semântica extra, como `#deprecated`, `#epic-123` ou `#team2`.
+
+```likec4
+specification {
+  tag deprecated
+  tag epic-123
+  tag team2
+}
+```
+
+Você pode atribuir cores:
+
+```likec4
+specification {
+  tag deprecated {
+    color gray
+  }
+
+  tag team2 {
+    color #AABBCC // or using rgb/rgba (see below)
+  }
+}
+```
+
+Você pode adicionar tags aos tipos de elementos:
+
+```likec4
+specification {
+  // Now every kafka-topic will be marked with the infra and data-lake tags
+  element kafka-topic {
+    #infra #data-lake
+  }
+  tag infra
+  tag data-lake
+}
+```
+
+## Cor
+
+Cores personalizadas podem ser definidas para estender os temas integrados. Depois de definidas na especificação, elas podem ser usadas junto com as cores do tema.
+
+```likec4
+specification {
+  color custom-color1 #F00
+  color custom-color2 #AABBCC
+  color custom-color3 rgb(255, 0, 0)
+  color custom-color4 rgb(100 150 200)
+  color custom-color5 rgba(44, 8, 128, 0.9)
+  color custom-color6 rgba(255, 200, 100, 50%)
+
+  element person {
+    style {
+      color custom-color1
+    }
+  }
+}
+```
+
+:::note
+Somente cores base com códigos hexadecimais de 3, 6 ou 8 caracteres e formatos `rgb()`/`rgba()` são compatíveis. O motivo é que, para desenhar um nó, precisamos não apenas de uma cor de preenchimento, mas também de uma cor de borda e uma cor de texto. O mesmo se aplica à cor das arestas, em que são necessárias uma cor de linha, uma cor de fundo do rótulo e uma cor de texto. Portanto, o LikeC4 gera uma paleta usada para criar um esquema de cores a partir da cor base fornecida.
+:::

--- a/apps/docs/src/content/docs/pt-br/guides/deploy-github-pages.mdx
+++ b/apps/docs/src/content/docs/pt-br/guides/deploy-github-pages.mdx
@@ -1,0 +1,142 @@
+---
+title: Deploy no GitHub Pages
+description: Como publicar um site estático com seus diagramas de arquitetura no GitHub Pages
+---
+
+:::note
+Você pode consultar o repositório <a href="https://github.com/likec4/template" target='_blank'>likec4/template</a>.  
+Ele gera e publica um site estático no GitHub Pages.
+
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/~/github.com/likec4/template)
+:::
+
+## Usar a CLI do LikeC4
+
+Prefira usar a [CLI do LikeC4](/tooling/cli/) diretamente nos seus scripts, pois ela oferece mais controle.  
+Exemplo de workflow (ele usa `bun` para acelerar a preparação, mas você pode usar o runtime que preferir):
+
+```yaml
+# Sample workflow for building and deploying a website to GitHub Pages
+name: Deploy Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_call:    
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+  
+# Allow only one concurrent deployment, skipping runs queued between the run in progress and the latest queued.
+# However, do NOT cancel in-progress runs, as we want to allow these production deployments to be completed.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build-pages:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5    
+      - uses: oven-sh/setup-bun@v2        
+
+      - uses: actions/configure-pages@v4
+        id: pages        
+
+      - name: build
+        run: |
+          bunx likec4@latest build \
+            --base "${{ steps.pages.outputs.base_path || '/' }}" \
+            --output dist      
+          
+      - name: upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist
+
+  # Deployment job
+  deploy-pages:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build-pages
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+
+```
+
+## Workflow do GitHub Actions
+
+Use a [LikeC4 GitHub Action](/tooling/github/) para gerar e publicar um site estático no GitHub Pages.
+
+```yaml
+# Sample workflow for building and deploying a website to GitHub Pages
+name: Deploy Pages
+
+on:
+  # Runs on pushes targeting the default branch and c4 files
+  push:
+    branches: ["main"]
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+  
+# Allow only one concurrent deployment, skipping runs queued between the run in progress and the latest queued.
+# However, do NOT cancel in-progress runs, as we want to allow these production deployments to be completed.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build-pages:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v4
+        
+      - name: Build
+        uses: likec4/actions@v1
+        with:
+          action: build
+          output: dist
+          # required if you don't set a custom domain for the repository
+          # https://docs.github.com/en/pages/getting-started-with-github-pages/about-github-pages#types-of-github-pages-sites
+          base: ${{ steps.pages.outputs.base_path }}
+          likec4-version: latest
+          
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist
+
+  # Deployment job
+  deploy-pages:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build-pages
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+```

--- a/apps/docs/src/content/docs/pt-br/guides/deploy-github-pages.mdx
+++ b/apps/docs/src/content/docs/pt-br/guides/deploy-github-pages.mdx
@@ -4,7 +4,7 @@ description: Como publicar um site estático com seus diagramas de arquitetura n
 ---
 
 :::note
-Você pode consultar o repositório <a href="https://github.com/likec4/template" target='_blank'>likec4/template</a>.  
+Você pode consultar o repositório <a href="https://github.com/likec4/template" target='_blank'>likec4/template</a>.
 Ele gera e publica um site estático no GitHub Pages.
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/~/github.com/likec4/template)
@@ -12,7 +12,7 @@ Ele gera e publica um site estático no GitHub Pages.
 
 ## Usar a CLI do LikeC4
 
-Prefira usar a [CLI do LikeC4](/tooling/cli/) diretamente nos seus scripts, pois ela oferece mais controle.  
+Prefira usar a [CLI do LikeC4](/tooling/cli/) diretamente nos seus scripts, pois ela oferece mais controle.
 Exemplo de workflow (ele usa `bun` para acelerar a preparação, mas você pode usar o runtime que preferir):
 
 ```yaml
@@ -25,7 +25,7 @@ on:
     branches: ["main"]
 
   # Allows you to run this workflow manually from the Actions tab
-  workflow_call:    
+  workflow_call:
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
@@ -33,7 +33,7 @@ permissions:
   contents: read
   pages: write
   id-token: write
-  
+
 # Allow only one concurrent deployment, skipping runs queued between the run in progress and the latest queued.
 # However, do NOT cancel in-progress runs, as we want to allow these production deployments to be completed.
 concurrency:
@@ -45,18 +45,18 @@ jobs:
   build-pages:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5    
-      - uses: oven-sh/setup-bun@v2        
+      - uses: actions/checkout@v5
+      - uses: oven-sh/setup-bun@v2
 
       - uses: actions/configure-pages@v4
-        id: pages        
+        id: pages
 
       - name: build
         run: |
           bunx likec4@latest build \
             --base "${{ steps.pages.outputs.base_path || '/' }}" \
-            --output dist      
-          
+            --output dist
+
       - name: upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
@@ -94,7 +94,7 @@ permissions:
   contents: read
   pages: write
   id-token: write
-  
+
 # Allow only one concurrent deployment, skipping runs queued between the run in progress and the latest queued.
 # However, do NOT cancel in-progress runs, as we want to allow these production deployments to be completed.
 concurrency:
@@ -112,7 +112,7 @@ jobs:
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v4
-        
+
       - name: Build
         uses: likec4/actions@v1
         with:
@@ -122,7 +122,7 @@ jobs:
           # https://docs.github.com/en/pages/getting-started-with-github-pages/about-github-pages#types-of-github-pages-sites
           base: ${{ steps.pages.outputs.base_path }}
           likec4-version: latest
-          
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/apps/docs/src/content/docs/pt-br/guides/deploy-github-pages.mdx
+++ b/apps/docs/src/content/docs/pt-br/guides/deploy-github-pages.mdx
@@ -28,11 +28,9 @@ on:
   workflow_call:
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+# Sets default permissions of the GITHUB_TOKEN
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 # Allow only one concurrent deployment, skipping runs queued between the run in progress and the latest queued.
 # However, do NOT cancel in-progress runs, as we want to allow these production deployments to be completed.
@@ -64,6 +62,9 @@ jobs:
 
   # Deployment job
   deploy-pages:
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -89,11 +90,9 @@ on:
   push:
     branches: ["main"]
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+# Sets default permissions of the GITHUB_TOKEN
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 # Allow only one concurrent deployment, skipping runs queued between the run in progress and the latest queued.
 # However, do NOT cancel in-progress runs, as we want to allow these production deployments to be completed.
@@ -130,6 +129,9 @@ jobs:
 
   # Deployment job
   deploy-pages:
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/apps/docs/src/content/docs/pt-br/guides/embed-to-website.mdx
+++ b/apps/docs/src/content/docs/pt-br/guides/embed-to-website.mdx
@@ -6,5 +6,5 @@ draft: true
 import { Card } from '@astrojs/starlight/components';
 
 <Card title="Em breve" icon="warning">
-  Esta página está em construção.  
+  Esta página está em construção.
 </Card>

--- a/apps/docs/src/content/docs/pt-br/guides/embed-to-website.mdx
+++ b/apps/docs/src/content/docs/pt-br/guides/embed-to-website.mdx
@@ -1,0 +1,10 @@
+---
+title: Incorporar em um site
+draft: true
+---
+
+import { Card } from '@astrojs/starlight/components';
+
+<Card title="Em breve" icon="warning">
+  Esta página está em construção.  
+</Card>

--- a/apps/docs/src/content/docs/pt-br/guides/preview-changes-in-pr.mdx
+++ b/apps/docs/src/content/docs/pt-br/guides/preview-changes-in-pr.mdx
@@ -1,0 +1,6 @@
+---
+title: Pré-visualizar alterações no PR
+draft: true
+---
+
+import { Card } from '@astrojs/starlight/components';

--- a/apps/docs/src/content/docs/pt-br/guides/static-website.mdx
+++ b/apps/docs/src/content/docs/pt-br/guides/static-website.mdx
@@ -12,7 +12,7 @@ import { PackageManagers } from 'starlight-package-managers';
 ## Pré-requisitos
 
 Você precisa ter o [Node.js](https://nodejs.org) instalado.
-A versão mínima suportada é a 20.x, mas recomendamos usar a versão estável mais recente.
+A versão mínima suportada é a 22.22.3, mas recomendamos usar a versão estável mais recente.
 
 Você também pode usar o [LikeC4 Docker](/tooling/docker/).
 

--- a/apps/docs/src/content/docs/pt-br/guides/static-website.mdx
+++ b/apps/docs/src/content/docs/pt-br/guides/static-website.mdx
@@ -1,0 +1,48 @@
+---
+title: Publicar um site estático
+description: Como gerar e publicar um site estático com o LikeC4
+sidebar:
+  order: 1
+---
+
+import { LinkCard } from '@astrojs/starlight/components';
+import { Aside } from '@astrojs/starlight/components';
+import { PackageManagers } from 'starlight-package-managers';
+
+## Pré-requisitos
+
+Você precisa ter o [Node.js](https://nodejs.org) instalado.  
+A versão mínima suportada é a 20.x, mas recomendamos usar a versão estável mais recente.  
+
+Você também pode usar o [LikeC4 Docker](/tooling/docker/).
+
+## Build
+
+Execute o comando `build`, que prepara uma pasta com arquivos estáticos prontos para publicação em qualquer hospedagem.
+
+```sh
+npx likec4 build -o ./dist
+```
+
+Opções disponíveis:
+
+| Opção                   | Descrição                                                                                         |
+| ----------------------- | ------------------------------------------------------------------------------------------------- |
+| `-o, --output`          | Diretório de saída                                                                                |
+| `--base`                | URL base a partir da qual o app é servido, por exemplo "/", "/pages/" ou "./" para um app realocável |
+| `--use-hash-history`    | Navegação baseada em hash, por exemplo "/#/view" em vez de "/view"                                |
+| `--use-dot`             | Usa binários locais do Graphviz ("dot") em vez do WASM incluído                                   |
+| `--title`               | Título base das páginas do app (o padrão é "LikeC4")                                              |
+| `--output-single-file`  | Gera um único arquivo HTML autocontido                                                            |
+
+Para ver todas as opções disponíveis, execute:
+
+```sh
+npx likec4 build -h
+```
+
+## Publicar
+
+A CLI do LikeC4 usa o Vite para gerar o site.  
+
+Todos os exemplos da [documentação do Vite](https://vitejs.dev/guide/static-deploy.html) se aplicam ao LikeC4; basta substituir `vite build` por `likec4 build`.

--- a/apps/docs/src/content/docs/pt-br/guides/static-website.mdx
+++ b/apps/docs/src/content/docs/pt-br/guides/static-website.mdx
@@ -11,8 +11,8 @@ import { PackageManagers } from 'starlight-package-managers';
 
 ## Pré-requisitos
 
-Você precisa ter o [Node.js](https://nodejs.org) instalado.  
-A versão mínima suportada é a 20.x, mas recomendamos usar a versão estável mais recente.  
+Você precisa ter o [Node.js](https://nodejs.org) instalado.
+A versão mínima suportada é a 20.x, mas recomendamos usar a versão estável mais recente.
 
 Você também pode usar o [LikeC4 Docker](/tooling/docker/).
 
@@ -43,6 +43,6 @@ npx likec4 build -h
 
 ## Publicar
 
-A CLI do LikeC4 usa o Vite para gerar o site.  
+A CLI do LikeC4 usa o Vite para gerar o site.
 
 Todos os exemplos da [documentação do Vite](https://vitejs.dev/guide/static-deploy.html) se aplicam ao LikeC4; basta substituir `vite build` por `likec4 build`.

--- a/apps/docs/src/content/docs/pt-br/guides/validate-your-model.mdx
+++ b/apps/docs/src/content/docs/pt-br/guides/validate-your-model.mdx
@@ -35,12 +35,12 @@ Suponha que queremos exigir que todo elemento do tipo `app` tenha uma `technolog
 
 ```ts
 // test/metadata.spec.ts
-import { LikeC4 } from './LikeC4'
+import { LikeC4 } from 'likec4'
 import { test } from 'vitest'
 
 // Initialize and compute LikeC4 Model
 const likec4 = await LikeC4.fromWorkspace('..')
-const model = likec4.computedModel()
+const model = await likec4.computedModel()
 
 // With `test.for` we generate tests for each element of kind `app`
 // This improves the output, showing each test failure separately
@@ -66,10 +66,9 @@ test('elements of kind `app` have technology', ({ expect }) => {
 ```
 
 :::note
-Chamadas para `LikeC4.fromWorkspace('..')` são memoizadas (por caminho absoluto).
-Você pode chamá-la várias vezes sem impacto de performance, por exemplo em `beforeEach`.
+Inicializar o workspace pode levar tempo. Se vários testes precisarem do mesmo modelo, prefira inicializá-lo uma vez e reutilizar a instância.
 
-Você também pode usar a função [`provide`](https://vitest.dev/advanced/api/vitest.html#provide) do Vitest para reutilizar o mesmo caminho do workspace.
+Você também pode usar a função [`provide`](https://vitest.dev/advanced/api/vitest.html#provide) do Vitest para compartilhar dados entre o setup e os testes.
 :::
 
 ## Pré-gerar o modelo

--- a/apps/docs/src/content/docs/pt-br/guides/validate-your-model.mdx
+++ b/apps/docs/src/content/docs/pt-br/guides/validate-your-model.mdx
@@ -1,7 +1,7 @@
 ---
 title: Aplicar regras e validar seu modelo
 description: Como aplicar regras personalizadas ao seu modelo LikeC4 ou validar sua consistência
-sidebar: 
+sidebar:
   label: Validar seu modelo
   order: 1
 ---
@@ -9,7 +9,7 @@ sidebar:
 import { Card, Aside } from '@astrojs/starlight/components';
 import { PackageManagers } from 'starlight-package-managers';
 
-Às vezes você pode querer aplicar regras personalizadas ao seu modelo ou validar sua consistência.  
+Às vezes você pode querer aplicar regras personalizadas ao seu modelo ou validar sua consistência.
 Aqui vai uma receita simples de como fazer isso.
 
 :::note
@@ -20,7 +20,7 @@ Consulte o repositório <a href="https://github.com/likec4/template" target='_bl
 
 ## Testar seu modelo
 
-Neste exemplo, vamos usar o [Vitest](https://vitest.dev) junto com a [API do LikeC4](/tooling/model-api/).  
+Neste exemplo, vamos usar o [Vitest](https://vitest.dev) junto com a [API do LikeC4](/tooling/model-api/).
 A API do LikeC4 oferece métodos para consultar e percorrer o modelo, perfeita para escrever testes que reforçam suas regras.
 
 <PackageManagers
@@ -66,7 +66,7 @@ test('elements of kind `app` have technology', ({ expect }) => {
 ```
 
 :::note
-Chamadas para `LikeC4.fromWorkspace('..')` são memoizadas (por caminho absoluto).  
+Chamadas para `LikeC4.fromWorkspace('..')` são memoizadas (por caminho absoluto).
 Você pode chamá-la várias vezes sem impacto de performance, por exemplo em `beforeEach`.
 
 Você também pode usar a função [`provide`](https://vitest.dev/advanced/api/vitest.html#provide) do Vitest para reutilizar o mesmo caminho do workspace.
@@ -98,7 +98,7 @@ test('Relationships should have metadata', ({ expect }) => {
   expect.hasAssertions()
   for (const r of likec4model.relationships()) {
     expect.soft(
-      r.getMetadata('key'), // here we get type checking 
+      r.getMetadata('key'), // here we get type checking
       `Relationship ${r.source.id} -> ${r.target.id} has no metadata`
     ).toBeDefined()
   }
@@ -134,7 +134,7 @@ likec4test('Relationships should have metadata', ({ expect, likec4 }) => {
   expect.hasAssertions()
   for (const r of likec4.relationships()) {
     expect.soft(
-      r.getMetadata('key'), // here we get type checking 
+      r.getMetadata('key'), // here we get type checking
       `Relationship ${r.source.id} -> ${r.target.id} has no metadata`
     ).toBeDefined()
   }
@@ -143,5 +143,5 @@ likec4test('Relationships should have metadata', ({ expect, likec4 }) => {
 
 ## Conclusão
 
-Essa abordagem facilita aplicar restrições personalizadas e validar a consistência do seu modelo.  
+Essa abordagem facilita aplicar restrições personalizadas e validar a consistência do seu modelo.
 Executar essas verificações no pipeline de CI é rápido e fornece feedback imediato quando o modelo quebra suas regras.

--- a/apps/docs/src/content/docs/pt-br/guides/validate-your-model.mdx
+++ b/apps/docs/src/content/docs/pt-br/guides/validate-your-model.mdx
@@ -1,0 +1,147 @@
+---
+title: Aplicar regras e validar seu modelo
+description: Como aplicar regras personalizadas ao seu modelo LikeC4 ou validar sua consistência
+sidebar: 
+  label: Validar seu modelo
+  order: 1
+---
+
+import { Card, Aside } from '@astrojs/starlight/components';
+import { PackageManagers } from 'starlight-package-managers';
+
+Às vezes você pode querer aplicar regras personalizadas ao seu modelo ou validar sua consistência.  
+Aqui vai uma receita simples de como fazer isso.
+
+:::note
+Consulte o repositório <a href="https://github.com/likec4/template" target='_blank'>likec4/template</a> para ver um exemplo completo.
+
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/~/github.com/likec4/template)
+:::
+
+## Testar seu modelo
+
+Neste exemplo, vamos usar o [Vitest](https://vitest.dev) junto com a [API do LikeC4](/tooling/model-api/).  
+A API do LikeC4 oferece métodos para consultar e percorrer o modelo, perfeita para escrever testes que reforçam suas regras.
+
+<PackageManagers
+  pkg="likec4 vitest"
+  pkgManagers={['npm', 'pnpm', 'yarn', 'bun']}
+  frame="none"
+/>
+
+### Exemplo
+
+Suponha que queremos exigir que todo elemento do tipo `app` tenha uma `technology` especificada.
+
+```ts
+// test/metadata.spec.ts
+import { LikeC4 } from './LikeC4'
+import { test } from 'vitest'
+
+// Initialize and compute LikeC4 Model
+const likec4 = await LikeC4.fromWorkspace('..')
+const model = likec4.computedModel()
+
+// With `test.for` we generate tests for each element of kind `app`
+// This improves the output, showing each test failure separately
+test.for(
+  model
+    // Select elements of kind `app`
+    .elementsWhere({ kind: 'app' })
+    // Map to array of [id, element] tuples, we need it for test names
+    .map(e => [e.id, e] as const)
+    .toArray(),
+)('app "%s" has technology', ([, e], { expect }) => {
+  expect(e.technology).toBeTruthy()
+})
+
+// Or we can use `expect.soft` to accumulate all errors
+test('elements of kind `app` have technology', ({ expect }) => {
+  expect.hasAssertions()
+  for (const app of model.elements()) {
+    if (app.kind !== 'app') continue // Skip non-app elements
+    expect.soft(app.technology, `app ${app.id} has no technology`).toBeTruthy()
+  }
+})
+```
+
+:::note
+Chamadas para `LikeC4.fromWorkspace('..')` são memoizadas (por caminho absoluto).  
+Você pode chamá-la várias vezes sem impacto de performance, por exemplo em `beforeEach`.
+
+Você também pode usar a função [`provide`](https://vitest.dev/advanced/api/vitest.html#provide) do Vitest para reutilizar o mesmo caminho do workspace.
+:::
+
+## Pré-gerar o modelo
+
+Podemos otimizar nossos testes pré-gerando o modelo no [global setup](https://vitest.dev/config/#globalsetup):
+
+```ts
+// global-setup.ts
+import { execSync } from 'node:child_process'
+
+export default function() {
+  execSync('npx likec4 gen model -o ./test/likec4-model.ts', {
+    stdio: 'inherit'
+  })
+}
+```
+
+O modelo gerado é totalmente tipado, oferecendo verificação de tipos e autocompletar nos testes:
+
+```ts
+// test/metadata.spec.ts
+import { likec4model } from './likec4-model'
+import { test } from 'vitest'
+
+test('Relationships should have metadata', ({ expect }) => {
+  expect.hasAssertions()
+  for (const r of likec4model.relationships()) {
+    expect.soft(
+      r.getMetadata('key'), // here we get type checking 
+      `Relationship ${r.source.id} -> ${r.target.id} has no metadata`
+    ).toBeDefined()
+  }
+})
+```
+
+Podemos ir além e usar o [contexto de teste](https://vitest.dev/api/#test-context) para melhorar nossa experiência:
+
+```ts
+// test/likec4test.ts
+import { likec4model } from './likec4-model'
+import { test } from 'vitest'
+
+interface LikeC4TestFixtures {
+  likec4: typeof likec4model
+}
+
+// This wil be our test function with the model in the context
+export const likec4test = test.extend<LikeC4TestFixtures>({
+  likec4: async ({}, use) => {
+    await use(likec4model)
+  },
+})
+```
+
+Agora refatore os testes para usá-la:
+
+```ts
+// test/metadata.spec.ts
+import { likec4test } from './likec4test'
+
+likec4test('Relationships should have metadata', ({ expect, likec4 }) => {
+  expect.hasAssertions()
+  for (const r of likec4.relationships()) {
+    expect.soft(
+      r.getMetadata('key'), // here we get type checking 
+      `Relationship ${r.source.id} -> ${r.target.id} has no metadata`
+    ).toBeDefined()
+  }
+})
+```
+
+## Conclusão
+
+Essa abordagem facilita aplicar restrições personalizadas e validar a consistência do seu modelo.  
+Executar essas verificações no pipeline de CI é rápido e fornece feedback imediato quando o modelo quebra suas regras.

--- a/apps/docs/src/content/docs/pt-br/tutorial.mdx
+++ b/apps/docs/src/content/docs/pt-br/tutorial.mdx
@@ -46,7 +46,7 @@ Depois, siga estas etapas:
     + }
     ```
 
-    Estes são os primeiros elementos do nosso modelo de arquitetura.  
+    Estes são os primeiros elementos do nosso modelo de arquitetura.
     Agora vamos adicionar mais detalhes.
 
 3. ##### Adicionar uma hierarquia
@@ -69,7 +69,7 @@ Depois, siga estas etapas:
     +    component backend
       }
     }
-    ```    
+    ```
 
 4. ##### Adicionar relacionamentos
 
@@ -134,7 +134,7 @@ Depois, siga estas etapas:
     +    include *
     +  }
     }
-    ```    
+    ```
 
     O resultado é este:
 
@@ -144,8 +144,8 @@ Depois, siga estas etapas:
     O predicado `include *` inclui apenas os elementos de "nível superior" e infere os relacionamentos entre eles a partir dos elementos aninhados:
     > `customer` possui um _relacionamento conhecido_ com o elemento aninhado `saas.ui`
 
-    Isso implica que:  
-    > `customer` possui _algum relacionamento_ com `saas`.  
+    Isso implica que:
+    > `customer` possui _algum relacionamento_ com `saas`.
 
     </Aside>
 
@@ -210,7 +210,7 @@ Depois, siga estas etapas:
         component ui 'Frontend' {
     +      description 'Nextjs application, hosted on Vercel'
     +      style {
-    +        icon tech:nextjs  
+    +        icon tech:nextjs
     +        shape browser
     +      }
         }
@@ -266,7 +266,7 @@ Depois, siga estas etapas:
 
     model {
       customer = actor 'Customer' {
-    -    description 'The regular customer of the system'        
+    -    description 'The regular customer of the system'
     +    description 'Our dear customer'
       }
 

--- a/apps/docs/src/content/docs/pt-br/tutorial.mdx
+++ b/apps/docs/src/content/docs/pt-br/tutorial.mdx
@@ -329,7 +329,7 @@ Depois, siga estas etapas:
 
     Explore [este tutorial no Playground](https://playground.likec4.dev/w/tutorial/) e tente fazer o seguinte:
 
-    - altere a forma ([`shape`](/pt-br/dsl/styling/#single-element)) do elemento `customer`
+    - altere a forma ([`shape`](/dsl/styling/#single-element)) do elemento `customer`
     - adicione um banco de dados (usando a forma `storage`) e tabelas como `customers` e `orders` — quais relacionamentos deveriam ser adicionados?
     - adicione um sistema externo, como o Stripe, e mostre como o backend poderia interagir com ele
 


### PR DESCRIPTION
## Summary

This PR is the next incremental Brazilian Portuguese (`pt-BR`) localization contribution after #3179.

It adds:

- the complete Guides section in Brazilian Portuguese;
- the fundamental DSL documentation in Brazilian Portuguese:
  - Introduction
  - Model
  - Relationships
  - Specification
  - Notations
  - References

## Translation approach

- LikeC4 DSL syntax and code examples were preserved.
- Terminology follows the previously merged pt-BR README and tutorial.
- Localized files mirror the English route structure under `pt-br`.
- The work intentionally remains incremental so future localization PRs can stay focused.

## Scope

This PR does **not** yet translate:

- remaining DSL sections such as Views, Config, Deployment, and Styling;
- Tooling;
- Showcases.

These can continue in subsequent incremental PRs under #3178.

## Validation

Commands executed:

- `git fetch --all --prune`: passed.
- `git rebase upstream/main`: passed; branch was already up to date with the latest fetched `upstream/main`.
- `npm exec --package=pnpm@11.25.0 -- pnpm generate`: passed.
- `git diff --check upstream/main...HEAD`: passed.
- `corepack pnpm exec dprint check --allow-no-files <changed pt-BR mdx files>`: passed; dprint has no configured formatter target for these MDX files.
- `npm exec --package=pnpm@11.25.0 -- pnpm --filter @likec4/docs-astro typecheck`: passed; Astro diagnostics reported 0 errors, 0 warnings, 0 hints.
- `npm exec --package=pnpm@11.25.0 -- pnpm --filter @likec4/docs-astro build`: passed; 84 pages built and all internal links validated.
- `npm exec --package=pnpm@11.25.0 -- pnpm typecheck`: passed.
- `npm exec --package=pnpm@11.25.0 -- pnpm test`: failed with one unrelated existing Windows path-casing assertion in `packages/language-server/src/filesystem/LikeC4FileSystem.spec.ts`; this branch does not change `packages/language-server`.
- `npm exec --package=pnpm@11.25.0 -- pnpm lint:errors-only`: failed with unrelated existing lint/type-resolution issues in `packages/diagram`, `packages/layouts`, and `e2e/tsconfig.json`; this branch does not change those paths.

Environment note: the local Git hooks invoke plain `pnpm`, but this shell only exposes pnpm through Corepack/npm exec. The commit and push were performed with hook verification disabled after the equivalent required checks above were run through `pnpm@11.25.0`.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask, and propose improvements. We're here to help. -->

- [x] I've thoroughly read the latest [contribution guidelines](https://github.com/likec4/likec4/blob/main/CONTRIBUTING.md).
- [x] I've rebased my branch onto `main` **before** creating this PR.
- [x] I've added tests to cover my changes (if applicable). N/A: documentation-only localization; no runtime behavior changed.
- [ ] I've verified `pnpm typecheck` and `pnpm test`. `pnpm typecheck` passed; `pnpm test` was run and failed due the unrelated language-server Windows path-casing assertion listed above.
- [ ] I've added [changesets](https://changesets-docs.vercel.app/) (you can use `/changeset-generator` SKILL). N/A: changeset was considered and is not applicable because this PR only changes documentation/localization, and `AGENTS.md` says to skip changesets for docs-only changes.
- [x] My change requires documentation updates.
- [x] I've updated the documentation accordingly (or will do in follow-up PR).

## Related issue

Related to #3178