### PR TITLE
fix(generators): emit valid Mermaid for views with a group

### DIFF
--- a/.changeset/fix-mermaid-view-groups.md
+++ b/.changeset/fix-mermaid-view-groups.md
@@ -1,0 +1,5 @@
+---
+'@likec4/generators': patch
+---
+
+Fix Mermaid export producing invalid output for views with a `group`. The subgraph id no longer starts with `@`, which Mermaid reserves for the `node@{ ... }` shape syntax, and grouped elements keep their own ids instead of being truncated by the length of the generated group id (which left short ids, such as `auth`, with an empty id).

--- a/packages/generators/src/__mocks__/data.ts
+++ b/packages/generators/src/__mocks__/data.ts
@@ -524,3 +524,60 @@ Label`.trimStart(),
   viewOf: null,
   width: 600,
 } as any
+
+export const fakeComputedViewWithGroups: ComputedView = {
+  id: 'index',
+  title: 'Landscape view',
+  nodes: [
+    {
+      id: 'app',
+      parent: null,
+      title: 'App',
+      children: [],
+      color: 'primary',
+      shape: 'rectangle',
+    },
+    {
+      id: '@gr1',
+      parent: null,
+      kind: '@group',
+      title: 'Infra',
+      children: ['auth', 'portal'],
+      color: 'primary',
+      shape: 'rectangle',
+    },
+    {
+      id: 'auth',
+      parent: '@gr1',
+      title: 'Auth',
+      children: [],
+      color: 'primary',
+      shape: 'rectangle',
+    },
+    {
+      id: 'portal',
+      parent: '@gr1',
+      title: 'Portal',
+      children: [],
+      color: 'primary',
+      shape: 'rectangle',
+    },
+  ],
+  edges: [
+    {
+      id: 'app:auth',
+      source: 'app',
+      target: 'auth',
+      label: 'signs in',
+    },
+    {
+      id: 'app:portal',
+      source: 'app',
+      target: 'portal',
+      label: 'authz',
+    },
+  ],
+  autoLayout: { direction: 'TB' },
+  rules: [],
+  viewOf: null,
+} as any

--- a/packages/generators/src/mmd/__snapshots__/generate-mmd.spec.ts.snap
+++ b/packages/generators/src/mmd/__snapshots__/generate-mmd.spec.ts.snap
@@ -83,3 +83,18 @@ graph TB
   Client -. "\`opens\`" .-> SystemFrontend
 "
 `;
+
+exports[`generate mermaid - view with group 1`] = `
+"---
+title: "Landscape view"
+---
+graph TB
+  App@{ shape: rectangle, label: "App" }
+  subgraph _gr1["\`Infra\`"]
+    _gr1.Auth@{ shape: rectangle, label: "Auth" }
+    _gr1.Portal@{ shape: rectangle, label: "Portal" }
+  end
+  App -. "\`signs in\`" .-> _gr1.Auth
+  App -. "\`authz\`" .-> _gr1.Portal
+"
+`;

--- a/packages/generators/src/mmd/generate-mmd.spec.ts
+++ b/packages/generators/src/mmd/generate-mmd.spec.ts
@@ -1,7 +1,13 @@
 import type { LikeC4ViewModel } from '@likec4/core/model'
 import type { aux, ProcessedView } from '@likec4/core/types'
 import { test, vi } from 'vitest'
-import { fakeComputedView3Levels, fakeComputedViewWithAllShapes, fakeDiagram, fakeDiagram2 } from '../__mocks__/data'
+import {
+  fakeComputedView3Levels,
+  fakeComputedViewWithAllShapes,
+  fakeComputedViewWithGroups,
+  fakeDiagram,
+  fakeDiagram2,
+} from '../__mocks__/data'
 import { generateMermaid } from './generate-mmd'
 
 const mockViewModel = vi.fn(function($view: ProcessedView) {
@@ -25,4 +31,14 @@ test('generate mermaid - fakeComputedView 3 Levels', ({ expect }) => {
 
 test('generate mermaid - AllShapes', ({ expect }) => {
   expect(generateMermaid(mockViewModel(fakeComputedViewWithAllShapes))).toMatchSnapshot()
+})
+
+test('generate mermaid - view with group', ({ expect }) => {
+  const mmd = generateMermaid(mockViewModel(fakeComputedViewWithGroups))
+  expect(mmd).toMatchSnapshot()
+  expect(mmd).not.toContain('@gr1')
+  expect(mmd).toContain('subgraph _gr1["`Infra`"]')
+  expect(mmd).toContain('_gr1.Auth@{ shape: rectangle, label: "Auth" }')
+  expect(mmd).toContain('_gr1.Portal@{ shape: rectangle, label: "Portal" }')
+  expect(mmd).toContain('App -. "`signs in`" .-> _gr1.Auth')
 })

--- a/packages/generators/src/mmd/generate-mmd.ts
+++ b/packages/generators/src/mmd/generate-mmd.ts
@@ -7,13 +7,16 @@ import { NL, toStringLF } from '../newline'
 
 const capitalizeFirstLetter = (value: string) => value.charAt(0).toLocaleUpperCase() + value.slice(1)
 
-const fqnName = (nodeId: string): string => nodeId.split('.').map(capitalizeFirstLetter).join('')
+const safeChars = (value: string): string => value.replace(/\W/g, '_')
+
+const fqnName = (nodeId: string): string => nodeId.split('.').map(safeChars).map(capitalizeFirstLetter).join('')
 
 type Node = AnyView['nodes'][number]
 type Edge = AnyView['edges'][number]
 
 const nodeName = (node: Node): string => {
-  return fqnName(node.parent ? node.id.slice(node.parent.length + 1) : node.id)
+  const prefix = node.parent ? node.parent + '.' : ''
+  return fqnName(prefix && node.id.startsWith(prefix) ? node.id.slice(prefix.length) : node.id)
 }
 
 const toSingleQuotes = (str: string): string => str.replace(/\\?"/g, `'`)


### PR DESCRIPTION
Fixes #3243

## Checklist

- [x] I've thoroughly read the latest [contribution guidelines](https://github.com/likec4/likec4/blob/main/CONTRIBUTING.md).
- [x] I've rebased my branch onto `main` **before** creating this PR.
- [x] I've added tests to cover my changes (if applicable).
- [x] I've verified `pnpm typecheck` and `pnpm test`.
- [x] I've added [changesets](https://changesets-docs.vercel.app/).
- [ ] My change requires documentation updates.
- [ ] I've updated the documentation accordingly (or will do in follow-up PR).

## The problem

`likec4 gen mmd` emits Mermaid that no renderer accepts for any view containing a view-level `group`. Two defects, one code path:

1. The subgraph id is `@gr1`. Mermaid reserves a leading `@` for the `node@{ ... }` shape syntax, so its lexer fails on the `subgraph` line.
2. Each grouped element's id is emitted with `groupId.length` characters removed from the front. `@gr1.` is 5 characters, so `portal` comes out as `L`, and `auth` — being shorter than 5 — comes out as the **empty string**, which is then used as a node id twice.

## Root cause

`packages/generators/src/mmd/generate-mmd.ts:16`

```ts
const nodeName = (node: Node): string => {
  return fqnName(node.parent ? node.id.slice(node.parent.length + 1) : node.id)
}
```

The slice assumes `node.parent` is a prefix of `node.id`, which holds for genuinely nested elements (`cloud` / `cloud.backend`). It does not hold for view groups: the group id is synthetic (`@gr${memory.groups.length + 1}`, `packages/core/src/compute-view/element-view/memory/memory.ts:113`) and members keep their own top-level ids, so the slice cuts into the member's real id.

## The change

- Only strip the parent prefix when the child id actually carries it.
- Sanitise generated ids to word characters, so `@` (and anything else outside `\w`) can never reach the output.

Existing snapshots for nested views are unchanged, so ordinary nesting keeps producing the same ids.

## Verification

Repro from the issue, generated with `pnpm cli gen mmd` from this branch:

```mermaid
---
title: "Landscape view"
---
graph TB
  App@{ shape: rectangle, label: "App" }
  subgraph _gr1["`Infra`"]
    _gr1.Auth@{ shape: rectangle, label: "Auth" }
    _gr1.Portal@{ shape: rectangle, label: "Portal" }
  end
  App -. "`signs in`" .-> _gr1.Auth
  App -. "`authz`" .-> _gr1.Portal
```

- Before the change, POSTing the generated file to a local Kroki `/mermaid/svg` returns `400 SyntaxError: Lexical error on line 3. Unrecognized text.` pointing at the `@` in `subgraph @gr1`. After, it returns `200` and the SVG contains all four labels.
- `pnpm test` — 294 files, 3008 passed.
- `pnpm typecheck` — 26/26 tasks successful.
- The new test fails on `main` and passes with the fix.

## Note, not fixed here

`packages/generators/src/d2/generate-d2.ts:12` has the same `node.id.slice(node.parent.length + 1)`, so the D2 generator likely truncates grouped element ids too. I left it alone to keep this PR scoped to the reported issue — happy to extend it if you'd prefer one PR.

---

Disclosure: this change was written with AI assistance. The repro, the fix and the verification above were all executed and confirmed against this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

