### PR TITLE
fix(mcp): advertise JSON Schema 2020-12

### DIFF
--- a/.changeset/advertise-mcp-json-schema-2020-12.md
+++ b/.changeset/advertise-mcp-json-schema-2020-12.md
@@ -1,0 +1,5 @@
+---
+'@likec4/mcp': patch
+---
+
+Advertise tool input and output schemas as JSON Schema 2020-12

--- a/packages/mcp/src/__tests__/createMCPServer.int.spec.ts
+++ b/packages/mcp/src/__tests__/createMCPServer.int.spec.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { describe, expect, it } from 'vitest'
 import { createMCPTestPair } from './test-utils'
 
@@ -36,6 +43,8 @@ const EXPECTED_TOOLS = [
   'preview-view',
 ] as const
 
+const JSON_SCHEMA_2020_12 = 'https://json-schema.org/draft/2020-12/schema'
+
 describe('createMCPServer — registration & discovery', () => {
   it('advertises tools, prompts, resources, and logging capabilities', async () => {
     await using pair = await createMCPTestPair(DSL)
@@ -66,6 +75,20 @@ describe('createMCPServer — registration & discovery', () => {
       expect(tool.description!.length).toBeGreaterThan(0)
       expect(tool.inputSchema, `tool ${tool.name} missing inputSchema`).toBeDefined()
       expect(tool.inputSchema.type).toBe('object')
+    }
+  })
+
+  it('advertises input and output schemas as JSON Schema 2020-12', async () => {
+    await using pair = await createMCPTestPair(DSL)
+    const { tools } = await pair.client.listTools()
+
+    for (const tool of tools) {
+      expect(tool.inputSchema['$schema'], `tool ${tool.name} inputSchema uses the wrong dialect`).toBe(
+        JSON_SCHEMA_2020_12,
+      )
+      expect(tool.outputSchema?.['$schema'], `tool ${tool.name} outputSchema uses the wrong dialect`).toBe(
+        JSON_SCHEMA_2020_12,
+      )
     }
   })
 

--- a/packages/mcp/src/tools/_common.ts
+++ b/packages/mcp/src/tools/_common.ts
@@ -20,7 +20,7 @@ import type { LikeC4LanguageServices } from '@likec4/language-server'
 import type { Locate } from '@likec4/language-server/protocol'
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types'
 import { URI } from 'vscode-uri'
-import * as z from 'zod/v3'
+import * as z from 'zod/v4'
 import { logger } from '../utils'
 
 /**
@@ -105,7 +105,7 @@ export const elementSummarySchema = z.object({
   kind: z.string().describe('Element kind'),
   title: z.string(),
   tags: z.array(z.string()),
-  metadata: z.record(z.union([z.string(), z.array(z.string())])),
+  metadata: z.record(z.string(), z.union([z.string(), z.array(z.string())])),
   includedInViews: z.array(z.object({
     id: z.string().describe('View id'),
     title: z.string().describe('View title'),

--- a/packages/mcp/src/tools/apply-semantic-layout.ts
+++ b/packages/mcp/src/tools/apply-semantic-layout.ts
@@ -1,10 +1,18 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import type { ProjectId } from '@likec4/core'
 import { enhanceLayoutWithAI } from '@likec4/layouts/ai'
 import { completable } from '@modelcontextprotocol/sdk/server/completable.js'
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { prop } from 'remeda'
-import * as z from 'zod/v3'
+import * as z from 'zod/v4'
 import { useLanguageServices } from '../ctx'
+import { mcpToolSchema } from '../utils'
 import { toolError } from './_common'
 
 export function applySemanticLayoutTool(
@@ -15,7 +23,7 @@ export function applySemanticLayoutTool(
     'apply-semantic-layout',
     {
       description: 'Apply semantic layout to the likec4 view',
-      inputSchema: {
+      inputSchema: mcpToolSchema({
         projectId: completable(
           z.string()
             .default('default' as ProjectId)
@@ -36,11 +44,11 @@ export function applySemanticLayoutTool(
             return Array.from(model.views()).filter((view) => view.id.startsWith(value)).map(prop('id'))
           },
         ),
-      },
-      outputSchema: {
+      }),
+      outputSchema: mcpToolSchema({
         reasoning: z.string().describe('Reasoning behind the layout changes'),
         snapshotUri: z.string().nullish().describe('Where snapshot was saved (after applying layout)'),
-      },
+      }),
     },
     async (args, ctx) => {
       const projectId = languageServices.projectsManager.ensureProjectId(args.projectId as ProjectId)

--- a/packages/mcp/src/tools/batch-read-elements.ts
+++ b/packages/mcp/src/tools/batch-read-elements.ts
@@ -3,7 +3,7 @@
 // Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import { invariant } from '@likec4/core'
-import * as z from 'zod/v3'
+import * as z from 'zod/v4'
 import { likec4Tool } from '../utils'
 import { elementSummarySchema, projectIdSchema, serializeElement } from './_common'
 

--- a/packages/mcp/src/tools/element-diff.ts
+++ b/packages/mcp/src/tools/element-diff.ts
@@ -3,7 +3,7 @@
 // Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import { invariant } from '@likec4/core'
-import * as z from 'zod/v3'
+import * as z from 'zod/v4'
 import { likec4Tool } from '../utils'
 import { projectIdSchema } from './_common'
 
@@ -31,14 +31,18 @@ const diffSchema = z.object({
     common: z.array(z.string()).describe('Tags present in both elements'),
   }),
   metadata: z.object({
-    onlyInElement1: z.record(z.union([z.string(), z.array(z.string())])).describe('Metadata keys only in element1'),
-    onlyInElement2: z.record(z.union([z.string(), z.array(z.string())])).describe('Metadata keys only in element2'),
+    onlyInElement1: z.record(z.string(), z.union([z.string(), z.array(z.string())])).describe(
+      'Metadata keys only in element1',
+    ),
+    onlyInElement2: z.record(z.string(), z.union([z.string(), z.array(z.string())])).describe(
+      'Metadata keys only in element2',
+    ),
     different: z.array(z.object({
       key: z.string(),
       element1Value: z.union([z.string(), z.array(z.string())]),
       element2Value: z.union([z.string(), z.array(z.string())]),
     })).describe('Metadata keys present in both but with different values'),
-    common: z.record(z.union([z.string(), z.array(z.string())])).describe(
+    common: z.record(z.string(), z.union([z.string(), z.array(z.string())])).describe(
       'Metadata keys with identical values in both',
     ),
   }),

--- a/packages/mcp/src/tools/find-relationship-paths.ts
+++ b/packages/mcp/src/tools/find-relationship-paths.ts
@@ -3,7 +3,7 @@
 // Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import { invariant } from '@likec4/core'
-import * as z from 'zod/v3'
+import * as z from 'zod/v4'
 import { likec4Tool } from '../utils'
 import { projectIdSchema } from './_common'
 

--- a/packages/mcp/src/tools/find-relationships.ts
+++ b/packages/mcp/src/tools/find-relationships.ts
@@ -1,6 +1,13 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { modelConnection } from '@likec4/core/model'
 import { invariant, isSameHierarchy } from '@likec4/core/utils'
-import * as z from 'zod/v3'
+import * as z from 'zod/v4'
 import { likec4Tool } from '../utils'
 import { includedInViews, includedInViewsSchema, locationSchema, mkLocate, projectIdSchema } from './_common'
 

--- a/packages/mcp/src/tools/list-projects.ts
+++ b/packages/mcp/src/tools/list-projects.ts
@@ -1,4 +1,11 @@
-import * as z from 'zod/v3'
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
+import * as z from 'zod/v4'
 import { likec4Tool } from '../utils'
 
 export const listProjects = likec4Tool({

--- a/packages/mcp/src/tools/open-view.ts
+++ b/packages/mcp/src/tools/open-view.ts
@@ -1,4 +1,11 @@
-import * as z from 'zod/v3'
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
+import * as z from 'zod/v4'
 import { likec4Tool } from '../utils'
 import { locationSchema, mkLocate, projectIdSchema } from './_common'
 

--- a/packages/mcp/src/tools/preview-view.ts
+++ b/packages/mcp/src/tools/preview-view.ts
@@ -12,8 +12,9 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types'
 import { randomUUID } from 'node:crypto'
 import { relative, sep } from 'node:path'
-import * as z from 'zod/v3'
+import * as z from 'zod/v4'
 import { useLanguageServices } from '../ctx'
+import { mcpToolSchema } from '../utils'
 import { buildRenderPayload, projectIdSchema, toolError } from './_common'
 import { renderViewResourceUri } from './render-view'
 
@@ -68,17 +69,17 @@ Behavior:
 Note: preview styling may not exactly match the real project (custom theme/style extensions aren't applied to the preview). Only \`view <id> ...\` (element view) declarations are recognized for id-detection — a \`dynamic view <id> {...}\` or \`deployment view <id> {...}\` will fail with a generic "could not find a \`view <id>\`" error instead.
 
 Use "preview-view" to iterate on a new view definition before creating it for real. Use "render-view" to render a view that's already saved.`,
-      inputSchema: {
+      inputSchema: mcpToolSchema({
         dsl: z.string().describe('A single `view <id> ... { ... }` LikeC4 DSL definition'),
         project: projectIdSchema,
-      },
-      outputSchema: {
+      }),
+      outputSchema: mcpToolSchema({
         id: z.string(),
         title: z.string(),
         project: z.string(),
         view: z.record(z.string(), z.unknown()),
         model: z.record(z.string(), z.unknown()),
-      },
+      }),
       annotations: {
         readOnlyHint: true,
         idempotentHint: true,

--- a/packages/mcp/src/tools/query-by-metadata.ts
+++ b/packages/mcp/src/tools/query-by-metadata.ts
@@ -2,7 +2,7 @@
 //
 // Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
-import * as z from 'zod/v3'
+import * as z from 'zod/v4'
 import { likec4Tool } from '../utils'
 import { elementSummarySchema, projectIdSchema, serializeElement } from './_common'
 

--- a/packages/mcp/src/tools/query-by-tag-pattern.ts
+++ b/packages/mcp/src/tools/query-by-tag-pattern.ts
@@ -3,7 +3,7 @@
 // Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import { isDeploymentNodeModel } from '@likec4/core/model'
-import * as z from 'zod/v3'
+import * as z from 'zod/v4'
 import { likec4Tool } from '../utils'
 import { elementSummarySchema, projectIdSchema, serializeElement } from './_common'
 

--- a/packages/mcp/src/tools/query-by-tags.ts
+++ b/packages/mcp/src/tools/query-by-tags.ts
@@ -4,7 +4,7 @@
 
 import { invariant } from '@likec4/core'
 import { isDeploymentNodeModel } from '@likec4/core/model'
-import * as z from 'zod/v3'
+import * as z from 'zod/v4'
 import { likec4Tool } from '../utils'
 import { type ElementSummary, elementSummarySchema, projectIdSchema, serializeElement } from './_common'
 

--- a/packages/mcp/src/tools/query-graph.ts
+++ b/packages/mcp/src/tools/query-graph.ts
@@ -3,7 +3,7 @@
 // Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import { invariant } from '@likec4/core'
-import * as z from 'zod/v3'
+import * as z from 'zod/v4'
 import { likec4Tool } from '../utils'
 import { type ElementSummary, elementSummarySchema, projectIdSchema, serializeElement } from './_common'
 

--- a/packages/mcp/src/tools/query-incomers-graph.ts
+++ b/packages/mcp/src/tools/query-incomers-graph.ts
@@ -3,7 +3,7 @@
 // Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import { invariant } from '@likec4/core'
-import * as z from 'zod/v3'
+import * as z from 'zod/v4'
 import { likec4Tool } from '../utils'
 import {
   type GraphNode,
@@ -102,10 +102,13 @@ plus all their dependencies, recursively up to maxDepth levels.
     totalNodes: z.number().describe('Total number of nodes in the graph'),
     maxDepth: z.number().describe('Maximum depth reached'),
     truncated: z.boolean().describe('True if result was truncated due to maxNodes limit'),
-    nodes: z.record(elementSummarySchema.extend({
-      incomers: z.array(neighborSchema).describe('Incoming relationships with details'),
-      depth: z.number().describe('Distance from target element (0 = target)'),
-    })),
+    nodes: z.record(
+      z.string(),
+      elementSummarySchema.extend({
+        incomers: z.array(neighborSchema).describe('Incoming relationships with details'),
+        depth: z.number().describe('Distance from target element (0 = target)'),
+      }),
+    ),
   },
 })(async (languageServices, args) => {
   const projectId = languageServices.projectsManager.ensureProjectId(args.project)

--- a/packages/mcp/src/tools/query-outgoers-graph.ts
+++ b/packages/mcp/src/tools/query-outgoers-graph.ts
@@ -3,7 +3,7 @@
 // Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import { invariant } from '@likec4/core'
-import * as z from 'zod/v3'
+import * as z from 'zod/v4'
 import { likec4Tool } from '../utils'
 import {
   type GraphNode,
@@ -102,10 +102,13 @@ plus all their consumers, recursively up to maxDepth levels.
     totalNodes: z.number().describe('Total number of nodes in the graph'),
     maxDepth: z.number().describe('Maximum depth reached'),
     truncated: z.boolean().describe('True if result was truncated due to maxNodes limit'),
-    nodes: z.record(elementSummarySchema.extend({
-      outgoers: z.array(neighborSchema).describe('Outgoing relationships with details'),
-      depth: z.number().describe('Distance from target element (0 = target)'),
-    })),
+    nodes: z.record(
+      z.string(),
+      elementSummarySchema.extend({
+        outgoers: z.array(neighborSchema).describe('Outgoing relationships with details'),
+        depth: z.number().describe('Distance from target element (0 = target)'),
+      }),
+    ),
   },
 })(async (languageServices, args) => {
   const projectId = languageServices.projectsManager.ensureProjectId(args.project)

--- a/packages/mcp/src/tools/read-deployment.ts
+++ b/packages/mcp/src/tools/read-deployment.ts
@@ -6,7 +6,7 @@
 // Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
 
 import { invariant } from '@likec4/core'
-import * as z from 'zod/v3'
+import * as z from 'zod/v4'
 import { likec4Tool } from '../utils'
 import { includedInViews, includedInViewsSchema, locationSchema, mkLocate, projectIdSchema } from './_common'
 
@@ -97,7 +97,7 @@ Example response (deployed instance):
     technology: z.string().nullable(),
     tags: z.array(z.string()),
     project: z.string(),
-    metadata: z.record(z.union([z.string(), z.array(z.string())])),
+    metadata: z.record(z.string(), z.union([z.string(), z.array(z.string())])),
     links: z.array(z.object({
       title: z.string().nullable().describe('Optional link title'),
       url: z.string().describe('Link URL'),

--- a/packages/mcp/src/tools/read-element.ts
+++ b/packages/mcp/src/tools/read-element.ts
@@ -6,7 +6,7 @@
 // Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
 
 import { invariant } from '@likec4/core'
-import * as z from 'zod/v3'
+import * as z from 'zod/v4'
 import { likec4Tool } from '../utils'
 import { includedInViews, includedInViewsSchema, locationSchema, mkLocate, projectIdSchema } from './_common'
 
@@ -118,7 +118,7 @@ Example response:
     technology: z.string().nullable(),
     tags: z.array(z.string()),
     project: z.string(),
-    metadata: z.record(z.union([z.string(), z.array(z.string())])),
+    metadata: z.record(z.string(), z.union([z.string(), z.array(z.string())])),
     links: z.array(z.object({
       title: z.string().nullable().describe('Optional link title'),
       url: z.string().describe('Link URL'),

--- a/packages/mcp/src/tools/read-project-summary.ts
+++ b/packages/mcp/src/tools/read-project-summary.ts
@@ -6,7 +6,7 @@
 // Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
 
 import { keys } from 'remeda'
-import * as z from 'zod/v3'
+import * as z from 'zod/v4'
 import { likec4Tool } from '../utils'
 import { projectConfigSchema, projectIdSchema, serializeConfig } from './_common'
 

--- a/packages/mcp/src/tools/read-view.ts
+++ b/packages/mcp/src/tools/read-view.ts
@@ -1,5 +1,12 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import type { NodeModel } from '@likec4/core/model'
-import * as z from 'zod/v3'
+import * as z from 'zod/v4'
 import { likec4Tool } from '../utils'
 import { locationSchema, mkLocate, projectIdSchema } from './_common'
 

--- a/packages/mcp/src/tools/render-view.ts
+++ b/packages/mcp/src/tools/render-view.ts
@@ -1,8 +1,16 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { registerAppTool } from '@modelcontextprotocol/ext-apps/server'
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types'
-import * as z from 'zod/v3'
+import * as z from 'zod/v4'
 import { useLanguageServices } from '../ctx'
+import { mcpToolSchema } from '../utils'
 import { buildRenderPayload, projectIdSchema, toolError } from './_common'
 
 export const renderViewResourceUri = 'ui://likec4/render-view.html'
@@ -20,11 +28,11 @@ Request:
 - project: string (optional) — project id. Defaults to "default" if omitted.
 
 Use this when the user wants to *see* a view. Use "read-view" instead when only the view's structure (nodes/edges) is needed.`,
-      inputSchema: {
+      inputSchema: mcpToolSchema({
         viewId: z.string().describe('View id (name)'),
         project: projectIdSchema,
-      },
-      outputSchema: {
+      }),
+      outputSchema: mcpToolSchema({
         id: z.string(),
         title: z.string(),
         project: z.string(),
@@ -35,7 +43,7 @@ Use this when the user wants to *see* a view. Use "read-view" instead when only 
             'Layouted model data (specification, elements, relations, deployments), scoped to this view only. '
               + 'Consumed by the paired UI to build a LikeC4Model for LikeC4ModelProvider — LikeC4Diagram requires one in context.',
           ),
-      },
+      }),
       annotations: {
         readOnlyHint: true,
         idempotentHint: true,

--- a/packages/mcp/src/tools/search-element.ts
+++ b/packages/mcp/src/tools/search-element.ts
@@ -1,5 +1,12 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import { ifilter } from '@likec4/core/utils'
-import * as z from 'zod/v3'
+import * as z from 'zod/v4'
 import { likec4Tool, logger } from '../utils'
 import { includedInViews, includedInViewsSchema } from './_common'
 
@@ -15,7 +22,7 @@ const searchResultSchema = z.array(
       technology: z.string().nullable(),
       shape: z.string(),
       includedInViews: includedInViewsSchema,
-      metadata: z.record(z.union([z.string(), z.array(z.string())])),
+      metadata: z.record(z.string(), z.union([z.string(), z.array(z.string())])),
       tags: z.array(z.string()),
     }),
     z.object({
@@ -28,7 +35,7 @@ const searchResultSchema = z.array(
       technology: z.string().nullable(),
       shape: z.string(),
       includedInViews: includedInViewsSchema,
-      metadata: z.record(z.union([z.string(), z.array(z.string())])),
+      metadata: z.record(z.string(), z.union([z.string(), z.array(z.string())])),
       tags: z.array(z.string()),
     }),
   ]),

--- a/packages/mcp/src/tools/subgraph-summary.ts
+++ b/packages/mcp/src/tools/subgraph-summary.ts
@@ -3,7 +3,7 @@
 // Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import { invariant } from '@likec4/core'
-import * as z from 'zod/v3'
+import * as z from 'zod/v4'
 import { likec4Tool } from '../utils'
 import { projectIdSchema } from './_common'
 
@@ -16,7 +16,7 @@ const descendantSummarySchema = z.object({
   title: z.string().describe('Human-readable title'),
   depth: z.number().describe('Depth relative to the root element (1 = direct child)'),
   tags: z.array(z.string()).describe('Assigned tags'),
-  metadata: z.record(z.union([z.string(), z.array(z.string())])).describe('Element metadata'),
+  metadata: z.record(z.string(), z.union([z.string(), z.array(z.string())])).describe('Element metadata'),
   childCount: z.number().describe('Number of direct children'),
   incomingCount: z.number().describe('Number of incoming relationships'),
   outgoingCount: z.number().describe('Number of outgoing relationships'),

--- a/packages/mcp/src/utils.ts
+++ b/packages/mcp/src/utils.ts
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2023-2026 Denis Davydkov
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Portions of this file have been modified by NVIDIA CORPORATION & AFFILIATES.
+
 import type { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js'
 import type {
   CallToolResult,
@@ -5,7 +12,7 @@ import type {
   ServerRequest,
   ToolAnnotations,
 } from '@modelcontextprotocol/sdk/types.js'
-import type { z, ZodRawShape, ZodTypeAny } from 'zod/v3'
+import { type ZodRawShape, z } from 'zod/v4'
 
 import { hasProp } from '@likec4/core'
 import type { LikeC4LanguageServices } from '@likec4/language-server'
@@ -22,10 +29,22 @@ export type MCPRegistrationFunction = (mcpServer: McpServer) => McpServer
 type inferArg<Args = unknown, Default = undefined> =
   // dprint-ignore
   Args extends ZodRawShape
-    ? z.objectOutputType<Args, ZodTypeAny>
+    ? z.output<z.ZodObject<Args>>
     : IsUnknown<Args> extends true
       ? unknown
       : Default
+
+const JSON_SCHEMA_2020_12 = 'https://json-schema.org/draft/2020-12/schema'
+
+/**
+ * Wraps an MCP tool schema and declares JSON Schema 2020-12.
+ *
+ * MCP SDK 1.x otherwise converts Zod schemas with draft-07 metadata. Direct tool registrations must apply this
+ * helper to both input and output schemas.
+ */
+export function mcpToolSchema<Shape extends ZodRawShape>(shape: Shape): z.ZodObject<Shape> {
+  return z.object(shape).meta({ $schema: JSON_SCHEMA_2020_12 })
+}
 
 type LikeC4ToolCallbackWithoutArgs = (
   tool: (
@@ -85,10 +104,13 @@ export function likec4Tool(
   },
 ) {
   return (tool: Function) => (mcpServer: McpServer) => {
-    const { name, description, ...rest } = config
+    const { name, description, inputSchema, outputSchema, ...rest } = config
+    const hasStructuredOutput = outputSchema !== undefined && !isEmptyish(outputSchema)
     const toolConfig = {
       description: description?.trim() ?? '',
       ...rest,
+      ...(inputSchema !== undefined ? { inputSchema: mcpToolSchema(inputSchema) } : {}),
+      ...(outputSchema !== undefined ? { outputSchema: mcpToolSchema(outputSchema) } : {}),
     }
     mcpServer.registerTool(
       name,
@@ -106,7 +128,7 @@ export function likec4Tool(
               }],
             }
           }
-          if (!isEmptyish(toolConfig.outputSchema)) {
+          if (hasStructuredOutput) {
             return {
               content: [],
               structuredContent: result,


### PR DESCRIPTION
## Summary

- Update MCP tool schemas to use the installed Zod 4 API.
- Advertise JSON Schema 2020-12 for all tool input and output schemas.
- Keep raw output-shape handling for structured tool results.
- Add a tools/list regression test and a patch changeset.

## Problem

MCP uses JSON Schema 2020-12 for embedded tool schemas. Implementations must support this dialect. See [SEP-1613](https://modelcontextprotocol.io/seps/1613-establish-json-schema-2020-12-as-default-dialect-f).

@modelcontextprotocol/sdk 1.29.0 emits draft-07 from tools/list when the converter has no target. See [#2084](https://github.com/modelcontextprotocol/typescript-sdk/issues/2084). Strict clients can reject these schemas. This can prevent native tool discovery. See [#745](https://github.com/modelcontextprotocol/typescript-sdk/issues/745).

LikeC4 uses Zod 4 metadata on root tool schemas. Input and output schemas now advertise JSON Schema 2020-12.

## Validation

- The focused tools/list regression test passed: 8 tests.
- The full MCP suite passed: 182 tests.
- The MCP typecheck passed.
- The MCP build passed.
- The repository pre-push typecheck passed: 26 tests.
- The license-header check passed.
- The agent-instruction checks passed.

## Checklist

- [x] I read the repository contribution guidance.
- [x] I ran the applicable tests and checks.
- [x] I added a patch changeset for @likec4/mcp.
- [x] This change does not require user documentation.