### PR TITLE
fix: respect dynamic view variant on initial render

### DIFF
--- a/.changeset/fix-dynamic-view-variant.md
+++ b/.changeset/fix-dynamic-view-variant.md
@@ -1,0 +1,5 @@
+---
+'likec4': patch
+---
+
+Respect a dynamic view's configured variant when the URL does not explicitly select one

--- a/e2e/src/likec4/model.c4
+++ b/e2e/src/likec4/model.c4
@@ -226,4 +226,10 @@ views {
     autoLayout TopBottom
   }
 
+  dynamic view dynamic-view-variant {
+    variant sequence
+
+    customer -> cloud.ui.mobile 'opens'
+    cloud.ui.mobile -> cloud.next.backend 'requests'
+  }
 }

--- a/e2e/tests/search-params.spec.ts
+++ b/e2e/tests/search-params.spec.ts
@@ -27,6 +27,7 @@ const EXPORT_CONFIG_PROJECT = 'export-config'
 const EXPORT_DISABLED_PROJECT = 'export-disabled'
 const STATIC_VIEW = 'index'
 const DYNAMIC_VIEW = 'dynamic-view-1'
+const DYNAMIC_VIEW_VARIANT = 'dynamic-view-variant'
 
 function projectExportUrl(projectId: string, viewId: string, extra?: Record<string, string>): string {
   const params = new URLSearchParams({ padding: '22', ...extra })
@@ -116,6 +117,18 @@ test.describe('?dynamic= search parameter', () => {
       await expect(page.locator(SEQ_ACTOR_SELECTOR)).toHaveCount(0)
     })
   }
+
+  test('view variant=sequence renders sequence when ?dynamic= is absent', async ({ page }) => {
+    await gotoAndWaitForCanvas(page, viewUrl(DYNAMIC_VIEW_VARIANT))
+
+    await expect(page.locator(SEQ_ACTOR_SELECTOR).first()).toBeVisible({ timeout: TIMEOUT_CANVAS })
+  })
+
+  test('?dynamic=diagram overrides view variant=sequence', async ({ page }) => {
+    await gotoAndWaitForCanvas(page, viewUrl(DYNAMIC_VIEW_VARIANT, { dynamic: 'diagram' }))
+
+    await expect(page.locator(SEQ_ACTOR_SELECTOR)).toHaveCount(0)
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/likec4-spa/src/routes/__root.tsx
+++ b/packages/likec4-spa/src/routes/__root.tsx
@@ -33,7 +33,7 @@ export const Route = createRootRouteWithContext<Context>()({
       stripSearchParams({
         padding: 20,
         theme: undefined,
-        dynamic: 'diagram',
+        dynamic: undefined,
         relationships: undefined,
         focusOnElement: undefined,
       }),

--- a/packages/likec4-spa/src/searchParams.spec.ts
+++ b/packages/likec4-spa/src/searchParams.spec.ts
@@ -15,7 +15,7 @@ describe('searchParamsSchema', () => {
 
   it('should parse default search params', () => {
     const parsed = searchParamsSchema.parse({})
-    expect(parsed.dynamic).toBe('diagram')
+    expect(parsed.dynamic).toBeUndefined()
     expect(parsed.padding).toBe(20)
     expect(parsed.relationships).toBeUndefined()
     expect(parsed.focusOnElement).toBeUndefined()

--- a/packages/likec4-spa/src/searchParams.ts
+++ b/packages/likec4-spa/src/searchParams.ts
@@ -6,8 +6,8 @@ export const searchParamsSchema = z.object({
     .optional()
     .catch(undefined),
   dynamic: z.enum(['diagram', 'sequence'])
-    .default('diagram')
-    .catch('diagram'),
+    .optional()
+    .catch(undefined),
   padding: z.number()
     .min(0)
     .default(20)


### PR DESCRIPTION
## Summary

Fix the initial rendering of dynamic views so that their configured `variant` is respected when the URL does not explicitly specify a `dynamic` parameter.

Previously, the search parameter parser always defaulted `dynamic` to `diagram`. This caused the SPA to override `variant sequence` defined in the LikeC4 source.

The URL parameter still takes precedence when explicitly provided, for example `?dynamic=diagram`.

Fixes #3202

## Changes

- Leave the parsed `dynamic` search parameter undefined when it is absent or invalid
- Allow the diagram state to select the variant configured on the view during initial rendering
- Preserve explicit URL overrides
- Add an E2E fixture and regression coverage for:
  - `variant sequence` without a `dynamic` URL parameter
  - `?dynamic=diagram` overriding `variant sequence`

## Verification

- [x] SPA typecheck
- [x] SPA unit tests
- [x] Search parameter E2E tests
- [x] Manual single-file build verification
- [x] Changeset added

## Notes

This change only affects initial rendering. The existing navigation behavior remains unchanged: the display variant selected on the previous page takes precedence over the `variant` configured on the destination view.
